### PR TITLE
TALXIS SDK 0.0.0.14 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -399,3 +399,4 @@ FodyWeavers.xsd
 
 
 
+dev-scripts/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-TODO: Version nuspec dependnecy in GitHub Actions
-
 # Power Platform MSBuild Tasks
 
 [![NuGet Version](https://img.shields.io/nuget/v/TALXIS.DevKit.Build.Dataverse.Tasks)](https://www.nuget.org/packages/TALXIS.DevKit.Build.Dataverse.Tasks)

--- a/docs/Tasks-Package.md
+++ b/docs/Tasks-Package.md
@@ -8,8 +8,8 @@ To integrate these custom MSBuild tasks into your dotnet project, add the follow
 <PropertyGroup>
     <!-- Major and minor version of the solution -->
     <Version>2.3</Version>
-    <!-- Folder in the project where Dataverse solution is unpacked (PAC CLI users src folder in the init command) -->
-    <SolutionRootPath>Declarations</SolutionRootPath>
+    <!-- Folder in the project where Dataverse solution is unpacked. Defaults to '.' (project root) if omitted. -->
+    <SolutionRootPath>.</SolutionRootPath>
 </PropertyGroup>
 ```
 Then, add a reference to this package to introduce build tasks to your project:
@@ -88,8 +88,8 @@ Now you can extend the build process explicitly calling additional tasks during 
         <AssemblyName>Some.Solution</AssemblyName>
         <!-- Define major and minor version of the solution here -->
         <Version>2.3</Version>
-        <!-- Folder in the project where Dataverse solution is unpacked -->
-        <SolutionRootPath>Declarations</SolutionRootPath>
+        <!-- Folder in the project where Dataverse solution is unpacked. Defaults to '.' (project root) if omitted. -->
+        <SolutionRootPath>.</SolutionRootPath>
     </PropertyGroup>
 
     <Target Name="TalxisAfterProcessCdsProjectReferencesOutputs" AfterTargets="ProcessCdsProjectReferencesOutputs" Condition="Exists('$(ProjectDir)$(SolutionRootPath)\Other\Solution.xml')">

--- a/src/Dataverse/CodeApp/README.md
+++ b/src/Dataverse/CodeApp/README.md
@@ -1,0 +1,66 @@
+# TALXIS.DevKit.Build.Dataverse.CodeApp
+
+MSBuild integration for Power Apps code-first canvas app projects. Automates the `npm install` / `npm run build` lifecycle, copies the compiled `dist/` output into the correct location, and exposes metadata targets that allow Solution projects to discover, generate `.meta.xml`, and package canvas apps into the solution `.zip`.
+
+## Installation
+
+```xml
+<PackageReference Include="TALXIS.DevKit.Build.Dataverse.CodeApp" Version="0.0.0.1" PrivateAssets="All" />
+```
+
+Or use the SDK approach:
+
+```xml
+<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.1">
+  <PropertyGroup>
+    <ProjectType>CodeApp</ProjectType>
+    <AppName>myapp</AppName>
+  </PropertyGroup>
+</Project>
+```
+
+## Prerequisites
+
+- **Node.js** and **npm** must be available in `PATH`.
+- A `package.json` must exist in the project root.
+- The `npm run build` script must produce output in a `dist/` folder.
+- A `power.config.json` file must exist, describing the app schema name and metadata used by `GenerateCodeAppMetaXml`.
+
+## How It Works
+
+### Build-time targets
+
+1. **CheckCodeAppPrereqs** -- validates that `package.json` exists and that `node` / `npm` are available in PATH. Runs only when `RunNodeBuild` is `true` (auto-detected from the presence of `package.json`).
+2. **BuildCodeApp** (runs before `Build`, depends on `CheckCodeAppPrereqs`) -- executes `npm install` followed by `npm run build` in the project root directory.
+3. **CopyCodeAppDist** (runs after `Build`) -- copies the `dist/` folder to `$(OutputPath)$(AppName)\`. Fails the build if `dist/` is missing or if `AppName` is not set.
+4. **CopyCodeAppDistPublish** (runs after `Publish`) -- same as above, but copies to `$(PublishDir)` instead.
+
+### Integration targets
+
+These targets are called by `TALXIS.DevKit.Build.Dataverse.Solution` when it discovers this project via `ProjectReference`:
+
+- **GetProjectType** -- returns `CodeApp` so the Solution build knows how to handle this reference.
+- **GetCodeAppOutputs** (depends on `Build`) -- returns the path to the compiled `dist/` folder along with `AppName` and `ConfigPath` (location of `power.config.json`) metadata. The Solution project uses this to call `GenerateCodeAppMetaXml` and produce the `.meta.xml` file for PAC packaging.
+
+### What happens in the Solution project
+
+When a Solution project has a `ProjectReference` to a CodeApp project, the following happens automatically during solution build:
+
+1. **ProbeCodeApps** discovers the CodeApp reference by calling `GetProjectType`.
+2. **BuildCodeApps** calls `GetCodeAppOutputs`, which triggers the full CodeApp build (npm install + build).
+3. **PrepareCodeAppsSources** generates `.meta.xml` via `GenerateCodeAppMetaXml`, adds a `RootComponent` entry (Type 300) to `Solution.xml`, and ensures the `CanvasApps` node exists in `Customizations.xml`.
+4. **CopyCodeAppsToMetadata** copies the CodeApp dist output into the solution metadata `CanvasApps/` folder before PAC packages the solution.
+
+The CodeApp reference is automatically filtered out of the standard `ResolveProjectReferences` pipeline to avoid unnecessary assembly resolution.
+
+## MSBuild Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `ProjectType` | `CodeApp` | Marks the project as a code app for reference discovery. |
+| `AppName` | _(required)_ | Application name; used as the output folder name and in `.meta.xml` generation. |
+| `RunNodeBuild` | Auto-detected | Set to `true` if `package.json` exists in project root; set explicitly to override. |
+
+## power.config.json
+
+The `GenerateCodeAppMetaXml` task reads this file to generate the `.meta.xml` required by PAC. Place it in the project root. The task scans `dist/` for all files, maps extensions to MIME types (50+ extensions supported), and produces `CodeAppPackageUri` entries.

--- a/src/Dataverse/CodeApp/TALXIS.DevKit.Build.Dataverse.CodeApp.csproj
+++ b/src/Dataverse/CodeApp/TALXIS.DevKit.Build.Dataverse.CodeApp.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <AssemblyName>TALXIS.DevKit.Build.Dataverse.CodeApp</AssemblyName>
+        <!-- https://github.com/dotnet/vscode-csharp/issues/5786 -->
+        <!-- <TargetFrameworks>net462;$(NetMinimum);$(NetCurrent)</TargetFrameworks> -->
+        <TargetFrameworks>net472;net6.0</TargetFrameworks>
+        <!-- Pack settings -->
+        <NoPackageAnalysis>true</NoPackageAnalysis>
+        <IsPackable>true</IsPackable>
+        <Version>0.0.0.1</Version>
+        <DevelopmentDependency>true</DevelopmentDependency>
+        <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+        <NoWarn>NU1604</NoWarn>
+
+        <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
+        <NuspecBasePath>$(OutputPath)</NuspecBasePath>
+        <NuspecProperties>Version=$(Version);MicrosoftPowerAppsTargetsVersion=$(MicrosoftPowerAppsTargetsVersion)</NuspecProperties>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Build" Version="16.11.6" />
+        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.11.6" />
+        <!-- Do not add any of the dependencies above to nuspec -->
+        <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
+    </ItemGroup>
+</Project>

--- a/src/Dataverse/CodeApp/TALXIS.DevKit.Build.Dataverse.CodeApp.nuspec
+++ b/src/Dataverse/CodeApp/TALXIS.DevKit.Build.Dataverse.CodeApp.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
-    <id>TALXIS.DevKit.Build.Dataverse.Pcf</id>
+    <id>TALXIS.DevKit.Build.Dataverse.CodeApp</id>
     <version>$Version$</version>
     <authors>TALXIS</authors>
     <developmentDependency>true</developmentDependency>
@@ -9,13 +9,11 @@
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <readme>README.md</readme>
     <projectUrl>https://github.com/TALXIS/tools-devkit-build</projectUrl>
-    <description>Dataverse MSBuild Pcf</description>
+    <description>Dataverse MSBuild CodeApp</description>
     <releaseNotes>https://github.com/TALXIS/tools-devkit-build/releases</releaseNotes>
     <copyright>2025 NETWORG</copyright>
     <repository type="git" url="https://github.com/TALXIS/tools-devkit-build" branch="master" />
     <dependencies>
-      <dependency id="Microsoft.PowerApps.MSBuild.Pcf" version="$MicrosoftPowerAppsTargetsVersion$" />
-      <dependency id="Microsoft.NETFramework.ReferenceAssemblies" version="1.0.0" />
       <dependency id="TALXIS.DevKit.Build.Dataverse.Tasks" version="$Version$" />
     </dependencies>
   </metadata>

--- a/src/Dataverse/CodeApp/msbuild/build/TALXIS.DevKit.Build.Dataverse.CodeApp.props
+++ b/src/Dataverse/CodeApp/msbuild/build/TALXIS.DevKit.Build.Dataverse.CodeApp.props
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$(MSBuildThisFileDirectory)..\tasks\$(MSBuildThisFile)" />
+</Project>

--- a/src/Dataverse/CodeApp/msbuild/build/TALXIS.DevKit.Build.Dataverse.CodeApp.targets
+++ b/src/Dataverse/CodeApp/msbuild/build/TALXIS.DevKit.Build.Dataverse.CodeApp.targets
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$(MSBuildThisFileDirectory)..\tasks\$(MSBuildThisFile)" />
+</Project>

--- a/src/Dataverse/CodeApp/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.CodeApp.props
+++ b/src/Dataverse/CodeApp/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.CodeApp.props
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <ProjectType Condition="'$(ProjectType)'==''">CodeApp</ProjectType>
+  </PropertyGroup>
+
+</Project>

--- a/src/Dataverse/CodeApp/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.CodeApp.targets
+++ b/src/Dataverse/CodeApp/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.CodeApp.targets
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <RunNodeBuild Condition="'$(RunNodeBuild)'=='' and Exists('$(MSBuildProjectDirectory)\package.json')">true</RunNodeBuild>
+    <RunNodeBuild Condition="'$(RunNodeBuild)'==''">false</RunNodeBuild>
+  </PropertyGroup>
+
+  <Target Name="CheckCodeAppPrereqs"
+    Condition="'$(RunNodeBuild)'=='true'">
+    <Error Condition="!Exists('$(MSBuildProjectDirectory)\package.json')" Text="CodeApp package.json not found in $(MSBuildProjectDirectory)" />
+    <Exec Command="where node" IgnoreExitCode="true" />
+    <Error Condition="'$(MSBuildLastTaskResult)'!='True'" Text="Node.js not found in PATH. Install Node.js to build CodeApp." />
+    <Exec Command="where npm" IgnoreExitCode="true" />
+    <Error Condition="'$(MSBuildLastTaskResult)'!='True'" Text="npm not found in PATH. Install Node.js (includes npm) to build CodeApp." />
+  </Target>
+
+  <Target Name="BuildCodeApp"
+    DependsOnTargets="CheckCodeAppPrereqs"
+    BeforeTargets="Build"
+    Condition="'$(RunNodeBuild)'=='true'">
+    <Message Text="Running npm install in $(MSBuildProjectDirectory)" Importance="High" />
+    <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Command="npm install" />
+    <Message Text="Running npm build in $(MSBuildProjectDirectory)" Importance="High" />
+    <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Command="npm run build" />
+  </Target>
+
+  <Target Name="CopyCodeAppDist"
+    AfterTargets="Build"
+    Condition="'$(RunNodeBuild)'=='true'">
+    <Error Condition="'$(AppName)'==''" Text="AppName property is not set. Set it in the project file." />
+
+    <ItemGroup>
+      <CodeAppDistFiles Include="$(MSBuildProjectDirectory)\dist\**\*.*" />
+    </ItemGroup>
+
+    <Error Condition="'@(CodeAppDistFiles)'==''" Text="No files found in $(MSBuildProjectDirectory)\dist. Ensure npm run build produces output in the dist folder." />
+
+    <Message Text="Copying CodeApp dist to $(OutputPath)$(AppName)\" Importance="High" />
+    <Copy SourceFiles="@(CodeAppDistFiles)" DestinationFiles="@(CodeAppDistFiles->'$(OutputPath)$(AppName)\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+  </Target>
+
+  <Target Name="GetProjectType" Returns="@(_ProjectType)" Condition="'$(ProjectType)'!=''">
+    <ItemGroup>
+      <_ProjectType Include="$(MSBuildProjectFullPath)">
+        <ProjectType>$(ProjectType)</ProjectType>
+      </_ProjectType>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GetCodeAppOutputs"
+    DependsOnTargets="Build"
+    Returns="@(_CodeAppOutputs)">
+    <ItemGroup>
+      <_CodeAppOutputs Include="$(MSBuildProjectDirectory)\dist">
+        <AppName>$(AppName)</AppName>
+        <ConfigPath>$(MSBuildProjectDirectory)\power.config.json</ConfigPath>
+      </_CodeAppOutputs>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CopyCodeAppDistPublish"
+    AfterTargets="Publish"
+    Condition="'$(RunNodeBuild)'=='true'">
+    <Error Condition="'$(AppName)'==''" Text="AppName property is not set. Set it in the project file." />
+
+    <ItemGroup>
+      <CodeAppDistPublishFiles Include="$(MSBuildProjectDirectory)\dist\**\*.*" />
+    </ItemGroup>
+
+    <Error Condition="'@(CodeAppDistPublishFiles)'==''" Text="No files found in $(MSBuildProjectDirectory)\dist. Ensure npm run build produces output in the dist folder." />
+
+    <Message Text="Copying CodeApp dist to $(PublishDir)$(AppName)\" Importance="High" />
+    <Copy SourceFiles="@(CodeAppDistPublishFiles)" DestinationFiles="@(CodeAppDistPublishFiles->'$(PublishDir)$(AppName)\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+  </Target>
+
+</Project>

--- a/src/Dataverse/CodeApp/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.CodeApp.targets
+++ b/src/Dataverse/CodeApp/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.CodeApp.targets
@@ -2,16 +2,16 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <RunNodeBuild Condition="'$(RunNodeBuild)'=='' and Exists('$(MSBuildProjectDirectory)\package.json')">true</RunNodeBuild>
+    <RunNodeBuild Condition="'$(RunNodeBuild)'=='' and Exists('$(MSBuildProjectDirectory)/package.json')">true</RunNodeBuild>
     <RunNodeBuild Condition="'$(RunNodeBuild)'==''">false</RunNodeBuild>
   </PropertyGroup>
 
   <Target Name="CheckCodeAppPrereqs"
     Condition="'$(RunNodeBuild)'=='true'">
-    <Error Condition="!Exists('$(MSBuildProjectDirectory)\package.json')" Text="CodeApp package.json not found in $(MSBuildProjectDirectory)" />
-    <Exec Command="where node" IgnoreExitCode="true" />
+    <Error Condition="!Exists('$(MSBuildProjectDirectory)/package.json')" Text="CodeApp package.json not found in $(MSBuildProjectDirectory)" />
+    <Exec Command="node --version" IgnoreExitCode="true" />
     <Error Condition="'$(MSBuildLastTaskResult)'!='True'" Text="Node.js not found in PATH. Install Node.js to build CodeApp." />
-    <Exec Command="where npm" IgnoreExitCode="true" />
+    <Exec Command="npm --version" IgnoreExitCode="true" />
     <Error Condition="'$(MSBuildLastTaskResult)'!='True'" Text="npm not found in PATH. Install Node.js (includes npm) to build CodeApp." />
   </Target>
 
@@ -21,7 +21,7 @@
     Condition="'$(RunNodeBuild)'=='true'">
     <Message Text="Running npm install in $(MSBuildProjectDirectory)" Importance="High" />
     <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Command="npm install" />
-    <Message Text="Running npm build in $(MSBuildProjectDirectory)" Importance="High" />
+    <Message Text="Running npm run build in $(MSBuildProjectDirectory)" Importance="High" />
     <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Command="npm run build" />
   </Target>
 
@@ -31,13 +31,13 @@
     <Error Condition="'$(AppName)'==''" Text="AppName property is not set. Set it in the project file." />
 
     <ItemGroup>
-      <CodeAppDistFiles Include="$(MSBuildProjectDirectory)\dist\**\*.*" />
+      <CodeAppDistFiles Include="$(MSBuildProjectDirectory)/dist/**/*.*" />
     </ItemGroup>
 
-    <Error Condition="'@(CodeAppDistFiles)'==''" Text="No files found in $(MSBuildProjectDirectory)\dist. Ensure npm run build produces output in the dist folder." />
+    <Error Condition="'@(CodeAppDistFiles)'==''" Text="No files found in $(MSBuildProjectDirectory)/dist. Ensure npm run build produces output in the dist folder." />
 
-    <Message Text="Copying CodeApp dist to $(OutputPath)$(AppName)\" Importance="High" />
-    <Copy SourceFiles="@(CodeAppDistFiles)" DestinationFiles="@(CodeAppDistFiles->'$(OutputPath)$(AppName)\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+    <Message Text="Copying CodeApp dist to $(OutputPath)$(AppName)/" Importance="High" />
+    <Copy SourceFiles="@(CodeAppDistFiles)" DestinationFiles="@(CodeAppDistFiles->'$(OutputPath)$(AppName)/%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
   </Target>
 
   <Target Name="GetProjectType" Returns="@(_ProjectType)" Condition="'$(ProjectType)'!=''">
@@ -52,9 +52,9 @@
     DependsOnTargets="Build"
     Returns="@(_CodeAppOutputs)">
     <ItemGroup>
-      <_CodeAppOutputs Include="$(MSBuildProjectDirectory)\dist">
+      <_CodeAppOutputs Include="$(MSBuildProjectDirectory)/dist">
         <AppName>$(AppName)</AppName>
-        <ConfigPath>$(MSBuildProjectDirectory)\power.config.json</ConfigPath>
+        <ConfigPath>$(MSBuildProjectDirectory)/power.config.json</ConfigPath>
       </_CodeAppOutputs>
     </ItemGroup>
   </Target>
@@ -65,13 +65,13 @@
     <Error Condition="'$(AppName)'==''" Text="AppName property is not set. Set it in the project file." />
 
     <ItemGroup>
-      <CodeAppDistPublishFiles Include="$(MSBuildProjectDirectory)\dist\**\*.*" />
+      <CodeAppDistPublishFiles Include="$(MSBuildProjectDirectory)/dist/**/*.*" />
     </ItemGroup>
 
-    <Error Condition="'@(CodeAppDistPublishFiles)'==''" Text="No files found in $(MSBuildProjectDirectory)\dist. Ensure npm run build produces output in the dist folder." />
+    <Error Condition="'@(CodeAppDistPublishFiles)'==''" Text="No files found in $(MSBuildProjectDirectory)/dist. Ensure npm run build produces output in the dist folder." />
 
-    <Message Text="Copying CodeApp dist to $(PublishDir)$(AppName)\" Importance="High" />
-    <Copy SourceFiles="@(CodeAppDistPublishFiles)" DestinationFiles="@(CodeAppDistPublishFiles->'$(PublishDir)$(AppName)\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+    <Message Text="Copying CodeApp dist to $(PublishDir)$(AppName)/" Importance="High" />
+    <Copy SourceFiles="@(CodeAppDistPublishFiles)" DestinationFiles="@(CodeAppDistPublishFiles->'$(PublishDir)$(AppName)/%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
   </Target>
 
 </Project>

--- a/src/Dataverse/PDPackage/README.md
+++ b/src/Dataverse/PDPackage/README.md
@@ -24,6 +24,14 @@ Or use the SDK approach:
 
 Props and targets from `Microsoft.PowerApps.MSBuild.PDPackage` are imported automatically. The version is controlled by `PdPackageMsBuildVersion`.
 
+### Defaults for ProjectReference
+
+All `ProjectReference` items default to `ReferenceOutputAssembly=false` via `ItemDefinitionGroup`. PDPackage projects reference other projects (e.g. Solution) purely for build ordering and packaging, not to consume their output assemblies as compile-time references. Override per-reference by explicitly setting `ReferenceOutputAssembly="true"`.
+
+### .NET Framework references
+
+`System.ComponentModel.Composition` is automatically referenced when targeting .NET Framework. This is required by `Microsoft.CrmSdk.XrmTooling.PackageDeployment` (MEF / `IImportPackageExtension`).
+
 ### Project reference filtering
 
 `_DetectPdProjectReferenceTypes` probes all `ProjectReference` items for `GetProjectType`. Solution-type references have `ReferenceOutputAssembly` set to `false` so their DLLs are not included in the package output.

--- a/src/Dataverse/PDPackage/msbuild/build/TALXIS.DevKit.Build.Dataverse.PdPackage.props
+++ b/src/Dataverse/PDPackage/msbuild/build/TALXIS.DevKit.Build.Dataverse.PdPackage.props
@@ -11,4 +11,14 @@
   </PropertyGroup>
 
   <Import Project="$(_PdPackageMsBuildProps)" Condition="Exists('$(_PdPackageMsBuildProps)')" />
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Reference Include="System.ComponentModel.Composition" />
+  </ItemGroup>
+
+  <ItemDefinitionGroup>
+    <ProjectReference>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemDefinitionGroup>
 </Project>

--- a/src/Dataverse/PDPackage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.PdPackage.ILRepack.targets
+++ b/src/Dataverse/PDPackage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.PdPackage.ILRepack.targets
@@ -11,6 +11,8 @@
     <PropertyGroup>
       <BuildedAssembly>$(TargetPath)</BuildedAssembly>
       <_KeyFileSwitch Condition="Exists('$(DataversePackageILRepackKeyFile)')">/keyfile:"$(DataversePackageILRepackKeyFile)"</_KeyFileSwitch>
+      <_ILRepackCommand Condition="$([MSBuild]::IsOSPlatform('Windows'))">"$(ILRepackExe)"</_ILRepackCommand>
+      <_ILRepackCommand Condition="!$([MSBuild]::IsOSPlatform('Windows'))">mono "$(ILRepackExe)"</_ILRepackCommand>
     </PropertyGroup>
 
     <Error Condition="'$(BuildedAssembly)'=='' or !Exists('$(BuildedAssembly)')" Text="Build output not found: $(BuildedAssembly)" />
@@ -29,12 +31,12 @@
       <OtherAssemblies Include="$(TargetDir)*.dll" Exclude="@(AssembliesToExclude)" />
     </ItemGroup>
 
-    <Message Text="ILRepackExe = $(ILRepackExe)" Importance="High" />
+    <Message Text="ILRepack command: $(_ILRepackCommand)" Importance="High" />
     <Message Text="Merging into: $(BuildedAssembly)" Importance="High" />
     <Message Text="OtherAssemblies: @(OtherAssemblies)" Importance="High" />
 
     <Message Text="ILRepack skipped: no additional assemblies to merge." Importance="High" Condition="'@(OtherAssemblies)'==''" />
 
-    <Exec Command="&quot;$(ILRepackExe)&quot; /lib:&quot;$(ReferencedAssembliesDir)&quot; /target:library /parallel $(_KeyFileSwitch) /out:&quot;$(BuildedAssembly)&quot; &quot;$(BuildedAssembly)&quot; @(OtherAssemblies,' ')" Condition="'@(OtherAssemblies)'!=''" />
+    <Exec Command="$(_ILRepackCommand) /lib:&quot;$(ReferencedAssembliesDir)&quot; /target:library /parallel $(_KeyFileSwitch) /out:&quot;$(BuildedAssembly)&quot; &quot;$(BuildedAssembly)&quot; @(OtherAssemblies,' ')" Condition="'@(OtherAssemblies)'!=''" />
   </Target>
 </Project>

--- a/src/Dataverse/PDPackage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.PdPackage.targets
+++ b/src/Dataverse/PDPackage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.PdPackage.targets
@@ -47,6 +47,21 @@
           Condition="'$(GeneratePdPackageOnBuild)'=='true'">
   </Target>
 
+  <Target Name="TalxisValidatePcfDependencies"
+          AfterTargets="TalxisGeneratePdPackageOnBuild"
+          Condition="'$(TalxisSkipPcfDependencyValidation)' != 'true'">
+    <ItemGroup>
+      <_PcfValidationZips Remove="@(_PcfValidationZips)" />
+      <_PcfValidationZips Include="$(PublishDir)PkgAssets\*.zip" />
+    </ItemGroup>
+    <Message Text="Validating PCF control dependencies across @(_PcfValidationZips->Count()) solution(s)..." Importance="high" />
+    <ValidatePcfDependencies
+        SolutionZipFiles="@(_PcfValidationZips)"
+        IgnoredPcfPrefixes="$(TalxisIgnoredPcfPrefixes)"
+        Condition="'@(_PcfValidationZips)' != ''" />
+    <Message Text="PCF dependency validation finished." Importance="high" />
+  </Target>
+
   <!-- NuGet packing support (dotnet pack → .nupkg with .pdpkg.zip) -->
   <Import Project="$(MSBuildThisFileDirectory)TALXIS.DevKit.Build.Dataverse.PdPackage.Pack.targets"
           Condition="Exists('$(MSBuildThisFileDirectory)TALXIS.DevKit.Build.Dataverse.PdPackage.Pack.targets')" />

--- a/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.props
+++ b/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.props
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath>$(MSBuildProjectDirectory)\out\controls</OutputPath>
+    <PowerAppsTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\PowerApps</PowerAppsTargetsPath>
+    <CopyBuildOutputToPublishDirectory>false</CopyBuildOutputToPublishDirectory>
+    <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
+  </PropertyGroup>
+
+  <Import Project="$(PowerAppsTargetsPath)\Microsoft.PowerApps.VisualStudio.Pcf.props" Condition="Exists('$(PowerAppsTargetsPath)\Microsoft.PowerApps.VisualStudio.Pcf.props')" />
+
 </Project>

--- a/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
+++ b/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
@@ -1,9 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup>
+    <ExcludeDirectories Include="$(MSBuildProjectDirectory)\.gitignore" />
+    <ExcludeDirectories Include="$(MSBuildProjectDirectory)\bin\**" />
+    <ExcludeDirectories Include="$(MSBuildProjectDirectory)\obj\**" />
+    <ExcludeDirectories Include="$(OutputPath)\**" />
+    <ExcludeDirectories Include="$(MSBuildProjectDirectory)\*.pcfproj" />
+    <ExcludeDirectories Include="$(MSBuildProjectDirectory)\*.pcfproj.user" />
+    <ExcludeDirectories Include="$(MSBuildProjectDirectory)\*.sln" />
+    <ExcludeDirectories Include="$(MSBuildProjectDirectory)\node_modules\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildProjectDirectory)\**" Exclude="@(ExcludeDirectories)" />
+  </ItemGroup>
+
+  <Import Project="$(PowerAppsTargetsPath)\Microsoft.PowerApps.VisualStudio.Pcf.targets" Condition="Exists('$(PowerAppsTargetsPath)\Microsoft.PowerApps.VisualStudio.Pcf.targets')" />
+
+  <Target Name="NpmInstall" BeforeTargets="BeforeBuild">
+    <Exec Command="npm install" WorkingDirectory="$(MSBuildProjectDirectory)" />
+  </Target>
+
   <!-- We need the build process to infer these numbers before BeforeBuild so that it generates correct header files -->
-  <Target Name="TalxisBeforeBuild" BeforeTargets="BeforeBuild">
+  <Target Name="TalxisBeforeBuild" BeforeTargets="BeforeBuild" DependsOnTargets="NpmInstall">
     <CallTarget Targets="GenerateVersionNumber"/>
     <CallTarget Targets="ApplyPcfVersionNumber"/>
   </Target>
+
+
+  <Target Name="_EnsurePcfStubAssembly"
+          BeforeTargets="Publish;GetCopyToPublishDirectoryItems"
+          Condition="!Exists('$(OutputPath)\$(AssemblyName).dll')">
+    <MakeDir Directories="$(OutputPath)" Condition="!Exists('$(OutputPath)')" />
+    <Touch Files="$(OutputPath)\$(AssemblyName).dll" AlwaysCreate="true" />
+  </Target>
+
+  <!-- After publish, copy PCF output to out\controls\publish -->
+  <Target Name="PcfCopyToPublish"
+          AfterTargets="Publish"
+          Condition="'$(_IsPublishing)' == 'true'">
+    <PropertyGroup>
+      <_PcfPublishDir>$(MSBuildProjectDirectory)\out\controls\publish</_PcfPublishDir>
+    </PropertyGroup>
+    <RemoveDir Directories="$(_PcfPublishDir)" Condition="Exists('$(_PcfPublishDir)')" />
+    <ItemGroup>
+      <_PcfOutputFiles Include="$(OutputPath)\**\*" Exclude="$(OutputPath)\$(AssemblyName).dll" />
+    </ItemGroup>
+    <MakeDir Directories="$(_PcfPublishDir)" />
+    <Copy SourceFiles="@(_PcfOutputFiles)"
+          DestinationFiles="@(_PcfOutputFiles->'$(_PcfPublishDir)\%(RecursiveDir)%(Filename)%(Extension)')"
+          Condition="'@(_PcfOutputFiles)' != ''" />
+    <Message Importance="high" Text="PCF publish: copied output to $(_PcfPublishDir)" />
+  </Target>
+
 </Project>

--- a/src/Dataverse/Solution/README.md
+++ b/src/Dataverse/Solution/README.md
@@ -45,12 +45,12 @@ The package sets `ProjectType` to `Solution` and imports `Microsoft.PowerApps.MS
 
 `ProcessCdsProjectReferencesOutputs` replaces the Microsoft default to filter ScriptLibrary, CodeApp, and WorkflowActivity references from PAC processing. Then `GenerateVersionNumber` and `ApplyVersionNumber` patch the version across all solution metadata.
 
-### 6. Schema validation
+### 6. Schema validation (manual)
 
-`TalxisValidateSolutionComponentSchema` runs automatically after `ProcessCdsProjectReferencesOutputs` and before `PowerAppsPackage`. It validates all solution XML files against 22 bundled XSD schemas and JSON flows against a JSON schema. Validation runs in batch mode -- all errors are collected before failing the build, with MSBuild-canonical error format for IDE click-through.
+`TalxisValidateSolutionComponentSchema` validates all solution XML files against 22 bundled XSD schemas and JSON flows against a JSON schema. Validation runs in batch mode -- all errors are collected before failing the build, with MSBuild-canonical error format for IDE click-through.
 
 > [!TIP]
-> To disable validation, set `<TalxisSkipSolutionComponentSchemaValidation>true</TalxisSkipSolutionComponentSchemaValidation>` in your csproj.
+> This validation is **not wired into the build pipeline automatically** -- it must be invoked manually, e.g. `dotnet build -t:TalxisValidateSolutionComponentSchema`.
 
 ### 7. Solution packaging
 
@@ -99,9 +99,7 @@ The package sets `ProjectType` to `Solution` and imports `Microsoft.PowerApps.MS
 
 ### Validation
 
-| Property | Default | Description |
-|----------|---------|-------------|
-| `TalxisSkipSolutionComponentSchemaValidation` | _(none)_ | Set to `true` to skip automatic schema validation. |
+Schema validation via `TalxisValidateSolutionComponentSchema` is **not wired automatically** -- invoke it manually (e.g. `dotnet build -t:TalxisValidateSolutionComponentSchema`). No skip property is needed.
 
 ## Related Packages
 

--- a/src/Dataverse/Solution/README.md
+++ b/src/Dataverse/Solution/README.md
@@ -1,6 +1,6 @@
 # TALXIS.DevKit.Build.Dataverse.Solution
 
-MSBuild integration for building complete Dataverse solutions. Orchestrates the entire solution build pipeline: discovers and builds referenced Plugin, WorkflowActivity, ScriptLibrary, CodeApp, and PCF projects; patches solution XML with version, publisher, and managed state; validates all solution metadata against XSD/JSON schemas; runs the PAC solution packager to produce a `.zip` file; and supports `dotnet pack` to generate a NuGet package containing the solution zip.
+MSBuild integration for building complete Dataverse solutions. Orchestrates the entire solution build pipeline: discovers and builds referenced Plugin, WorkflowActivity, ScriptLibrary, CodeApp, and PCF projects; patches solution XML with version, publisher, and managed state; supports manual invocation of schema validation targets for solution metadata against XSD/JSON schemas; runs the PAC solution packager to produce a `.zip` file; and supports `dotnet pack` to generate a NuGet package containing the solution zip.
 
 ## Installation
 

--- a/src/Dataverse/Solution/README.md
+++ b/src/Dataverse/Solution/README.md
@@ -47,10 +47,10 @@ The package sets `ProjectType` to `Solution` and imports `Microsoft.PowerApps.MS
 
 ### 6. Schema validation (manual)
 
-`TalxisValidateSolutionComponentSchema` validates all solution XML files against 22 bundled XSD schemas and JSON flows against a JSON schema. Validation runs in batch mode -- all errors are collected before failing the build, with MSBuild-canonical error format for IDE click-through.
+`ValidateSolutionComponentSchema` validates all solution XML files against 22 bundled XSD schemas and JSON flows against a JSON schema. Validation runs in batch mode -- all errors are collected before failing the build, with MSBuild-canonical error format for IDE click-through.
 
 > [!TIP]
-> This validation is **not wired into the build pipeline automatically** -- it must be invoked manually, e.g. `dotnet build -t:TalxisValidateSolutionComponentSchema`.
+> This validation is **not wired into the build pipeline automatically** -- it must be invoked manually, e.g. `dotnet build -t:ValidateSolutionComponentSchema`.
 
 ### 7. Solution packaging
 
@@ -99,7 +99,7 @@ The package sets `ProjectType` to `Solution` and imports `Microsoft.PowerApps.MS
 
 ### Validation
 
-Schema validation via `TalxisValidateSolutionComponentSchema` is **not wired automatically** -- invoke it manually (e.g. `dotnet build -t:TalxisValidateSolutionComponentSchema`). No skip property is needed.
+Schema validation via `ValidateSolutionComponentSchema` is **not wired automatically** -- invoke it manually (e.g. `dotnet build -t:ValidateSolutionComponentSchema`). No skip property is needed.
 
 ## Related Packages
 

--- a/src/Dataverse/Solution/README.md
+++ b/src/Dataverse/Solution/README.md
@@ -1,6 +1,6 @@
 # TALXIS.DevKit.Build.Dataverse.Solution
 
-MSBuild integration for building complete Dataverse solutions. Orchestrates the entire solution build pipeline: discovers and builds referenced Plugin, WorkflowActivity, ScriptLibrary, and PCF projects; patches solution XML with version, publisher, and managed state; runs the PAC solution packager to produce a `.zip` file; and supports `dotnet pack` to generate a NuGet package containing the solution zip.
+MSBuild integration for building complete Dataverse solutions. Orchestrates the entire solution build pipeline: discovers and builds referenced Plugin, WorkflowActivity, ScriptLibrary, CodeApp, and PCF projects; patches solution XML with version, publisher, and managed state; validates all solution metadata against XSD/JSON schemas; runs the PAC solution packager to produce a `.zip` file; and supports `dotnet pack` to generate a NuGet package containing the solution zip.
 
 ## Installation
 
@@ -24,17 +24,18 @@ The package sets `ProjectType` to `Solution` and imports `Microsoft.PowerApps.MS
 
 ### 1. Component discovery
 
-`ProbePluginLibraries`, `ProbeScriptLibraries`, and `ProbeWorkflowActivityLibraries` call `GetProjectType` on all `ProjectReference` items to classify them by component type.
+`ProbePluginLibraries`, `ProbeScriptLibraries`, `ProbeCodeApps`, and `ProbeWorkflowActivityLibraries` call `GetProjectType` on all `ProjectReference` items to classify them by component type. ScriptLibrary and CodeApp references are removed from `@(ProjectReference)` after discovery so the standard .NET `ResolveProjectReferences` pipeline does not build them a second time -- they are built explicitly in the next step.
 
 ### 2. Component builds
 
-`BuildPluginLibraries`, `BuildScriptLibraries`, and `BuildWorkflowActivityLibraries` compile each referenced component project before `CopyCdsSolutionContent`.
+`BuildPluginLibraries`, `BuildScriptLibraries`, `BuildCodeApps`, and `BuildWorkflowActivityLibraries` compile each referenced component project before `CopyCdsSolutionContent`.
 
 ### 3. Component metadata generation
 
 - **Plugin assemblies** -- `EnsurePluginAssemblyDataXml` generates `.data.xml` files under `PluginAssemblies/`.
 - **Workflow activities** -- `EnsureWorkflowActivityAssemblyDataXml` generates `.data.xml` for workflow activity assemblies.
 - **Script libraries** -- `CopyScriptLibrariesToWebResources` resolves web resource names with the publisher prefix, generates `.data.xml`, and registers root components in `Solution.xml`.
+- **Code apps** -- `PrepareCodeAppsSources` generates `.meta.xml` via `GenerateCodeAppMetaXml`, adds root components (Type 300) to `Solution.xml`, and ensures the `CanvasApps` node exists in `Customizations.xml`.
 
 ### 4. Solution XML patching
 
@@ -42,13 +43,20 @@ The package sets `ProjectType` to `Solution` and imports `Microsoft.PowerApps.MS
 
 ### 5. PAC override and versioning
 
-`ProcessCdsProjectReferencesOutputs` replaces the Microsoft default to filter ScriptLibrary and WorkflowActivity references from PAC processing. Then `GenerateVersionNumber` and `ApplyVersionNumber` patch the version across all solution metadata.
+`ProcessCdsProjectReferencesOutputs` replaces the Microsoft default to filter ScriptLibrary, CodeApp, and WorkflowActivity references from PAC processing. Then `GenerateVersionNumber` and `ApplyVersionNumber` patch the version across all solution metadata.
 
-### 6. Solution packaging
+### 6. Schema validation
 
-`PackDataverseSolution` invokes the PAC solution packager to produce the output `.zip`.
+`TalxisValidateSolutionComponentSchema` runs automatically after `ProcessCdsProjectReferencesOutputs` and before `PowerAppsPackage`. It validates all solution XML files against 22 bundled XSD schemas and JSON flows against a JSON schema. Validation runs in batch mode -- all errors are collected before failing the build, with MSBuild-canonical error format for IDE click-through.
 
-### 7. NuGet packing
+> [!TIP]
+> To disable validation, set `<TalxisSkipSolutionComponentSchemaValidation>true</TalxisSkipSolutionComponentSchemaValidation>` in your csproj.
+
+### 7. Solution packaging
+
+`PowerAppsPackage` invokes the PAC solution packager to produce the output `.zip`.
+
+### 8. NuGet packing
 
 `dotnet pack` produces a `.nupkg` with the solution `.zip` under `content/solution/`.
 
@@ -89,9 +97,13 @@ The package sets `ProjectType` to `Solution` and imports `Microsoft.PowerApps.MS
 | `WebResourcesDir` | `$(MSBuildProjectDirectory)\$(SolutionRootPath)\WebResources\` | Destination folder for script library web resources. |
 | `PcfForceUpdate` | _(none)_ | Forwarded to PAC `ProcessCdsProjectReferencesOutputs` to force PCF updates. |
 
+### Validation
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `TalxisSkipSolutionComponentSchemaValidation` | _(none)_ | Set to `true` to skip automatic schema validation. |
+
 ## Related Packages
 
 - **Depends on**: `TALXIS.DevKit.Build.Dataverse.Tasks`, `Microsoft.PowerApps.MSBuild.Solution`
-- **Discovers and builds**: `Plugin`, `WorkflowActivity`, `ScriptLibrary`, and `Pcf` projects via `ProjectReference`
-
-
+- **Discovers and builds**: `Plugin`, `WorkflowActivity`, `ScriptLibrary`, `CodeApp`, and `Pcf` projects via `ProjectReference`

--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.CodeApps.targets
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.CodeApps.targets
@@ -3,7 +3,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Target Name="ProbeCodeApps"
-          Condition="'@(ProjectReference)'!=''">
+          BeforeTargets="PrepareProjectReferences;ResolveProjectReferences;BuildCodeApps"
+          Condition="'@(ProjectReference)'!='' and '@(_CodeAppProjects)'==''">
 
     <MSBuild Projects="@(ProjectReference->'%(FullPath)')"
              Targets="GetProjectType"
@@ -17,6 +18,15 @@
       <_CodeAppProjects Remove="@(_CodeAppProjects)" />
       <_CodeAppProjects Include="@(_ProjectTypeFromReferences)"
                         Condition="'%(ProjectType)'=='CodeApp'" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_CodeAppProjectsList>;@(_CodeAppProjects->'%(Identity)');</_CodeAppProjectsList>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Remove="@(ProjectReference)"
+                        Condition="$([System.String]::Copy('$(_CodeAppProjectsList)').Contains(';%(FullPath);'))" />
     </ItemGroup>
 
     <Message Importance="high"
@@ -48,7 +58,7 @@
     <PropertyGroup>
       <_HasCodeAppOutputs Condition="'@(_CodeAppOutputs)'!=''">true</_HasCodeAppOutputs>
       <_DeclarationsRoot>$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)/$(SolutionRootPath)))</_DeclarationsRoot>
-      <_DeclarationsCanvasAppsDir>$(_DeclarationsRoot)\CanvasApps\</_DeclarationsCanvasAppsDir>
+      <_DeclarationsCanvasAppsDir>$(_DeclarationsRoot)/CanvasApps/</_DeclarationsCanvasAppsDir>
     </PropertyGroup>
 
     <MakeDir Directories="$(_DeclarationsCanvasAppsDir)"
@@ -57,7 +67,7 @@
     <!-- Patch source Solution.xml with CanvasApp root component -->
     <AddRootComponentToSolution
         Condition="'$(_HasCodeAppOutputs)'=='true'"
-        SolutionPath="$(_DeclarationsRoot)\Other\Solution.xml"
+        SolutionPath="$(_DeclarationsRoot)/Other/Solution.xml"
         Type="300"
         SchemaName="$(PublisherPrefix)_%(_CodeAppOutputs.AppName)"
         Behavior="0" />
@@ -72,7 +82,7 @@
     <!-- Ensure CanvasApps node in source Customizations.xml -->
     <EnsureCustomizationsNode
         Condition="'$(_HasCodeAppOutputs)'=='true'"
-        CustomizationsXmlFile="$(_DeclarationsRoot)\Other\Customizations.xml"
+        CustomizationsXmlFile="$(_DeclarationsRoot)/Other/Customizations.xml"
         NodeName="CanvasApps" />
   </Target>
 
@@ -83,25 +93,25 @@
 
     <PropertyGroup>
       <_HasCodeAppOutputs Condition="'@(_CodeAppOutputs)'!=''">true</_HasCodeAppOutputs>
-      <_MetadataCanvasAppsDir>$(SolutionPackagerMetadataWorkingDirectory)\CanvasApps\</_MetadataCanvasAppsDir>
+      <_MetadataCanvasAppsDir>$(SolutionPackagerMetadataWorkingDirectory)/CanvasApps/</_MetadataCanvasAppsDir>
     </PropertyGroup>
 
     <MakeDir Directories="$(_MetadataCanvasAppsDir)"
              Condition="'$(_HasCodeAppOutputs)'=='true'" />
 
     <ItemGroup Condition="'$(_HasCodeAppOutputs)'=='true'">
-      <_CodeAppDistFiles Include="%(_CodeAppOutputs.Identity)\**\*.*">
+      <_CodeAppDistFiles Include="%(_CodeAppOutputs.Identity)/**/*.*">
         <AppName>%(_CodeAppOutputs.AppName)</AppName>
       </_CodeAppDistFiles>
     </ItemGroup>
 
     <Message Importance="high"
              Condition="'$(_HasCodeAppOutputs)'=='true'"
-             Text="Copying CodeApp dist to $(_MetadataCanvasAppsDir)$(PublisherPrefix)_%(_CodeAppOutputs.AppName)_CodeAppPackages\" />
+             Text="Copying CodeApp dist to $(_MetadataCanvasAppsDir)$(PublisherPrefix)_%(_CodeAppOutputs.AppName)_CodeAppPackages/" />
 
     <Copy Condition="'$(_HasCodeAppOutputs)'=='true'"
           SourceFiles="@(_CodeAppDistFiles)"
-          DestinationFiles="@(_CodeAppDistFiles->'$(_MetadataCanvasAppsDir)$(PublisherPrefix)_%(AppName)_CodeAppPackages\%(RecursiveDir)%(Filename)%(Extension)')"
+          DestinationFiles="@(_CodeAppDistFiles->'$(_MetadataCanvasAppsDir)$(PublisherPrefix)_%(AppName)_CodeAppPackages/%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true"
           OverwriteReadOnlyFiles="true" />
   </Target>

--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.CodeApps.targets
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.CodeApps.targets
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="ProbeCodeApps"
+          Condition="'@(ProjectReference)'!=''">
+
+    <MSBuild Projects="@(ProjectReference->'%(FullPath)')"
+             Targets="GetProjectType"
+             Properties="Configuration=$(Configuration)"
+             BuildInParallel="true"
+             SkipNonexistentTargets="true">
+      <Output TaskParameter="TargetOutputs" ItemName="_ProjectTypeFromReferences" />
+    </MSBuild>
+
+    <ItemGroup>
+      <_CodeAppProjects Remove="@(_CodeAppProjects)" />
+      <_CodeAppProjects Include="@(_ProjectTypeFromReferences)"
+                        Condition="'%(ProjectType)'=='CodeApp'" />
+    </ItemGroup>
+
+    <Message Importance="high"
+             Text="Detected CodeApp projects: @(_CodeAppProjects)"
+             Condition="'@(_CodeAppProjects)'!=''" />
+  </Target>
+
+  <Target Name="BuildCodeApps"
+          DependsOnTargets="ProbeCodeApps"
+          Condition="'@(_CodeAppProjects)'!=''">
+
+    <MSBuild Projects="@(_CodeAppProjects->'%(FullPath)')"
+             Targets="GetCodeAppOutputs"
+             Properties="Configuration=$(Configuration);RunNodeBuild=true"
+             BuildInParallel="true"
+             SkipNonexistentTargets="true">
+      <Output TaskParameter="TargetOutputs" ItemName="_CodeAppOutputs" />
+    </MSBuild>
+
+    <Message Importance="high"
+             Text="CodeApp outputs: @(_CodeAppOutputs->'%(Identity) [AppName=%(AppName)]')"
+             Condition="'@(_CodeAppOutputs)'!=''" />
+  </Target>
+
+  <Target Name="PrepareCodeAppsSources"
+          BeforeTargets="CopyCdsSolutionContent"
+          DependsOnTargets="BuildCodeApps">
+
+    <PropertyGroup>
+      <_HasCodeAppOutputs Condition="'@(_CodeAppOutputs)'!=''">true</_HasCodeAppOutputs>
+      <_DeclarationsRoot>$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)/$(SolutionRootPath)))</_DeclarationsRoot>
+      <_DeclarationsCanvasAppsDir>$(_DeclarationsRoot)\CanvasApps\</_DeclarationsCanvasAppsDir>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(_DeclarationsCanvasAppsDir)"
+             Condition="'$(_HasCodeAppOutputs)'=='true'" />
+
+    <!-- Patch source Solution.xml with CanvasApp root component -->
+    <AddRootComponentToSolution
+        Condition="'$(_HasCodeAppOutputs)'=='true'"
+        SolutionPath="$(_DeclarationsRoot)\Other\Solution.xml"
+        Type="300"
+        SchemaName="$(PublisherPrefix)_%(_CodeAppOutputs.AppName)"
+        Behavior="0" />
+
+    <!-- Generate .meta.xml in Declarations/CanvasApps/ -->
+    <GenerateCodeAppMetaXml
+        Condition="'$(_HasCodeAppOutputs)'=='true'"
+        ConfigPath="%(_CodeAppOutputs.ConfigPath)"
+        AppSchemaName="$(PublisherPrefix)_%(_CodeAppOutputs.AppName)"
+        OutputPath="$(_DeclarationsCanvasAppsDir)$(PublisherPrefix)_%(_CodeAppOutputs.AppName).meta.xml" />
+
+    <!-- Ensure CanvasApps node in source Customizations.xml -->
+    <EnsureCustomizationsNode
+        Condition="'$(_HasCodeAppOutputs)'=='true'"
+        CustomizationsXmlFile="$(_DeclarationsRoot)\Other\Customizations.xml"
+        NodeName="CanvasApps" />
+  </Target>
+
+  <Target Name="CopyCodeAppsToMetadata"
+          AfterTargets="CopyCdsSolutionContent"
+          BeforeTargets="ProcessCdsProjectReferencesOutputs"
+          DependsOnTargets="BuildCodeApps">
+
+    <PropertyGroup>
+      <_HasCodeAppOutputs Condition="'@(_CodeAppOutputs)'!=''">true</_HasCodeAppOutputs>
+      <_MetadataCanvasAppsDir>$(SolutionPackagerMetadataWorkingDirectory)\CanvasApps\</_MetadataCanvasAppsDir>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(_MetadataCanvasAppsDir)"
+             Condition="'$(_HasCodeAppOutputs)'=='true'" />
+
+    <ItemGroup Condition="'$(_HasCodeAppOutputs)'=='true'">
+      <_CodeAppDistFiles Include="%(_CodeAppOutputs.Identity)\**\*.*">
+        <AppName>%(_CodeAppOutputs.AppName)</AppName>
+      </_CodeAppDistFiles>
+    </ItemGroup>
+
+    <Message Importance="high"
+             Condition="'$(_HasCodeAppOutputs)'=='true'"
+             Text="Copying CodeApp dist to $(_MetadataCanvasAppsDir)$(PublisherPrefix)_%(_CodeAppOutputs.AppName)_CodeAppPackages\" />
+
+    <Copy Condition="'$(_HasCodeAppOutputs)'=='true'"
+          SourceFiles="@(_CodeAppDistFiles)"
+          DestinationFiles="@(_CodeAppDistFiles->'$(_MetadataCanvasAppsDir)$(PublisherPrefix)_%(AppName)_CodeAppPackages\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true"
+          OverwriteReadOnlyFiles="true" />
+  </Target>
+
+</Project>

--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.OverridePAC.targets
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.OverridePAC.targets
@@ -4,7 +4,7 @@
 
   <Target Name="ProcessCdsProjectReferencesOutputs"
           BeforeTargets="PowerAppsPackage"
-          DependsOnTargets="ProbeScriptLibraries"
+          DependsOnTargets="ProbeScriptLibraries;ProbeCodeApps"
           Condition="'@(ProjectReference)'!=''">
 
     <MSBuild Projects="@(ProjectReference->'%(FullPath)')"
@@ -27,6 +27,7 @@
     <PropertyGroup>
       <_ScriptLibraryProjectsList>;@(_ScriptLibraryProjects->'%(Identity)');</_ScriptLibraryProjectsList>
       <_WorkflowActivityProjectsList>;@(_WorkflowActivityProjects->'%(Identity)');</_WorkflowActivityProjectsList>
+      <_CodeAppProjectsList>;@(_CodeAppProjects->'%(Identity)');</_CodeAppProjectsList>
     </PropertyGroup>
 
     <ItemGroup>
@@ -38,6 +39,8 @@
                 Condition="$([System.String]::Copy('$(_ScriptLibraryProjectsList)').Contains(';%(FullPath);'))" />
       <_CdsRefs Remove="@(_CdsRefs)"
                 Condition="$([System.String]::Copy('$(_WorkflowActivityProjectsList)').Contains(';%(FullPath);'))" />
+      <_CdsRefs Remove="@(_CdsRefs)"
+                Condition="$([System.String]::Copy('$(_CodeAppProjectsList)').Contains(';%(FullPath);'))" />
     </ItemGroup>
 
     <Message Importance="high"
@@ -51,6 +54,10 @@
     <Message Importance="high"
              Text="Detected WorkflowActivity projects: @(_WorkflowActivityProjects->'%(Identity)', ', ')"
              Condition="'@(_WorkflowActivityProjects)'!=''" />
+
+    <Message Importance="high"
+             Text="Detected CodeApp projects: @(_CodeAppProjects->'%(Identity)', ', ')"
+             Condition="'@(_CodeAppProjects)'!=''" />
 
     <Message Importance="high"
              Text="PAC refs after filtering: @(_CdsRefs->'%(FullPath)', ', ')"
@@ -82,7 +89,7 @@
   <Target Name="PowerAppsPackage" AfterTargets="AfterBuild">
     <InvokeSolutionPackager
         Action="Pack"
-        PackageType="Managed"
+        PackageType="$(SolutionPackageType)"
         MappingFilePath="$(SolutionPackageMapFilePath)"
         SolutionRootDirectory="$(SolutionPackagerMetadataWorkingDirectory)"
         PathToZipFile="$(SolutionPackageZipFilePath)"

--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.ScriptLibraries.targets
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.ScriptLibraries.targets
@@ -115,7 +115,7 @@
     <MakeDir Directories="$(_MetadataWebResourcesDir)" />
 
     <EnsureCustomizationsNode
-        CustomizationsXmlFile="$(SolutionPackagerMetadataWorkingDirectory)\Other\customizations.xml"
+        CustomizationsXmlFile="$(SolutionPackagerMetadataWorkingDirectory)\Other\Customizations.xml"
         NodeName="WebResources" />
 
     <Message Importance="high"

--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.ScriptLibraries.targets
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.ScriptLibraries.targets
@@ -3,8 +3,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Target Name="ProbeScriptLibraries"
-          BeforeTargets="BuildScriptLibraries"
-          Condition="'@(ProjectReference)'!=''">
+          BeforeTargets="PrepareProjectReferences;ResolveProjectReferences;BuildScriptLibraries"
+          Condition="'@(ProjectReference)'!='' and '@(_ScriptLibraryProjects)'==''">
 
     <MSBuild Projects="@(ProjectReference->'%(FullPath)')"
              Targets="GetProjectType"
@@ -20,6 +20,15 @@
                               Condition="'%(ProjectType)'=='ScriptLibrary'" />
     </ItemGroup>
 
+    <PropertyGroup>
+      <_ScriptLibraryProjectsList>;@(_ScriptLibraryProjects->'%(Identity)');</_ScriptLibraryProjectsList>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Remove="@(ProjectReference)"
+                        Condition="$([System.String]::Copy('$(_ScriptLibraryProjectsList)').Contains(';%(FullPath);'))" />
+    </ItemGroup>
+
     <Message Importance="high"
              Text="Detected ScriptLibrary projects: @(_ScriptLibraryProjects)"
              Condition="'@(_ScriptLibraryProjects)'!=''" />
@@ -28,13 +37,12 @@
   <Target Name="BuildScriptLibraries"
           BeforeTargets="CoreCompile"
           DependsOnTargets="ProbeScriptLibraries"
-          Condition="'@(ProjectReference)'!=''">
+          Condition="'@(_ScriptLibraryProjects)'!=''">
 
-    <MSBuild Projects="@(ProjectReference->'%(FullPath)')"
+    <MSBuild Projects="@(_ScriptLibraryProjects)"
              Targets="GetScriptLibraryOutputs"
-             Properties="Configuration=$(Configuration);RunNodeBuild=true"
-             BuildInParallel="true"
-             SkipNonexistentTargets="true">
+             Properties="Configuration=$(Configuration)"
+             BuildInParallel="true">
       <Output TaskParameter="TargetOutputs" ItemName="_ScriptLibraryOutputs" />
     </MSBuild>
 
@@ -105,6 +113,10 @@
     </PropertyGroup>
 
     <MakeDir Directories="$(_MetadataWebResourcesDir)" />
+
+    <EnsureCustomizationsNode
+        CustomizationsXmlFile="$(SolutionPackagerMetadataWorkingDirectory)\Other\customizations.xml"
+        NodeName="WebResources" />
 
     <Message Importance="high"
              Text="Copy scripts to metadata: @(_ScriptFilesToCopy->'%(Identity) -> $(_MetadataWebResourcesDir)%(ResolvedName)', ', ')" />

--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.targets
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.targets
@@ -50,7 +50,7 @@
   </Target>
   
 <!-- XSD schema validation of solution components. Not wired automatically -->
-  <Target Name="TalxisValidateSolutionComponentSchema"
+  <Target Name="ValidateSolutionComponentSchema"
           DependsOnTargets="ValidateSolutionComponentSchema"
           Condition="Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\Solution.xml')" />
 

--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.targets
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.targets
@@ -39,6 +39,35 @@
     <CallTarget Targets="ApplyVersionNumber" />
   </Target>
 
+  <!--Ensure all required nodes exist in Customizations.xml -->
+  <Target Name="TalxisEnsureAllCustomizationsNodes"
+          AfterTargets="ProcessCdsProjectReferencesOutputs"
+          BeforeTargets="PowerAppsPackage"
+          Condition="Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\Customizations.xml')">
+    <EnsureAllCustomizationsNodes
+        CustomizationsXmlFile="$(SolutionPackagerMetadataWorkingDirectory)\Other\Customizations.xml"
+        MetadataWorkingDirectory="$(SolutionPackagerMetadataWorkingDirectory)" />
+  </Target>
+  
+<!-- XSD schema validation of solution components. Not wired automatically -->
+  <Target Name="TalxisValidateSolutionComponentSchema"
+          DependsOnTargets="ValidateSolutionComponentSchema"
+          Condition="Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\Solution.xml')" />
+
+  <!-- Detect duplicate GUIDs across all solution metadata files. -->
+  <Target Name="TalxisValidateDuplicateGuids"
+          AfterTargets="ProcessCdsProjectReferencesOutputs"
+          BeforeTargets="PowerAppsPackage"
+          DependsOnTargets="ValidateDuplicateGuids"
+          Condition="'$(TalxisSkipDuplicateGuidValidation)' != 'true' and Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\Solution.xml')" />
+
+  <!-- Validate that Quick Find views have search attributes configured -->
+  <Target Name="TalxisValidateQuickFindViews"
+          AfterTargets="ProcessCdsProjectReferencesOutputs"
+          BeforeTargets="PowerAppsPackage"
+          DependsOnTargets="ValidateQuickFindViews"
+          Condition="'$(TalxisSkipQuickFindValidation)' != 'true' and Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\Solution.xml')" />
+
     <!--  Data update in solution.xml logic  -->
     <Import Project="$(MSBuildThisFileDirectory)TALXIS.DevKit.Build.Dataverse.Solution.Data.targets"
     Condition="Exists('$(MSBuildThisFileDirectory)TALXIS.DevKit.Build.Dataverse.Solution.Data.targets')" />
@@ -46,6 +75,10 @@
   <!--  ScriptLibrary logic (detect, build, copy) -->
   <Import Project="$(MSBuildThisFileDirectory)TALXIS.DevKit.Build.Dataverse.Solution.ScriptLibraries.targets"
           Condition="Exists('$(MSBuildThisFileDirectory)TALXIS.DevKit.Build.Dataverse.Solution.ScriptLibraries.targets')" />
+
+  <!--  CodeApp logic (detect, build, copy to CanvasApps) -->
+  <Import Project="$(MSBuildThisFileDirectory)TALXIS.DevKit.Build.Dataverse.Solution.CodeApps.targets"
+          Condition="Exists('$(MSBuildThisFileDirectory)TALXIS.DevKit.Build.Dataverse.Solution.CodeApps.targets')" />
 
   <!--  PluginLibrary logic (detect, generate data xml) -->
   <Import Project="$(MSBuildThisFileDirectory)TALXIS.DevKit.Build.Dataverse.Solution.Plugin.targets"

--- a/src/Dataverse/Tasks/README.md
+++ b/src/Dataverse/Tasks/README.md
@@ -19,9 +19,9 @@ The package ships compiled task assemblies for `net472` and `net6.0`. At build t
 | Category | Tasks |
 |----------|-------|
 | Versioning | `GenerateGitVersion`, `ApplyVersionNumber`, `ApplyPcfVersionNumber`, `ApplyPluginVersionNumberInSolution` |
-| Solution packaging | `InvokeSolutionPackager`, `PatchSolutionXml`, `EnsureCustomizationsNode` |
+| Solution packaging | `InvokeSolutionPackager`, `PatchSolutionXml`, `EnsureCustomizationsNode`, `EnsureAllCustomizationsNodes` |
 | Component metadata | `EnsurePluginAssemblyDataXml`, `EnsureWorkflowActivityAssemblyDataXml`, `EnsureWebResourceDataXml`, `AddRootComponentToSolution`, `GenerateCodeAppMetaXml` |
-| Validation | `ValidateXmlFiles`, `ValidateJsonFiles` |
+| Validation | `ValidateXmlFiles`, `ValidateJsonFiles`, `ValidateDuplicateGuids`, `ValidateQuickFindViews`, `ValidatePcfDependencies` |
 | CMT data | `MergeCmtDataXml`, `MergeCmtDataSchemaXml`, `AppendCmtDataFileToImportConfig`, `PostProcessImportConfig` |
 | Utilities | `RetrieveProjectReferences`, `ResolveWebResourceName` |
 
@@ -51,7 +51,7 @@ Error codes emitted by validation tasks:
 | `TALXISJSONSCHEMA001` | `ValidateJsonFiles` | JSON file violates its JSON schema. |
 
 > [!TIP]
-> When used from a `TALXIS.DevKit.Build.Dataverse.Solution` project, validation runs automatically after `ProcessCdsProjectReferencesOutputs` and before `PowerAppsPackage`. To disable it, set `<TalxisSkipSolutionComponentSchemaValidation>true</TalxisSkipSolutionComponentSchemaValidation>` in your csproj.
+> Schema validation is **not wired into the build pipeline automatically**. To run it, invoke the `TalxisValidateSolutionComponentSchema` target manually, e.g. `dotnet build -t:TalxisValidateSolutionComponentSchema`.
 
 ## MSBuild Properties
 

--- a/src/Dataverse/Tasks/README.md
+++ b/src/Dataverse/Tasks/README.md
@@ -51,7 +51,7 @@ Error codes emitted by validation tasks:
 | `TALXISJSONSCHEMA001` | `ValidateJsonFiles` | JSON file violates its JSON schema. |
 
 > [!TIP]
-> Schema validation is **not wired into the build pipeline automatically**. To run it, invoke the `TalxisValidateSolutionComponentSchema` target manually, e.g. `dotnet build -t:TalxisValidateSolutionComponentSchema`.
+> Schema validation is **not wired into the build pipeline automatically**. To run it, invoke the `ValidateSolutionComponentSchema` target manually, e.g. `dotnet build -t:ValidateSolutionComponentSchema`.
 
 ## MSBuild Properties
 

--- a/src/Dataverse/Tasks/README.md
+++ b/src/Dataverse/Tasks/README.md
@@ -1,6 +1,6 @@
 # TALXIS.DevKit.Build.Dataverse.Tasks
 
-Core MSBuild tasks and targets library shared by all `TALXIS.DevKit.Build.Dataverse.*` packages. Provides custom C# MSBuild tasks for Git-based version generation, solution XML patching, solution packaging via PAC CLI, schema validation, CMT data merging, and web resource management. Most users do not reference this package directly -- it is pulled in as a dependency of the higher-level packages (`Plugin`, `Solution`, `Pcf`, etc.).
+Core MSBuild tasks and targets library shared by all `TALXIS.DevKit.Build.Dataverse.*` packages. Provides custom C# MSBuild tasks for Git-based version generation, solution XML patching, solution packaging via PAC CLI, schema validation, CMT data merging, code app metadata generation, and web resource management. Most users do not reference this package directly -- it is pulled in as a dependency of the higher-level packages (`Plugin`, `Solution`, `Pcf`, etc.).
 
 ## Installation
 
@@ -20,9 +20,9 @@ The package ships compiled task assemblies for `net472` and `net6.0`. At build t
 |----------|-------|
 | Versioning | `GenerateGitVersion`, `ApplyVersionNumber`, `ApplyPcfVersionNumber`, `ApplyPluginVersionNumberInSolution` |
 | Solution packaging | `InvokeSolutionPackager`, `PatchSolutionXml`, `EnsureCustomizationsNode` |
-| Component metadata | `EnsurePluginAssemblyDataXml`, `EnsureWorkflowActivityAssemblyDataXml`, `EnsureWebResourceDataXml`, `AddRootComponentToSolution` |
-| Validation | `ValidateSolutionComponentSchema`, `ValidateXmlFiles`, `ValidateJsonFiles` |
-| CMT data | `MergeCmtDataXml`, `MergeCmtDataSchemaXml`, `AppendCmtDataFileToImportConfig` |
+| Component metadata | `EnsurePluginAssemblyDataXml`, `EnsureWorkflowActivityAssemblyDataXml`, `EnsureWebResourceDataXml`, `AddRootComponentToSolution`, `GenerateCodeAppMetaXml` |
+| Validation | `ValidateXmlFiles`, `ValidateJsonFiles` |
+| CMT data | `MergeCmtDataXml`, `MergeCmtDataSchemaXml`, `AppendCmtDataFileToImportConfig`, `PostProcessImportConfig` |
 | Utilities | `RetrieveProjectReferences`, `ResolveWebResourceName` |
 
 ### Key targets
@@ -31,9 +31,27 @@ The package ships compiled task assemblies for `net472` and `net6.0`. At build t
 - **ApplyVersionNumber** -- patches the generated version into solution metadata folders (`SolutionXml`, `PluginAssemblies`, `Workflows`, `Controls`, `SdkMessageProcessingSteps`).
 - **ApplyPcfVersionNumber** -- updates the version in `ControlManifest.xml` for PCF controls.
 - **PackDataverseSolution** -- invokes the PAC solution packager to produce a `.zip` from the working directory.
-- **ValidateSolutionComponentSchema** -- validates solution XML files against bundled XSD schemas and JSON files against JSON schemas.
+- **ValidateSolutionComponentSchema** -- validates all solution XML files against bundled XSD schemas (22 schemas covering Solution, Entity, Form, Ribbon, Relationship, AppModule, Sitemap, OptionSet, Workflow, PluginAssembly, and more) and JSON files against JSON schemas (`Flow.schema.json` for Power Automate flows). Runs in batch mode -- collects all errors across all files before failing the build, with MSBuild-canonical error format (`file(line,col): error CODE: message`) for IDE click-through support.
 - **InitializeSolutionPackagerWorkingDirectory** -- copies solution source files into the intermediate working directory for packaging.
 - **CleanupWorkingDirectory** -- removes temporary localization and working directories after build.
+
+### Validation
+
+The `ValidateXmlFiles` and `ValidateJsonFiles` tasks ship with 22 XSD schemas and 1 JSON schema covering all Dataverse solution component types. Schemas are bundled in the NuGet package under `contentFiles/ValidationSchema/`.
+
+All XSD schemas share the null target namespace and are loaded into a single `XmlSchemaSet`, so cross-schema type references (e.g. `CrmCascadeSecurityLinkType` defined in `Customizations.xsd` but used in `Relationship.xsd`) are resolved automatically at compile time.
+
+Error codes emitted by validation tasks:
+
+| Code | Task | Meaning |
+|------|------|---------|
+| `TALXISXSD001` | `ValidateXmlFiles` | XML file violates its XSD schema. |
+| `TALXISXML001` | `ValidateXmlFiles` | XML file is not well-formed. |
+| `TALXISJSON001` | `ValidateJsonFiles` | JSON file is not valid JSON. |
+| `TALXISJSONSCHEMA001` | `ValidateJsonFiles` | JSON file violates its JSON schema. |
+
+> [!TIP]
+> When used from a `TALXIS.DevKit.Build.Dataverse.Solution` project, validation runs automatically after `ProcessCdsProjectReferencesOutputs` and before `PowerAppsPackage`. To disable it, set `<TalxisSkipSolutionComponentSchemaValidation>true</TalxisSkipSolutionComponentSchemaValidation>` in your csproj.
 
 ## MSBuild Properties
 
@@ -70,7 +88,6 @@ This is the foundational package in the ecosystem. The following packages depend
 - `TALXIS.DevKit.Build.Dataverse.Plugin`
 - `TALXIS.DevKit.Build.Dataverse.WorkflowActivity`
 - `TALXIS.DevKit.Build.Dataverse.ScriptLibrary`
+- `TALXIS.DevKit.Build.Dataverse.CodeApp`
 - `TALXIS.DevKit.Build.Dataverse.Solution`
 - `TALXIS.DevKit.Build.Dataverse.PdPackage`
-
-

--- a/src/Dataverse/Tasks/Tasks/AddRootComponentToSolution.cs
+++ b/src/Dataverse/Tasks/Tasks/AddRootComponentToSolution.cs
@@ -106,13 +106,10 @@ public sealed class AddRootComponentToSolution : Task
                              string.Equals(Normalize(idAttr), Normalize(Id), StringComparison.OrdinalIgnoreCase);
 
             bool schemaMatches = !string.IsNullOrWhiteSpace(SchemaName) &&
-                                 string.Equals(schemaAttr?.Trim(), SchemaName.Trim(), StringComparison.Ordinal);
+                                 string.Equals(schemaAttr?.Trim(), SchemaName.Trim(), StringComparison.OrdinalIgnoreCase);
 
-            if ((idMatches && !string.IsNullOrWhiteSpace(Id)) ||
-                (schemaMatches && !string.IsNullOrWhiteSpace(SchemaName)))
-            {
+            if (idMatches || schemaMatches)
                 return true;
-            }
         }
 
         return false;

--- a/src/Dataverse/Tasks/Tasks/EnsureAllCustomizationsNodes.cs
+++ b/src/Dataverse/Tasks/Tasks/EnsureAllCustomizationsNodes.cs
@@ -34,11 +34,11 @@ public class EnsureAllCustomizationsNodes : Task
         ("Controls",                          "CustomControls"),
 
         // Subfolder-based components (under Other/)
-        ("Other\\Relationships",              "EntityRelationships"),
+        (Path.Combine("Other", "Relationships"),             "EntityRelationships"),
 
         // File-based components (single XML files)
-        ("Other\\EntityMaps.xml",             "EntityMaps"),
-        ("Other\\FieldSecurityProfiles.xml",  "FieldSecurityProfiles"),
+        (Path.Combine("Other", "EntityMaps.xml"),            "EntityMaps"),
+        (Path.Combine("Other", "FieldSecurityProfiles.xml"), "FieldSecurityProfiles"),
     };
 
     public override bool Execute()

--- a/src/Dataverse/Tasks/Tasks/EnsureAllCustomizationsNodes.cs
+++ b/src/Dataverse/Tasks/Tasks/EnsureAllCustomizationsNodes.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+public class EnsureAllCustomizationsNodes : Task
+{
+    [Required]
+    public string CustomizationsXmlFile { get; set; }
+
+    [Required]
+    public string MetadataWorkingDirectory { get; set; }
+
+    private static readonly (string FolderOrFile, string NodeName)[] ComponentMap = new[]
+    {
+        // Folder-based components
+        ("Entities",                          "Entities"),
+        ("Roles",                             "Roles"),
+        ("Workflows",                         "Workflows"),
+        ("WebResources",                      "WebResources"),
+        ("PluginAssemblies",                  "SolutionPluginAssemblies"),
+        ("SdkMessageProcessingSteps",         "SdkMessageProcessingSteps"),
+        ("OptionSets",                        "optionsets"),
+        ("AppModules",                        "AppModules"),
+        ("AppModuleSiteMaps",                 "AppModuleSiteMaps"),
+        ("Dialogs",                           "Dialogs"),
+        ("Dashboards",                        "Dashboards"),
+        ("CanvasApps",                        "CanvasApps"),
+        ("Controls",                          "CustomControls"),
+
+        // Subfolder-based components (under Other/)
+        ("Other\\Relationships",              "EntityRelationships"),
+
+        // File-based components (single XML files)
+        ("Other\\EntityMaps.xml",             "EntityMaps"),
+        ("Other\\FieldSecurityProfiles.xml",  "FieldSecurityProfiles"),
+    };
+
+    public override bool Execute()
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(CustomizationsXmlFile) || !File.Exists(CustomizationsXmlFile))
+            {
+                Log.LogMessage(MessageImportance.Low,
+                    $"EnsureAllCustomizationsNodes: Customizations.xml not found at {CustomizationsXmlFile}, skipping.");
+                return true;
+            }
+
+            if (string.IsNullOrWhiteSpace(MetadataWorkingDirectory) || !Directory.Exists(MetadataWorkingDirectory))
+            {
+                Log.LogMessage(MessageImportance.Low,
+                    $"EnsureAllCustomizationsNodes: metadata directory not found at {MetadataWorkingDirectory}, skipping.");
+                return true;
+            }
+
+            var doc = XDocument.Load(CustomizationsXmlFile);
+            var root = doc.Root;
+            if (root == null)
+            {
+                Log.LogError($"EnsureAllCustomizationsNodes: Customizations.xml has no root element: {CustomizationsXmlFile}");
+                return false;
+            }
+
+            var addedNodes = new List<string>();
+
+            foreach (var (folderOrFile, nodeName) in ComponentMap)
+            {
+                if (!ComponentExists(folderOrFile))
+                    continue;
+
+                var elementName = root.Name.Namespace + nodeName;
+                if (root.Elements(elementName).Any())
+                    continue;
+
+                root.Add(new XElement(elementName));
+                addedNodes.Add(nodeName);
+            }
+
+            if (addedNodes.Count == 0)
+            {
+                Log.LogMessage(MessageImportance.Low,
+                    "EnsureAllCustomizationsNodes: all required nodes already present.");
+                return true;
+            }
+
+            var settings = new XmlWriterSettings
+            {
+                Encoding = new UTF8Encoding(false),
+                Indent = true,
+                NewLineChars = Environment.NewLine,
+                NewLineHandling = NewLineHandling.Replace
+            };
+
+            using (var writer = XmlWriter.Create(CustomizationsXmlFile, settings))
+            {
+                doc.Save(writer);
+            }
+
+            Log.LogMessage(MessageImportance.High,
+                $"EnsureAllCustomizationsNodes: added missing nodes to Customizations.xml: {string.Join(", ", addedNodes)}");
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.LogErrorFromException(ex, true);
+            return false;
+        }
+    }
+
+    private bool ComponentExists(string relativePath)
+    {
+        var fullPath = Path.Combine(MetadataWorkingDirectory, relativePath);
+
+        if (relativePath.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
+            return File.Exists(fullPath);
+
+        if (!Directory.Exists(fullPath))
+            return false;
+
+        try
+        {
+            return Directory.EnumerateFiles(fullPath, "*", SearchOption.AllDirectories).Any();
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/Dataverse/Tasks/Tasks/GenerateCodeAppMetaXml.cs
+++ b/src/Dataverse/Tasks/Tasks/GenerateCodeAppMetaXml.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json.Linq;
+
+/// <summary>
+/// MSBuild task that generates a .meta.xml file for a Power Apps Code App
+/// based on power.config.json and the build output (dist/) directory.
+/// </summary>
+public sealed class GenerateCodeAppMetaXml : Task
+{
+    /// <summary>
+    /// Path to power.config.json.
+    /// </summary>
+    [Required]
+    public string ConfigPath { get; set; } = "";
+
+    /// <summary>
+    /// Schema name of the app (e.g. "pub_myapp").
+    /// Used for the Name element and CodeAppPackageUri paths.
+    /// </summary>
+    [Required]
+    public string AppSchemaName { get; set; } = "";
+
+    /// <summary>
+    /// Path where the .meta.xml will be written.
+    /// </summary>
+    [Required]
+    public string OutputPath { get; set; } = "";
+
+    private static readonly Dictionary<string, string> MimeTypes =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            { ".html",  "text/html" },
+            { ".htm",   "text/html" },
+            { ".js",    "application/javascript" },
+            { ".mjs",   "application/javascript" },
+            { ".css",   "text/css" },
+            { ".svg",   "image/svg+xml" },
+            { ".png",   "image/png" },
+            { ".jpg",   "image/jpeg" },
+            { ".jpeg",  "image/jpeg" },
+            { ".gif",   "image/gif" },
+            { ".webp",  "image/webp" },
+            { ".ico",   "image/x-icon" },
+            { ".json",  "application/json" },
+            { ".woff",  "font/woff" },
+            { ".woff2", "font/woff2" },
+            { ".ttf",   "font/ttf" },
+            { ".eot",   "application/vnd.ms-fontobject" },
+            { ".map",   "application/json" },
+            { ".txt",   "text/plain" },
+            { ".xml",   "application/xml" },
+            { ".wasm",  "application/wasm" },
+        };
+
+    public override bool Execute()
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(ConfigPath) || !File.Exists(ConfigPath))
+            {
+                Log.LogError($"power.config.json not found: {ConfigPath}");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(AppSchemaName))
+            {
+                Log.LogError("AppSchemaName is required.");
+                return false;
+            }
+
+            var xml = Generate();
+
+            var dir = Path.GetDirectoryName(OutputPath);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            File.WriteAllText(OutputPath, xml, new UTF8Encoding(false));
+            Log.LogMessage(MessageImportance.High, $"Generated CodeApp meta.xml: {OutputPath}");
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.LogErrorFromException(ex, true, true, null);
+            return false;
+        }
+    }
+
+    private string Generate()
+    {
+        // ── Load config ──
+        var configFullPath = Path.GetFullPath(ConfigPath);
+        var configDir = Path.GetDirectoryName(configFullPath);
+        var config = JObject.Parse(File.ReadAllText(configFullPath));
+
+        var buildPathRaw = (string)config["buildPath"] ?? "./dist";
+        var buildPath = Path.IsPathRooted(buildPathRaw)
+            ? buildPathRaw
+            : Path.GetFullPath(Path.Combine(configDir, buildPathRaw));
+
+        if (!Directory.Exists(buildPath))
+            throw new DirectoryNotFoundException(
+                $"Build path not found: {buildPath}. Ensure npm run build produces output.");
+
+        var displayName = (string)config["appDisplayName"] ?? AppSchemaName;
+        var description = (string)config["description"];
+        var hasDescription = !string.IsNullOrWhiteSpace(description);
+
+        // ── DatabaseReferences JSON ──
+        var dbRefsOut = new JObject();
+        var cdsDeps = new JArray();
+
+        var databaseReferences = config["databaseReferences"] as JObject;
+        if (databaseReferences != null)
+        {
+            foreach (var prop in databaseReferences.Properties())
+            {
+                var key = prop.Name;
+                var dbRef = (JObject)prop.Value;
+                var envVarName = (string)dbRef["environmentVariableName"] ?? "";
+
+                var dataSources = new JObject();
+                var dsNode = dbRef["dataSources"] as JObject;
+                if (dsNode != null)
+                {
+                    foreach (var dsProp in dsNode.Properties())
+                    {
+                        var ds = (JObject)dsProp.Value;
+                        var entitySetName = (string)ds["entitySetName"] ?? "";
+                        var logicalName = (string)ds["logicalName"] ?? "";
+
+                        dataSources[dsProp.Name] = new JObject
+                        {
+                            ["entitySetName"] = entitySetName,
+                            ["logicalName"] = logicalName
+                        };
+
+                        cdsDeps.Add(new JObject
+                        {
+                            ["logicalname"] = logicalName,
+                            ["componenttype"] = 1
+                        });
+                    }
+                }
+
+                dbRefsOut[key] = new JObject
+                {
+                    ["databaseDetails"] = new JObject
+                    {
+                        ["referenceType"] = "Environmental",
+                        ["environmentName"] = key,
+                        ["overrideValues"] = new JObject
+                        {
+                            ["status"] = "NotSpecified",
+                            ["environmentVariableName"] = envVarName
+                        }
+                    },
+                    ["dataSources"] = dataSources
+                };
+            }
+        }
+
+        var dbRefsJson = dbRefsOut.ToString(Newtonsoft.Json.Formatting.None);
+        var cdsDepsJson = new JObject { ["cdsdependencies"] = cdsDeps }
+            .ToString(Newtonsoft.Json.Formatting.None);
+
+        // ── ConnectionReferences ──
+        var connRefs = config["connectionReferences"];
+        var connRefsJson = connRefs != null && connRefs.Type != JTokenType.Null
+            ? connRefs.ToString(Newtonsoft.Json.Formatting.None)
+            : "{}";
+        if (string.IsNullOrWhiteSpace(connRefsJson) || connRefsJson == "null")
+            connRefsJson = "{}";
+
+        // ── Scan build output → CodeAppPackageUris ──
+        var packageUriBase = $"/CanvasApps/{AppSchemaName}_CodeAppPackages";
+        var allFiles = Directory.GetFiles(buildPath, "*", SearchOption.AllDirectories);
+        var codeAppPackageUris = new List<string>();
+
+        foreach (var file in allFiles)
+        {
+            var relativePath = MakeRelativePath(buildPath, file).Replace('\\', '/');
+            var mime = GetMimeType(file);
+            codeAppPackageUris.Add($"{packageUriBase}/{relativePath}_ContentType_{mime}");
+        }
+
+        // ── Build XML ──
+        var timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
+        const string xsiNs = "http://www.w3.org/2001/XMLSchema-instance";
+
+        var settings = new XmlWriterSettings
+        {
+            Indent = true,
+            IndentChars = "  ",
+            Encoding = new UTF8Encoding(false),
+            OmitXmlDeclaration = false,
+        };
+
+        using (var stream = new MemoryStream())
+        {
+            using (var writer = XmlWriter.Create(stream, settings))
+            {
+                writer.WriteStartDocument();
+                writer.WriteStartElement("CanvasApp");
+                writer.WriteAttributeString("xmlns", "xsi", null, xsiNs);
+
+                writer.WriteElementString("Name", AppSchemaName);
+                writer.WriteElementString("AppVersion", timestamp);
+                writer.WriteElementString("Status", "Ready");
+                writer.WriteElementString("CreatedByClientVersion", "0.0.0.0");
+                writer.WriteElementString("MinClientVersion", "0.0.0.0");
+                writer.WriteElementString("Tags", "{}");
+                writer.WriteElementString("IsCdsUpgraded", "0");
+
+                WriteNilElement(writer, "GalleryItemId", xsiNs);
+
+                writer.WriteElementString("BackgroundColor", "RGBA(255,255,255,1)");
+                writer.WriteElementString("DisplayName", displayName);
+
+                if (hasDescription)
+                    writer.WriteElementString("Description", description);
+                else
+                    WriteNilElement(writer, "Description", xsiNs);
+
+                WriteNilElement(writer, "CommitMessage", xsiNs);
+                WriteNilElement(writer, "Publisher", xsiNs);
+
+                writer.WriteElementString("AuthorizationReferences", "[]");
+                writer.WriteElementString("ConnectionReferences", connRefsJson);
+                writer.WriteElementString("DatabaseReferences", dbRefsJson);
+                writer.WriteElementString("AppComponents", "[]");
+                writer.WriteElementString("AppComponentDependencies", "[]");
+                writer.WriteElementString("CanConsumeAppPass", "1");
+                writer.WriteElementString("CanvasAppType", "4");
+                writer.WriteElementString("BypassConsent", "0");
+                writer.WriteElementString("AdminControlBypassConsent", "0");
+
+                WriteNilElement(writer, "EmbeddedApp", xsiNs);
+
+                writer.WriteElementString("IntroducedVersion", "1.0");
+                writer.WriteElementString("CdsDependencies", cdsDepsJson);
+                writer.WriteElementString("IsCustomizable", "1");
+
+                // CodeAppPackageUris
+                writer.WriteStartElement("CodeAppPackageUris");
+                foreach (var uri in codeAppPackageUris)
+                {
+                    writer.WriteElementString("CodeAppPackageUri", uri);
+                }
+                writer.WriteEndElement();
+
+                writer.WriteEndElement(); // CanvasApp
+                writer.WriteEndDocument();
+            }
+
+            return Encoding.UTF8.GetString(stream.ToArray());
+        }
+    }
+
+    private static void WriteNilElement(XmlWriter writer, string name, string xsiNs)
+    {
+        writer.WriteStartElement(name);
+        writer.WriteAttributeString("xsi", "nil", xsiNs, "true");
+        writer.WriteFullEndElement();
+    }
+
+    private static string GetMimeType(string filePath)
+    {
+        var ext = Path.GetExtension(filePath);
+        return MimeTypes.TryGetValue(ext, out var mime) ? mime : "application/octet-stream";
+    }
+
+    /// <summary>
+    /// Compatible replacement for Path.GetRelativePath (not available in net472).
+    /// </summary>
+    private static string MakeRelativePath(string basePath, string fullPath)
+    {
+        if (!basePath.EndsWith(Path.DirectorySeparatorChar.ToString()))
+            basePath += Path.DirectorySeparatorChar;
+
+        var baseUri = new Uri(basePath);
+        var fullUri = new Uri(fullPath);
+        return Uri.UnescapeDataString(baseUri.MakeRelativeUri(fullUri).ToString())
+                   .Replace('/', Path.DirectorySeparatorChar);
+    }
+}

--- a/src/Dataverse/Tasks/Tasks/InvokeSolutionPackager.cs
+++ b/src/Dataverse/Tasks/Tasks/InvokeSolutionPackager.cs
@@ -38,19 +38,7 @@ public class InvokeSolutionPackager : Task
 			? new[] { "pac.exe", "pac.cmd" }
 			: new[] { "pac" };
 
-		// Check the standard global tools location first
-		var toolsDir = Path.Combine(
-			Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-			".dotnet", "tools");
-
-		foreach (var name in candidates)
-		{
-			var globalToolPath = Path.Combine(toolsDir, name);
-			if (File.Exists(globalToolPath))
-				return globalToolPath;
-		}
-
-		// Check the standalone Power Platform CLI location on Windows
+		// Check the standalone Power Platform CLI location first (preferred, supports latest versions)
 		if (isWindows)
 		{
 			var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
@@ -60,6 +48,18 @@ public class InvokeSolutionPackager : Task
 				if (File.Exists(standalonePath))
 					return standalonePath;
 			}
+		}
+
+		// Check the standard global tools location
+		var toolsDir = Path.Combine(
+			Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+			".dotnet", "tools");
+
+		foreach (var name in candidates)
+		{
+			var globalToolPath = Path.Combine(toolsDir, name);
+			if (File.Exists(globalToolPath))
+				return globalToolPath;
 		}
 
 		// Fall back to searching PATH

--- a/src/Dataverse/Tasks/Tasks/ValidateDuplicateGuids.cs
+++ b/src/Dataverse/Tasks/Tasks/ValidateDuplicateGuids.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using System.Xml;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+public class ValidateDuplicateGuids : Task
+{
+    [Required]
+    public ITaskItem[] FilesForValidation { get; set; }
+
+    private static readonly Regex GuidPattern = new Regex(
+        @"\{?[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\}?",
+        RegexOptions.Compiled);
+
+    private static readonly (string ElementName, string FilePattern)[] IdentityRules = new[]
+    {
+        ("savedqueryid",                    "SavedQueries"),
+        ("savedqueryvisualizationid",       "SavedQueries"),
+        ("formid",                          "FormXml"),
+        ("WebResourceId",                   ".data.xml"),
+        ("WorkflowId",                      "Workflows"),
+        ("SdkMessageProcessingStepId",      "SdkMessageProcessingSteps"),
+        ("PluginTypeId",                    "PluginAssemblies"),
+        ("connectionroleid",                "ConnectionRoles"),
+        ("OptionSetId",                     "OptionSets"),
+        ("environmentvariabledefinitionid", "environmentvariabledefinitions"),
+        ("environmentvariablevalueid",      "environmentvariabledefinitions"),
+        ("AppModuleId",                     "AppModules"),
+        ("RoleId",                          "Roles"),
+    };
+
+    private static readonly Dictionary<string, List<string>> IdentityLookup;
+
+    static ValidateDuplicateGuids()
+    {
+        IdentityLookup = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (elementName, filePattern) in IdentityRules)
+        {
+            if (!IdentityLookup.TryGetValue(elementName, out var patterns))
+            {
+                patterns = new List<string>();
+                IdentityLookup[elementName] = patterns;
+            }
+            if (filePattern != null)
+                patterns.Add(filePattern);
+        }
+    }
+
+    private struct GuidLocation
+    {
+        public string FilePath;
+        public string ElementName;
+        public int Line;
+        public int Column;
+    }
+
+    public override bool Execute()
+    {
+        try
+        {
+            if (FilesForValidation == null || FilesForValidation.Length == 0)
+                return true;
+
+            var guidMap = new Dictionary<string, List<GuidLocation>>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var fileItem in FilesForValidation)
+            {
+                var filePath = fileItem.ItemSpec;
+                if (!File.Exists(filePath))
+                    continue;
+
+                try
+                {
+                    ScanFile(filePath, guidMap);
+                }
+                catch (Exception ex)
+                {
+                    Log.LogWarning($"ValidateDuplicateGuids: could not parse {filePath}: {ex.Message}");
+                }
+            }
+
+            int duplicateCount = 0;
+            foreach (var entry in guidMap)
+            {
+                var locations = entry.Value;
+                if (locations.Count < 2)
+                    continue;
+
+                duplicateCount++;
+                var guid = entry.Key;
+
+                for (int i = 0; i < locations.Count; i++)
+                {
+                    var loc = locations[i];
+                    var otherFiles = locations
+                        .Where((_, idx) => idx != i)
+                        .Select(l => Path.GetFileName(l.FilePath))
+                        .ToArray();
+
+                    Log.LogError(
+                        subcategory: "guid",
+                        errorCode: "TALXISGUID001",
+                        helpKeyword: null,
+                        file: loc.FilePath,
+                        lineNumber: loc.Line,
+                        columnNumber: loc.Column,
+                        endLineNumber: 0,
+                        endColumnNumber: 0,
+                        message: $"Duplicate GUID {{{guid}}} in <{loc.ElementName}>. Also found in: {string.Join(", ", otherFiles)}");
+                }
+            }
+
+            if (duplicateCount > 0)
+            {
+                Log.LogError($"ValidateDuplicateGuids: found {duplicateCount} duplicate GUID(s) across {FilesForValidation.Length} files.");
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+        catch (Exception ex)
+        {
+            Log.LogErrorFromException(ex);
+            return false;
+        }
+    }
+
+    private void ScanFile(string filePath, Dictionary<string, List<GuidLocation>> guidMap)
+    {
+        var doc = XDocument.Load(filePath, LoadOptions.SetLineInfo);
+        ScanElements(doc.Root, filePath, guidMap);
+    }
+
+    private void ScanElements(XElement element, string filePath, Dictionary<string, List<GuidLocation>> guidMap)
+    {
+        if (!element.HasElements)
+        {
+            var localName = element.Name.LocalName;
+
+            if (!IsInsideParameters(element) && IsIdentityElement(localName, filePath))
+            {
+                var value = element.Value.Trim();
+                if (GuidPattern.IsMatch(value))
+                {
+                    var normalized = NormalizeGuid(value);
+                    if (normalized != null)
+                    {
+                        var lineInfo = (IXmlLineInfo)element;
+                        AddGuid(guidMap, normalized, new GuidLocation
+                        {
+                            FilePath = filePath,
+                            ElementName = localName,
+                            Line = lineInfo.HasLineInfo() ? lineInfo.LineNumber : 0,
+                            Column = lineInfo.HasLineInfo() ? lineInfo.LinePosition : 0
+                        });
+                    }
+                }
+            }
+        }
+
+        foreach (var child in element.Elements())
+        {
+            ScanElements(child, filePath, guidMap);
+        }
+    }
+
+    private static bool IsInsideParameters(XElement element)
+    {
+        var parent = element.Parent;
+        while (parent != null)
+        {
+            if (parent.Name.LocalName.Equals("parameters", StringComparison.OrdinalIgnoreCase))
+                return true;
+            parent = parent.Parent;
+        }
+        return false;
+    }
+
+    private static bool IsIdentityElement(string elementName, string filePath)
+    {
+        if (!IdentityLookup.TryGetValue(elementName, out var patterns))
+            return false;
+
+        if (patterns.Count == 0)
+            return true;
+
+        foreach (var pattern in patterns)
+        {
+            if (filePath.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string NormalizeGuid(string raw)
+    {
+        var stripped = raw.Trim().TrimStart('{').TrimEnd('}').ToLowerInvariant();
+        if (Guid.TryParse(stripped, out var parsed))
+            return parsed.ToString("D");
+        return null;
+    }
+
+    private static void AddGuid(Dictionary<string, List<GuidLocation>> map, string guid, GuidLocation location)
+    {
+        if (!map.TryGetValue(guid, out var list))
+        {
+            list = new List<GuidLocation>();
+            map[guid] = list;
+        }
+        list.Add(location);
+    }
+}

--- a/src/Dataverse/Tasks/Tasks/ValidateJsonFiles.cs
+++ b/src/Dataverse/Tasks/Tasks/ValidateJsonFiles.cs
@@ -19,17 +19,51 @@ public class ValidateJsonFiles : Task
     {
         try
         {
-            foreach (var fileForValidation in FilesForValidation)
+            if (SchemaFiles == null || SchemaFiles.Length == 0)
             {
-                bool isValid = ValidateJsonAgainstSchema(fileForValidation.ItemSpec, SchemaFiles.Select(x => x.ItemSpec));
+                Log.LogError("ValidateJsonFiles: no JSON schema files were provided.");
+                return false;
+            }
 
-                if (!isValid)
+           var schemas = new List<KeyValuePair<string, JSchema>>();
+            foreach (var schemaFilePath in SchemaFiles.Select(x => x.ItemSpec))
+            {
+                if (!File.Exists(schemaFilePath))
                 {
-                    Log.LogError($"The JSON file {fileForValidation} is not valid against the JSON schema");
+                    Log.LogError($"ValidateJsonFiles: schema file not found: {schemaFilePath}");
+                    return false;
+                }
+                try
+                {
+                    var parsed = JSchema.Parse(File.ReadAllText(schemaFilePath));
+                    schemas.Add(new KeyValuePair<string, JSchema>(schemaFilePath, parsed));
+                }
+                catch (Exception ex)
+                {
+                    Log.LogError($"ValidateJsonFiles: failed to parse schema {schemaFilePath}: {ex.Message}");
                     return false;
                 }
             }
-            return true;
+
+            int total  = FilesForValidation?.Length ?? 0;
+            int failed = 0;
+
+            for (int i = 0; i < total; i++)
+            {
+                var filePath = FilesForValidation[i].ItemSpec;
+                if (!ValidateSingleFile(filePath, schemas))
+                {
+                    failed++;
+                }
+            }
+
+            if (failed > 0)
+            {
+                Log.LogError($"ValidateJsonFiles: {failed} of {total} JSON file(s) failed schema validation.");
+                return false;
+            }
+
+            return !Log.HasLoggedErrors;
         }
         catch (Exception ex)
         {
@@ -38,29 +72,63 @@ public class ValidateJsonFiles : Task
         }
     }
 
-    private bool ValidateJsonAgainstSchema(string jsonFilePath, IEnumerable<string> schemaFilePaths)
+    private bool ValidateSingleFile(string jsonFilePath, List<KeyValuePair<string, JSchema>> schemas)
     {
-        bool isValid = true;
-        JSchema schema = new JSchema();
-
-        foreach (var schemaFilePath in schemaFilePaths)
+        if (!File.Exists(jsonFilePath))
         {
-            var schemaContent = File.ReadAllText(schemaFilePath);
-            schema = JSchema.Parse(schemaContent);
+            Log.LogError($"ValidateJsonFiles: file not found: {jsonFilePath}");
+            return false;
         }
 
-        var jsonContent = File.ReadAllText(jsonFilePath);
-        var jsonObject = JObject.Parse(jsonContent);
-
-        IList<string> messages;
-        if (!jsonObject.IsValid(schema, out messages))
+        JToken jsonToken;
+        try
         {
-            foreach (var message in messages)
+            // Parse as generic token so we accept both objects and arrays at the root.
+            jsonToken = JToken.Parse(File.ReadAllText(jsonFilePath));
+        }
+        catch (Exception ex)
+        {
+            Log.LogError(
+                subcategory: "json",
+                errorCode:   "TALXISJSON001",
+                helpKeyword: null,
+                file:        jsonFilePath,
+                lineNumber:  0,
+                columnNumber: 0,
+                endLineNumber: 0,
+                endColumnNumber: 0,
+                message:     $"invalid JSON - {ex.Message}");
+            return false;
+        }
+
+      var perSchemaMessages = new List<KeyValuePair<string, IList<string>>>();
+
+        foreach (var pair in schemas)
+        {
+            IList<string> messages;
+            if (jsonToken.IsValid(pair.Value, out messages))
             {
-                Log.LogError($"Schema validation error: {message}");
-                isValid = false;
+                return true;
+            }
+            perSchemaMessages.Add(new KeyValuePair<string, IList<string>>(pair.Key, messages));
+        }
+
+        foreach (var entry in perSchemaMessages)
+        {
+            foreach (var msg in entry.Value)
+            {
+                Log.LogError(
+                    subcategory: "schema",
+                    errorCode:   "TALXISJSONSCHEMA001",
+                    helpKeyword: null,
+                    file:        jsonFilePath,
+                    lineNumber:  0,
+                    columnNumber: 0,
+                    endLineNumber: 0,
+                    endColumnNumber: 0,
+                    message:     $"[{Path.GetFileName(entry.Key)}] {msg}");
             }
         }
-        return isValid;
+        return false;
     }
 }

--- a/src/Dataverse/Tasks/Tasks/ValidatePcfDependencies.cs
+++ b/src/Dataverse/Tasks/Tasks/ValidatePcfDependencies.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+public class ValidatePcfDependencies : Task
+{
+    [Required]
+    public ITaskItem[] SolutionZipFiles { get; set; }
+
+    public string IgnoredPcfPrefixes { get; set; }
+
+    public override bool Execute()
+    {
+        try
+        {
+            if (SolutionZipFiles == null || SolutionZipFiles.Length == 0)
+                return true;
+
+            var ignoredPrefixes = ParsePrefixes(IgnoredPcfPrefixes);
+            var providedControls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var usedControls = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var zipItem in SolutionZipFiles)
+            {
+                var zipPath = zipItem.ItemSpec;
+                if (!File.Exists(zipPath))
+                    continue;
+
+                try
+                {
+                    ScanSolutionZip(zipPath, providedControls, usedControls);
+                }
+                catch (Exception ex)
+                {
+                    Log.LogWarning($"ValidatePcfDependencies: could not read {Path.GetFileName(zipPath)}: {ex.Message}");
+                }
+            }
+
+            int missingCount = 0;
+            foreach (var entry in usedControls)
+            {
+                var controlName = entry.Key;
+
+                if (providedControls.Contains(controlName))
+                    continue;
+
+                if (IsIgnored(controlName, ignoredPrefixes))
+                    continue;
+
+                missingCount++;
+                var solutions = string.Join(", ", entry.Value.Distinct());
+                Log.LogWarning(
+                    subcategory: "pcf",
+                    warningCode: "TALXISPCF001",
+                    helpKeyword: null,
+                    file: null,
+                    lineNumber: 0,
+                    columnNumber: 0,
+                    endLineNumber: 0,
+                    endColumnNumber: 0,
+                    message: $"PCF control \"{controlName}\" is used in forms (solutions: {solutions}) " +
+                             $"but no solution in the PDPackage provides it (RootComponent type=\"66\"). " +
+                             $"Add the solution containing this control, or add its prefix to TalxisIgnoredPcfPrefixes.");
+            }
+
+            if (missingCount > 0)
+            {
+                Log.LogWarning($"ValidatePcfDependencies: {missingCount} PCF control(s) used in forms but not provided by any solution in the package.");
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.LogErrorFromException(ex);
+            return false;
+        }
+    }
+
+    private void ScanSolutionZip(string zipPath, HashSet<string> providedControls, Dictionary<string, List<string>> usedControls)
+    {
+        var solutionName = Path.GetFileNameWithoutExtension(zipPath);
+
+        using (var archive = ZipFile.OpenRead(zipPath))
+        {
+            foreach (var entry in archive.Entries)
+            {
+                var name = entry.FullName.Replace('\\', '/');
+
+                if (name.Equals("solution.xml", StringComparison.OrdinalIgnoreCase) ||
+                    name.Equals("Other/Solution.xml", StringComparison.OrdinalIgnoreCase))
+                {
+                    using (var stream = entry.Open())
+                    {
+                        var doc = XDocument.Load(stream);
+                        ExtractProvidedControls(doc, providedControls);
+                    }
+                }
+                else if (name.Equals("customizations.xml", StringComparison.OrdinalIgnoreCase) ||
+                         name.Equals("Other/customizations.xml", StringComparison.OrdinalIgnoreCase))
+                {
+                    using (var stream = entry.Open())
+                    {
+                        var doc = XDocument.Load(stream);
+                        ExtractUsedControls(doc, solutionName, usedControls);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void ExtractProvidedControls(XDocument solutionXml, HashSet<string> provided)
+    {
+        foreach (var rc in solutionXml.Descendants("RootComponent"))
+        {
+            var type = rc.Attribute("type")?.Value;
+            var schemaName = rc.Attribute("schemaName")?.Value;
+
+            if (type == "66" && !string.IsNullOrEmpty(schemaName))
+                provided.Add(schemaName);
+        }
+    }
+
+    private static void ExtractUsedControls(XDocument formXml, string solutionName, Dictionary<string, List<string>> used)
+    {
+        foreach (var cc in formXml.Descendants("customControl"))
+        {
+            var name = cc.Attribute("name")?.Value;
+            if (string.IsNullOrEmpty(name))
+                continue;
+
+            if (!used.TryGetValue(name, out var solutions))
+            {
+                solutions = new List<string>();
+                used[name] = solutions;
+            }
+            if (!solutions.Contains(solutionName))
+                solutions.Add(solutionName);
+        }
+    }
+
+
+
+    private static bool IsIgnored(string controlName, HashSet<string> ignoredPrefixes)
+    {
+        if (ignoredPrefixes.Count == 0)
+            return false;
+
+        var underscoreIdx = controlName.IndexOf('_');
+        if (underscoreIdx <= 0)
+            return false;
+
+        var prefix = controlName.Substring(0, underscoreIdx);
+        return ignoredPrefixes.Contains(prefix);
+    }
+
+    private static HashSet<string> ParsePrefixes(string raw)
+    {
+        var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(raw))
+            return result;
+
+        foreach (var part in raw.Split(new[] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var trimmed = part.Trim();
+            if (trimmed.Length > 0)
+                result.Add(trimmed);
+        }
+        return result;
+    }
+}

--- a/src/Dataverse/Tasks/Tasks/ValidateQuickFindViews.cs
+++ b/src/Dataverse/Tasks/Tasks/ValidateQuickFindViews.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
@@ -19,7 +18,6 @@ public class ValidateQuickFindViews : Task
             if (FilesForValidation == null || FilesForValidation.Length == 0)
                 return true;
 
-            int filesChecked = 0;
             int quickFindCount = 0;
             int failedCount = 0;
 
@@ -36,7 +34,6 @@ public class ValidateQuickFindViews : Task
 
                     foreach (var sq in savedQueries)
                     {
-                        filesChecked++;
                         if (!IsQuickFind(sq))
                             continue;
 

--- a/src/Dataverse/Tasks/Tasks/ValidateQuickFindViews.cs
+++ b/src/Dataverse/Tasks/Tasks/ValidateQuickFindViews.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+public class ValidateQuickFindViews : Task
+{
+    [Required]
+    public ITaskItem[] FilesForValidation { get; set; }
+
+    public override bool Execute()
+    {
+        try
+        {
+            if (FilesForValidation == null || FilesForValidation.Length == 0)
+                return true;
+
+            int filesChecked = 0;
+            int quickFindCount = 0;
+            int failedCount = 0;
+
+            foreach (var fileItem in FilesForValidation)
+            {
+                var filePath = fileItem.ItemSpec;
+                if (!File.Exists(filePath))
+                    continue;
+
+                try
+                {
+                    var doc = XDocument.Load(filePath, LoadOptions.SetLineInfo);
+                    var savedQueries = doc.Descendants("savedquery");
+
+                    foreach (var sq in savedQueries)
+                    {
+                        filesChecked++;
+                        if (!IsQuickFind(sq))
+                            continue;
+
+                        quickFindCount++;
+                        if (!ValidateSingleQuickFind(sq, filePath))
+                            failedCount++;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.LogWarning($"ValidateQuickFindViews: could not parse {filePath}: {ex.Message}");
+                }
+            }
+
+            if (failedCount > 0)
+            {
+                Log.LogWarning($"ValidateQuickFindViews: {failedCount} of {quickFindCount} Quick Find view(s) are missing search attributes.");
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.LogErrorFromException(ex);
+            return false;
+        }
+    }
+
+    private static bool IsQuickFind(XElement savedQuery)
+    {
+        var el = savedQuery.Element("isquickfindquery");
+        return el != null && el.Value.Trim() == "1";
+    }
+
+    private bool ValidateSingleQuickFind(XElement savedQuery, string filePath)
+    {
+        // Get the display name for a readable error message.
+        var nameEl = savedQuery.Descendants("LocalizedName").FirstOrDefault();
+        var displayName = nameEl?.Attribute("description")?.Value ?? "(unnamed)";
+
+        // Navigate: <fetchxml> → <fetch> → <entity> → <filter isquickfindfields="1">
+        var fetchXmlEl = savedQuery.Element("fetchxml");
+        if (fetchXmlEl == null)
+        {
+            ReportWarning(savedQuery, filePath, displayName, "has no <fetchxml> element");
+            return false;
+        }
+
+        var fetchEl = fetchXmlEl.Element("fetch");
+        if (fetchEl == null)
+        {
+            ReportWarning(savedQuery, filePath, displayName, "has no <fetch> element inside <fetchxml>");
+            return false;
+        }
+
+        var entityEl = fetchEl.Element("entity");
+        if (entityEl == null)
+        {
+            ReportWarning(savedQuery, filePath, displayName, "has no <entity> element inside <fetch>");
+            return false;
+        }
+
+        // Look for <filter isquickfindfields="1"> anywhere under <entity> (can be nested)
+        var quickFindFilter = entityEl
+            .Descendants("filter")
+            .FirstOrDefault(f => f.Attribute("isquickfindfields")?.Value == "1");
+
+        if (quickFindFilter == null)
+        {
+            ReportWarning(savedQuery, filePath, displayName,
+                "is marked as Quick Find (isquickfindquery=1) but FetchXML has no <filter isquickfindfields=\"1\">. " +
+                "Users will not be able to search by any attribute.");
+            return false;
+        }
+
+        // The filter exists — check it has at least one <condition>
+        var conditions = quickFindFilter.Elements("condition").ToList();
+        if (conditions.Count == 0)
+        {
+            ReportWarning(savedQuery, filePath, displayName,
+                "has <filter isquickfindfields=\"1\"> but it contains no <condition> elements. " +
+                "Add at least one condition to define searchable attributes.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private void ReportWarning(XElement element, string filePath, string displayName, string detail)
+    {
+        var lineInfo = (IXmlLineInfo)element;
+        int line = lineInfo.HasLineInfo() ? lineInfo.LineNumber : 0;
+        int col = lineInfo.HasLineInfo() ? lineInfo.LinePosition : 0;
+
+        Log.LogWarning(
+            subcategory: "quickfind",
+            warningCode: "TALXISQF001",
+            helpKeyword: null,
+            file: filePath,
+            lineNumber: line,
+            columnNumber: col,
+            endLineNumber: 0,
+            endColumnNumber: 0,
+            message: $"Quick Find view \"{displayName}\" {detail}");
+    }
+}

--- a/src/Dataverse/Tasks/Tasks/ValidateXmlFiles.cs
+++ b/src/Dataverse/Tasks/Tasks/ValidateXmlFiles.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
@@ -15,51 +14,72 @@ public class ValidateXmlFiles : Task
     [Required]
     public ITaskItem[] SchemaFiles { get; set; }
 
+    // Tracks the file currently being validated so the ValidationEventHandler
+    // can emit MSBuild-canonical error messages (file(line,col): error CODE: ...).
+    private string _currentFile;
+    private bool _currentFileHasError;
 
     public override bool Execute()
     {
         try
         {
-            XmlSchemaSet schemas = new XmlSchemaSet();
+            if (SchemaFiles == null || SchemaFiles.Length == 0)
+            {
+                Log.LogError("ValidateXmlFiles: no XSD schema files were provided.");
+                return false;
+            }
 
+            var schemas = new XmlSchemaSet();
             foreach (var xsdFilePath in SchemaFiles.Select(x => x.ItemSpec))
             {
+                if (!File.Exists(xsdFilePath))
+                {
+                    Log.LogError($"ValidateXmlFiles: schema file not found: {xsdFilePath}");
+                    return false;
+                }
                 schemas.Add(null, xsdFilePath);
             }
 
-            XmlReaderSettings settings = new XmlReaderSettings
+            try
             {
-                ValidationType = ValidationType.Schema,
-                ValidationFlags = XmlSchemaValidationFlags.ReportValidationWarnings | XmlSchemaValidationFlags.ProcessIdentityConstraints | XmlSchemaValidationFlags.ProcessInlineSchema | XmlSchemaValidationFlags.ProcessSchemaLocation,
-                Schemas = schemas,
-                DtdProcessing = DtdProcessing.Ignore
-            };
-
-            settings.ValidationEventHandler += (object sender, ValidationEventArgs e) =>
-            {
-                switch (e.Severity)
-                {
-                    case XmlSeverityType.Error:
-                        string text = $"Line: {e.Exception?.LineNumber}, Column: {e.Exception?.LinePosition}> {e.Message}";
-                        // fail the build if there is an error
-                        throw new Exception(text);
-                    case XmlSeverityType.Warning:
-                        Log.LogWarning($"Schema validation warning: {e.Message}");
-                        break;
-                }
-            };
-
-
-            foreach (var fileForValidation in FilesForValidation)
-            {
-                bool isValid = ValidateXmlAgainstXsd(settings, fileForValidation.ItemSpec);
-
-                if (!isValid)
-                {
-                    return false;
-                }
+                schemas.Compile();
             }
-            return true;
+            catch (XmlSchemaException ex)
+            {
+                Log.LogError($"ValidateXmlFiles: failed to compile schema set: {ex.Message}");
+                return false;
+            }
+
+            var settings = new XmlReaderSettings
+            {
+                ValidationType  = ValidationType.Schema,
+                ValidationFlags = XmlSchemaValidationFlags.ReportValidationWarnings
+                                | XmlSchemaValidationFlags.ProcessIdentityConstraints
+                                | XmlSchemaValidationFlags.ProcessInlineSchema
+                                | XmlSchemaValidationFlags.ProcessSchemaLocation,
+                Schemas         = schemas,
+                DtdProcessing   = DtdProcessing.Ignore
+            };
+            settings.ValidationEventHandler += OnValidationEvent;
+
+            int total   = FilesForValidation?.Length ?? 0;
+            int failed  = 0;
+
+            for (int i = 0; i < total; i++)
+            {
+                _currentFile = FilesForValidation[i].ItemSpec;
+                _currentFileHasError = false;
+                ValidateSingleFile(_currentFile, settings);
+                if (_currentFileHasError) failed++;
+            }
+
+            if (failed > 0)
+            {
+                Log.LogError($"ValidateXmlFiles: {failed} of {total} XML file(s) failed schema validation.");
+                return false;
+            }
+
+            return !Log.HasLoggedErrors;
         }
         catch (Exception ex)
         {
@@ -68,23 +88,76 @@ public class ValidateXmlFiles : Task
         }
     }
 
-    private bool ValidateXmlAgainstXsd(XmlReaderSettings readerSettings, string xmlFilePath)
+    private void OnValidationEvent(object sender, ValidationEventArgs e)
     {
-        bool isValid = true;
-        XmlReader reader = XmlReader.Create(xmlFilePath, readerSettings);
+        int line = e.Exception?.LineNumber   ?? 0;
+        int col  = e.Exception?.LinePosition ?? 0;
+
+        if (e.Severity == XmlSeverityType.Error)
+        {
+            // MSBuild canonical format: IDEs (VS, Rider, VS Code) pick up file+line+col.
+            Log.LogError(
+                subcategory: "schema",
+                errorCode:   "TALXISXSD001",
+                helpKeyword: null,
+                file:        _currentFile,
+                lineNumber:  line,
+                columnNumber: col,
+                endLineNumber: 0,
+                endColumnNumber: 0,
+                message:     e.Message);
+            _currentFileHasError = true;
+        }
+        else
+        {
+            Log.LogWarning(
+                subcategory: "schema",
+                warningCode: "TALXISXSD001",
+                helpKeyword: null,
+                file:        _currentFile,
+                lineNumber:  line,
+                columnNumber: col,
+                endLineNumber: 0,
+                endColumnNumber: 0,
+                message:     e.Message);
+        }
+    }
+
+    private void ValidateSingleFile(string xmlFilePath, XmlReaderSettings settings)
+    {
+        if (!File.Exists(xmlFilePath))
+        {
+            Log.LogError($"ValidateXmlFiles: file not found: {xmlFilePath}");
+            _currentFileHasError = true;
+            return;
+        }
+
         try
         {
-            while (reader.Read()) { /* Empty loop to ensure all content is read and validated */ }
+            using (var reader = XmlReader.Create(xmlFilePath, settings))
+            {
+                while (reader.Read()) { /* drives validation */ }
+            }
         }
-        catch (Exception e)
+        catch (XmlException ex)
         {
-            Log.LogError($"File {xmlFilePath} is not valid against the XSD schema. Error detail: {e.Message}");
-            isValid = false;
+            // Malformed XML (not a schema violation).
+            Log.LogError(
+                subcategory: "xml",
+                errorCode:   "TALXISXML001",
+                helpKeyword: null,
+                file:        xmlFilePath,
+                lineNumber:  ex.LineNumber,
+                columnNumber: ex.LinePosition,
+                endLineNumber: 0,
+                endColumnNumber: 0,
+                message:     ex.Message);
+            _currentFileHasError = true;
         }
-        finally
+        catch (Exception ex)
         {
-            reader.Dispose();
+            Log.LogError($"{xmlFilePath}: {ex.Message}");
+            _currentFileHasError = true;
         }
-        return isValid;
     }
 }

--- a/src/Dataverse/Tasks/Tasks/ValidateXmlFiles.cs
+++ b/src/Dataverse/Tasks/Tasks/ValidateXmlFiles.cs
@@ -54,11 +54,10 @@ public class ValidateXmlFiles : Task
             {
                 ValidationType  = ValidationType.Schema,
                 ValidationFlags = XmlSchemaValidationFlags.ReportValidationWarnings
-                                | XmlSchemaValidationFlags.ProcessIdentityConstraints
-                                | XmlSchemaValidationFlags.ProcessInlineSchema
-                                | XmlSchemaValidationFlags.ProcessSchemaLocation,
+                                | XmlSchemaValidationFlags.ProcessIdentityConstraints,
                 Schemas         = schemas,
-                DtdProcessing   = DtdProcessing.Ignore
+                DtdProcessing   = DtdProcessing.Ignore,
+                XmlResolver     = null
             };
             settings.ValidationEventHandler += OnValidationEvent;
 

--- a/src/Dataverse/Tasks/ValidationSchema/AppModule.xsd
+++ b/src/Dataverse/Tasks/ValidationSchema/AppModule.xsd
@@ -15,7 +15,7 @@
             <xs:element name="statuscode" type="xs:integer" minOccurs="0" maxOccurs="1" />
             <xs:element name="statecode" type="xs:integer" minOccurs="0" maxOccurs="1" />
             <xs:element name="WelcomePageId" type="xs:string" minOccurs="0" maxOccurs="1" />
-            <xs:element name="FormFactor" type="xs:integer" minOccurs="1" maxOccurs="1" />
+            <xs:element name="FormFactor" type="xs:integer" minOccurs="0" maxOccurs="1" />
             <xs:element name="ClientType" minOccurs="0" maxOccurs="1">
                 <xs:simpleType>
                     <xs:restriction base="xs:integer">
@@ -37,7 +37,12 @@
             <xs:element name="AppModuleRoleMaps" minOccurs="0" maxOccurs="1">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element name="Role" type="AppModuleRoleType" minOccurs="1" maxOccurs="unbounded" />
+                        <xs:element name="Role" type="AppModuleRoleType" minOccurs="0" maxOccurs="unbounded" />
+                        <xs:element name="Everyone" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                                <xs:attribute name="id" use="optional" type="GuidType" />
+                            </xs:complexType>
+                        </xs:element>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -55,6 +60,13 @@
             </xs:element>
             <xs:element name="LocalizedNames" type="LocalizedNamesType" minOccurs="1" maxOccurs="1" />
             <xs:element name="Descriptions" type="DescriptionsType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="appsettings" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
         </xs:all>
     </xs:complexType>
     <xs:complexType name="AppModuleComponentType">

--- a/src/Dataverse/Tasks/ValidationSchema/Customizations.xsd
+++ b/src/Dataverse/Tasks/ValidationSchema/Customizations.xsd
@@ -28,6 +28,8 @@
         <xs:restriction base="xs:string">
             <xs:enumeration value="Cascade" />
             <xs:enumeration value="NoCascade" />
+            <xs:enumeration value="RemoveLink" />
+            <xs:enumeration value="Restrict" />
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="NavPaneDisplayOptionType">
@@ -511,9 +513,9 @@
         <xs:sequence>
             <xs:element name="CustomControlDefaultConfig" minOccurs="0" maxOccurs="unbounded">
                 <xs:complexType>
-                    <xs:sequence>
+                    <xs:all>
                         <xs:element name="PrimaryEntityTypeCode" type="xs:integer" minOccurs="0" maxOccurs="1" />
-                        <xs:element name="CustomControlDefaultConfigId" type="GuidType" minOccurs="1" maxOccurs="1" />
+                        <xs:element name="CustomControlDefaultConfigId" type="GuidType" minOccurs="0" maxOccurs="1" />
                         <xs:element name="ControlDescriptionXML">
                             <xs:complexType>
                                 <xs:sequence>
@@ -552,7 +554,7 @@
                         <xs:element name="IntroducedVersion" type="xs:string" minOccurs="0" maxOccurs="1" />
                         <xs:element name="formLibraries" type="FormXmlLibraryType" minOccurs="0" maxOccurs="1" />
                         <xs:element name="events" type="FormXmlEventsType" minOccurs="0" maxOccurs="1" />
-                    </xs:sequence>
+                    </xs:all>
                 </xs:complexType>
             </xs:element>
         </xs:sequence>

--- a/src/Dataverse/Tasks/ValidationSchema/Entity.xsd
+++ b/src/Dataverse/Tasks/ValidationSchema/Entity.xsd
@@ -29,7 +29,7 @@
 		</xs:complexType>
 	</xs:element>
 	<xs:complexType name="EntityInfoType">
-		<xs:choice minOccurs="1" maxOccurs="1">
+		<xs:choice minOccurs="0" maxOccurs="1">
 			<xs:element name="entity">
 				<xs:complexType>
 					<xs:all>
@@ -140,7 +140,7 @@
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element name="attributes" minOccurs="1" maxOccurs="1">
+						<xs:element name="attributes" minOccurs="0" maxOccurs="1">
 							<xs:complexType>
 								<xs:sequence>
 									<xs:element name="attribute" minOccurs="0" maxOccurs="unbounded">
@@ -207,6 +207,7 @@
 											</xs:all>
 											<xs:attribute name="PhysicalName" use="required" type="EntityAttributeNameBaseType" />
 											<xs:attribute name="unmodified" use="optional" type="TrueFalse01Type" />
+											<xs:attribute name="IsHidden" use="optional" type="TrueFalse01Type" />
 										</xs:complexType>
 									</xs:element>
 								</xs:sequence>
@@ -360,7 +361,7 @@
 						<xs:element name="IsPrimaryKey" type="xs:boolean" minOccurs="1" maxOccurs="1" />
 						<xs:element name="IsUniqueConstraint" type="xs:boolean" minOccurs="0" maxOccurs="1" />
 						<xs:element name="IndexType" type="xs:integer" minOccurs="0" maxOccurs="1" />
-						<xs:element name="attributes" minOccurs="1" maxOccurs="1">
+						<xs:element name="attributes" minOccurs="0" maxOccurs="1">
 							<xs:complexType>
 								<xs:sequence>
 									<xs:element name="attribute" minOccurs="1" maxOccurs="unbounded">

--- a/src/Dataverse/Tasks/ValidationSchema/Form.xsd
+++ b/src/Dataverse/Tasks/ValidationSchema/Form.xsd
@@ -27,10 +27,11 @@
 						<xs:element name="FormPresentation" type="xs:nonNegativeInteger" minOccurs="0" maxOccurs="1" />
 						<xs:element name="FormActivationState" type="xs:nonNegativeInteger" minOccurs="0" maxOccurs="1" />
 						<xs:element name="form" type="FormType" minOccurs="1" maxOccurs="1" />
-						<xs:element name="LocalizedNames" type="LocalizedNamesType" minOccurs="1" maxOccurs="1" />
+						<xs:element name="LocalizedNames" type="LocalizedNamesType" minOccurs="0" maxOccurs="1" />
 						<xs:element name="Descriptions" type="DescriptionsType" minOccurs="0" maxOccurs="1" />
 					</xs:all>
 					<xs:attribute name="unmodified" use="optional" type="TrueFalse01Type" />
+					<xs:attribute name="solutionaction" use="optional" type="solutionactionType" />
 				</xs:complexType>
 			</xs:element>
 		</xs:sequence>
@@ -87,7 +88,7 @@
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="tabs" minOccurs="1" maxOccurs="1">
+			<xs:element name="tabs" minOccurs="0" maxOccurs="1">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="tab" minOccurs="1" maxOccurs="100">
@@ -455,7 +456,7 @@
 			<xs:element name="labels" type="FormXmlLabelsType" minOccurs="0" maxOccurs="1" />
 			<xs:element name="parameters" minOccurs="0" maxOccurs="1">
 				<xs:complexType>
-					<xs:choice minOccurs="1" maxOccurs="1">
+					<xs:choice minOccurs="0" maxOccurs="unbounded">
 						<!-- LATER: (TobinZ, 2008-07-24) - Divide this list up into sets that are valid together. -->
 						<xs:choice minOccurs="1" maxOccurs="unbounded">
 							<xs:element name="Url" type="xs:string" minOccurs="0" maxOccurs="1" />
@@ -490,7 +491,7 @@
 							<xs:element name="ViewName" type="xs:string" minOccurs="0" maxOccurs="1" />
 						</xs:choice>
 						<!--Parameters for unbound lookup control-->
-						<xs:choice minOccurs="1" maxOccurs="unbounded">
+						<xs:choice minOccurs="0" maxOccurs="unbounded">
 							<xs:element name="TargetEntities" minOccurs="0" maxOccurs="1">
 								<xs:complexType>
 									<xs:sequence>
@@ -563,6 +564,8 @@
 							<xs:element name="UnboundLookupBrowse" type="xs:boolean" minOccurs="0" maxOccurs="1" />
 							<xs:element name="UnboundLookupControlType" type="xs:string" minOccurs="0" maxOccurs="1" />
 							<xs:element name="ShowAsBreadcrumbControl" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+							<xs:element name="useMainFormDialogForEdit" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+							<xs:element name="useMainFormDialogForCreate" type="xs:boolean" minOccurs="0" maxOccurs="1" />
 						</xs:choice>
 						<!-- Parameters for the TextBox -->
 						<xs:choice minOccurs="1" maxOccurs="unbounded">
@@ -685,10 +688,11 @@
 		<xs:attribute name="isrequired" type="xs:boolean" />
 		<xs:attribute name="relationship" type="xs:string" />
 		<xs:attribute name="indicationOfSubgrid" type="xs:boolean" />
+		<xs:attribute name="solutionaction" type="solutionactionType" />
 	</xs:complexType>
 	<xs:complexType name="FormXmlLibraryType">
 		<xs:sequence>
-			<xs:element name="Library" minOccurs="1" maxOccurs="50">
+			<xs:element name="Library" minOccurs="0" maxOccurs="50">
 				<xs:complexType>
 					<xs:attribute name="name" type="xs:string" use="required" />
 					<xs:attribute name="libraryUniqueId" type="xs:string" use="required" />
@@ -724,7 +728,7 @@
 	</xs:complexType>
 	<xs:complexType name="FormXmlEventsType">
 		<xs:sequence>
-			<xs:element name="event" minOccurs="1" maxOccurs="unbounded">
+			<xs:element name="event" minOccurs="0" maxOccurs="unbounded">
 				<xs:complexType>
 					<xs:all>
 						<xs:element name="Handlers" minOccurs="0" maxOccurs="1">
@@ -849,7 +853,7 @@
 	</xs:attributeGroup>
 	<xs:attributeGroup name="FormXmlRowCommon">
 		<xs:attribute name="height" type="xs:string" />
-
+		<xs:attribute name="solutionaction" type="solutionactionType" />
 	</xs:attributeGroup>
 	<xs:attributeGroup name="FormXmlCellCommon">
 		<xs:attribute name="id" type="FormGuidType" />

--- a/src/Dataverse/Tasks/ValidationSchema/Ribbon.xsd
+++ b/src/Dataverse/Tasks/ValidationSchema/Ribbon.xsd
@@ -3,7 +3,7 @@
 	xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
 	<!-- Root Element-->
-	<xs:element name="RibbonDiffXml" type="RibbonGlobalDiffXmlType" />
+	<xs:element name="RibbonDiffXml" type="RibbonEntityDiffXmlType" />
 	<xs:element name="CommandDefinitions" type="CommandDefinitionsType" />
 	<xs:element name="RuleDefinitions" type="RuleDefinitionsGlobalType" />
 	<xs:element name="Templates" type="TemplatesType" />
@@ -117,11 +117,11 @@
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="CommandDefinitionType">
-		<xs:sequence>
-			<xs:element name="EnableRules" type="ReferenceEnableRulesType" minOccurs="1" maxOccurs="1" />
-			<xs:element name="DisplayRules" type="ReferenceDisplayRulesType" minOccurs="1" maxOccurs="1" />
-			<xs:element name="Actions" type="ActionsType" minOccurs="1" maxOccurs="1" />
-		</xs:sequence>
+		<xs:all>
+			<xs:element name="EnableRules" type="ReferenceEnableRulesType" minOccurs="0" maxOccurs="1" />
+			<xs:element name="DisplayRules" type="ReferenceDisplayRulesType" minOccurs="0" maxOccurs="1" />
+			<xs:element name="Actions" type="ActionsType" minOccurs="0" maxOccurs="1" />
+		</xs:all>
 		<xs:attribute name="Id" type="xs:string" use="required" />
 	</xs:complexType>
 	<xs:complexType name="JavaScriptFunctionType">
@@ -193,18 +193,18 @@
 
 	<!-- Rule Container Types -->
 	<xs:complexType name="RuleDefinitionsEntityType">
-		<xs:sequence>
-			<xs:element name="TabDisplayRules" type="TabDisplayRulesEntityType" minOccurs="1" maxOccurs="1" />
-			<xs:element name="DisplayRules" type="DisplayRulesType" minOccurs="1" maxOccurs="1" />
-			<xs:element name="EnableRules" type="EnableRulesType" minOccurs="1" maxOccurs="1" />
-		</xs:sequence>
+		<xs:all>
+			<xs:element name="TabDisplayRules" type="TabDisplayRulesEntityType" minOccurs="0" maxOccurs="1" />
+			<xs:element name="DisplayRules" type="DisplayRulesType" minOccurs="0" maxOccurs="1" />
+			<xs:element name="EnableRules" type="EnableRulesType" minOccurs="0" maxOccurs="1" />
+		</xs:all>
 	</xs:complexType>
 	<xs:complexType name="RuleDefinitionsGlobalType">
-		<xs:sequence>
-			<xs:element name="TabDisplayRules" type="TabDisplayRulesGlobalType" minOccurs="1" maxOccurs="1" />
-			<xs:element name="DisplayRules" type="DisplayRulesType" minOccurs="1" maxOccurs="1" />
-			<xs:element name="EnableRules" type="EnableRulesType" minOccurs="1" maxOccurs="1" />
-		</xs:sequence>
+		<xs:all>
+			<xs:element name="TabDisplayRules" type="TabDisplayRulesGlobalType" minOccurs="0" maxOccurs="1" />
+			<xs:element name="DisplayRules" type="DisplayRulesType" minOccurs="0" maxOccurs="1" />
+			<xs:element name="EnableRules" type="EnableRulesType" minOccurs="0" maxOccurs="1" />
+		</xs:all>
 	</xs:complexType>
 
 	<xs:complexType name="EnableRulesType">
@@ -280,7 +280,7 @@
 	</xs:complexType>
 
 	<xs:complexType name="DisplayRulesType">
-		<xs:sequence minOccurs="0" maxOccurs="unbounded">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
 			<xs:element name="DisplayRule">
 				<xs:complexType>
 					<xs:choice minOccurs="1" maxOccurs="unbounded">
@@ -290,7 +290,8 @@
 					<xs:attribute name="Id" type="xs:string" use="required" />
 				</xs:complexType>
 			</xs:element>
-		</xs:sequence>
+			<xs:element name="EnableRule" type="ReferenceEnableRuleType" />
+		</xs:choice>
 	</xs:complexType>
 
 	<xs:complexType name="OrDisplayRuleType">
@@ -353,6 +354,8 @@
 			<xs:element name="HideIfUserIsNotTenantAdminRule" type ="HideIfUserIsNotTenantAdminType" />
 			<xs:element name="HideIfEmailIsApprovedByAdminBasedOnESPRule" type ="HideIfEmailIsApprovedByAdminBasedOnESPRuleType" />
 			<xs:element name="HideIfProductRecommendationsNotEnabledRule" type ="HideIfProductRecommendationsNotEnabledType" />
+			<xs:element name="CustomRule" type="CustomRuleType" />
+			<xs:element name="EnableRule" type="ReferenceEnableRuleType" />
 		</xs:choice>
 	</xs:group>
 
@@ -1824,7 +1827,7 @@
 
   <xs:complexType name="TemplatesType">
     <xs:all>
-      <xs:element name="RibbonTemplates" type="RibbonTemplatesType" />
+      <xs:element name="RibbonTemplates" type="RibbonTemplatesType" minOccurs="0" />
     </xs:all>
   </xs:complexType>
 

--- a/src/Dataverse/Tasks/ValidationSchema/Role.xsd
+++ b/src/Dataverse/Tasks/ValidationSchema/Role.xsd
@@ -7,11 +7,12 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="RoleType">
-        <xs:sequence>
+        <xs:all>
             <xs:element name="IsCustomizable" type="TrueFalse01Type" minOccurs="0" maxOccurs="1" />
+            <xs:element name="IsAutoAssigned" type="TrueFalse01Type" minOccurs="0" maxOccurs="1" />
             <xs:element name="IntroducedVersion" type="VersionType" minOccurs="0" maxOccurs="1" />
             <xs:element name="RolePrivileges" type="RolePrivilegestype" minOccurs="0" maxOccurs="1" />
-        </xs:sequence>
+        </xs:all>
         <xs:attribute name="name" use="required" type="xs:string" />
         <xs:attribute name="isinherited" use="optional" type="TrueFalse01Type" />
         <xs:attribute name="id" use="required" type="GuidType" />

--- a/src/Dataverse/Tasks/ValidationSchema/SavedQuery.xsd
+++ b/src/Dataverse/Tasks/ValidationSchema/SavedQuery.xsd
@@ -37,7 +37,7 @@
                                                             <xs:element name="cell" minOccurs="0" maxOccurs="unbounded">
                                                                 <xs:complexType>
                                                                     <xs:attribute name="name" type="xs:string" />
-                                                                    <xs:attribute name="width" type="xs:nonNegativeInteger" />
+                                                                    <xs:attribute name="width" type="xs:string" />
                                                                     <xs:attribute name="disableMetaDataBinding" type="TrueFalse01Type" />
                                                                     <xs:attribute name="LabelId" type="xs:string" />
                                                                     <xs:attribute name="ishidden" type="TrueFalse01Type" />
@@ -128,6 +128,7 @@
                         </xs:element>
                     </xs:all>
                     <xs:attribute name="unmodified" use="optional" type="TrueFalse01Type" />
+                    <xs:anyAttribute processContents="lax" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>

--- a/src/Dataverse/Tasks/ValidationSchema/SharedTypes.xsd
+++ b/src/Dataverse/Tasks/ValidationSchema/SharedTypes.xsd
@@ -22,7 +22,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="^[0-9]+(\.[0-9]+){1,3}$" />
+            <xs:pattern value=".+" />
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="TrueFalseType">
@@ -59,6 +59,7 @@
     <xs:complexType name="DescriptionsType">
         <xs:sequence>
             <xs:element name="Description" type="FieldXmlFieldUIType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="Descriptions" type="DescriptionsType" minOccurs="0" maxOccurs="1" />
         </xs:sequence>
     </xs:complexType>
     <xs:simpleType name="CrmDataType">

--- a/src/Dataverse/Tasks/ValidationSchema/Sitemap.xsd
+++ b/src/Dataverse/Tasks/ValidationSchema/Sitemap.xsd
@@ -4,6 +4,10 @@
     <xs:complexType name="AppModuleSiteMapType">
         <xs:sequence>
             <xs:element name="SiteMapUniqueName" type="xs:string" minOccurs="1" maxOccurs="1" />
+            <xs:element name="EnableCollapsibleGroups" type="xs:string" minOccurs="0" maxOccurs="1" />
+            <xs:element name="ShowHome" type="xs:string" minOccurs="0" maxOccurs="1" />
+            <xs:element name="ShowPinned" type="xs:string" minOccurs="0" maxOccurs="1" />
+            <xs:element name="ShowRecents" type="xs:string" minOccurs="0" maxOccurs="1" />
             <xs:element name="SiteMapName" type="xs:string" minOccurs="0" maxOccurs="1" />
             <xs:element name="SiteMap" type="SiteMapType" minOccurs="1" maxOccurs="1">
                 <xs:unique name="AreaIdMustBeUniqueForAppModuleSiteMap">

--- a/src/Dataverse/Tasks/ValidationSchema/Solution.xsd
+++ b/src/Dataverse/Tasks/ValidationSchema/Solution.xsd
@@ -63,8 +63,8 @@
                                                 </xs:sequence>
                                             </xs:complexType>
                                         </xs:element>
-                                        <xs:element type="xs:string" name="EMailAddress" nillable="true"/>
-                                        <xs:element type="xs:string" name="SupportingWebsiteUrl" nillable="true"/>
+                                        <xs:element type="xs:string" name="EMailAddress" />
+                                        <xs:element type="xs:string" name="SupportingWebsiteUrl" />
                                         <xs:element type="xs:string" name="CustomizationPrefix"/>
                                         <xs:element type="xs:int" name="CustomizationOptionValuePrefix"/>
                                         <xs:element name="Addresses">
@@ -75,30 +75,30 @@
                                                             <xs:sequence>
                                                                 <xs:element type="xs:byte" name="AddressNumber" minOccurs="0" maxOccurs="1" />
                                                                 <xs:element type="xs:byte" name="AddressTypeCode" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="City" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="County" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Country" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Fax" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="FreightTermsCode" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="ImportSequenceNumber" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Latitude" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Line1" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Line2" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Line3" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Longitude" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Name" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="PostalCode" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="PostOfficeBox" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="PrimaryContactName" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:byte" name="ShippingMethodCode" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="StateOrProvince" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Telephone1" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Telephone2" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Telephone3" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="TimeZoneRuleVersionNumber" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="UPSZone" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="UTCOffset" nillable="true" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="UTCConversionTimeZoneCode" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="City" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="County" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Country" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Fax" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="FreightTermsCode" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="ImportSequenceNumber" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Latitude" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Line1" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Line2" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Line3" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Longitude" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Name" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="PostalCode" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="PostOfficeBox" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="PrimaryContactName" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:byte" name="ShippingMethodCode"  minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="StateOrProvince" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Telephone1" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Telephone2" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Telephone3" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="TimeZoneRuleVersionNumber" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="UPSZone" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="UTCOffset" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="UTCConversionTimeZoneCode" minOccurs="0" maxOccurs="1" />
                                                             </xs:sequence>
                                                         </xs:complexType>
                                                     </xs:element>

--- a/src/Dataverse/Tasks/msbuild/tasks/Props/ProjectPaths.props
+++ b/src/Dataverse/Tasks/msbuild/tasks/Props/ProjectPaths.props
@@ -7,6 +7,10 @@
         <SolutionPackageLogFilePath Condition="'$(SolutionPackageLogFilePath)' == ''">$(IntermediateOutputPath)SolutionPackager.log</SolutionPackageLogFilePath>
         <SolutionPackageZipFilePath Condition="'$(SolutionPackageZipFilePath)' == ''">$(OutputPath)$(MSBuildProjectName).zip</SolutionPackageZipFilePath>
 
+        <!-- Package type: Unmanaged for Debug, Managed otherwise. Can be overridden explicitly. -->
+        <SolutionPackageType Condition="'$(SolutionPackageType)' == '' And '$(Configuration)' == 'Debug'">Unmanaged</SolutionPackageType>
+        <SolutionPackageType Condition="'$(SolutionPackageType)' == ''">Managed</SolutionPackageType>
+
         <!-- Property names for this package -->
         <DataverseSolutionSourceFolderFullPath>$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)/$(SolutionRootPath)))</DataverseSolutionSourceFolderFullPath>
     </PropertyGroup>

--- a/src/Dataverse/Tasks/msbuild/tasks/Props/SolutionFileItems.props
+++ b/src/Dataverse/Tasks/msbuild/tasks/Props/SolutionFileItems.props
@@ -1,7 +1,7 @@
 <Project>
     <ItemGroup>
-        <XsdSchemaFiles Include="$(MSBuildThisFileDirectory)\..\contentFiles\ValidationSchema\*.xsd" />
-        <JsonSchemaFiles Include="$(MSBuildThisFileDirectory)\..\contentFiles\ValidationSchema\*.schema.json" />
+       <XsdSchemaFiles  Include="$(MSBuildThisFileDirectory)\..\..\contentFiles\ValidationSchema\*.xsd" />
+        <JsonSchemaFiles Include="$(MSBuildThisFileDirectory)\..\..\contentFiles\ValidationSchema\*.schema.json" />
         <SolutionXml Include="$(SolutionPackagerMetadataWorkingDirectory)\Other\Solution.xml"/>
         <EntityMaps Include="$(SolutionPackagerMetadataWorkingDirectory)\Other\EntityMaps.xml" Condition="Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\EntityMaps.xml')"/>
         <AppModules Include="$(SolutionPackagerMetadataWorkingDirectory)\AppModules\*\*.xml"/>

--- a/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.targets
@@ -14,7 +14,7 @@
         <TasksAssembly>$(ThisPackageBuildExtensionsDirectory)$(MSBuildThisFileName).dll</TasksAssembly>
     </PropertyGroup>
 
-    <UsingTask TaskName="ValidateSolutionComponentSchema" AssemblyFile="$(TasksAssembly)" />
+
     <UsingTask TaskName="GenerateGitVersion" AssemblyFile="$(TasksAssembly)" />
     <UsingTask TaskName="ApplyVersionNumber" AssemblyFile="$(TasksAssembly)" />
     <UsingTask TaskName="ApplyPcfVersionNumber" AssemblyFile="$(TasksAssembly)" />
@@ -34,4 +34,9 @@
     <UsingTask TaskName="AppendCmtDataFileToImportConfig" AssemblyFile="$(TasksAssembly)" />
     <UsingTask TaskName="ResolveWebResourceName" AssemblyFile="$(TasksAssembly)" />
     <UsingTask TaskName="PostProcessImportConfig" AssemblyFile="$(TasksAssembly)" />
+    <UsingTask TaskName="GenerateCodeAppMetaXml" AssemblyFile="$(TasksAssembly)" />
+    <UsingTask TaskName="ValidateDuplicateGuids" AssemblyFile="$(TasksAssembly)" />
+    <UsingTask TaskName="ValidateQuickFindViews" AssemblyFile="$(TasksAssembly)" />
+    <UsingTask TaskName="EnsureAllCustomizationsNodes" AssemblyFile="$(TasksAssembly)" />
+    <UsingTask TaskName="ValidatePcfDependencies" AssemblyFile="$(TasksAssembly)" />
 </Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/PackDataverseSolution.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/PackDataverseSolution.targets
@@ -1,13 +1,12 @@
 <Project>
     <Target Name="PackDataverseSolution">
-        <!-- TODO: Decide package type based on configuration -->
         <PropertyGroup>
             <SolutionPackageMapFilePath>$(ProjectDir)map.xml</SolutionPackageMapFilePath>
             <SolutionPackageMapFilePath Condition="!Exists('$(ProjectDir)map.xml')"></SolutionPackageMapFilePath>
             <SolutionPackageEnableLocalization>false</SolutionPackageEnableLocalization>
             <SolutionPackageEnableLocalization Condition="Exists('$(DataverseSolutionSourceFolderFullPath)Resources')">true</SolutionPackageEnableLocalization>
         </PropertyGroup>
-        <InvokeSolutionPackager Action="Pack" PackageType="Managed" MappingFilePath="$(SolutionPackageMapFilePath)" SolutionRootDirectory="$(DataverseSolutionSourceFolderFullPath)" PathToZipFile="$(SolutionPackageZipFilePath)" ErrorLevel="Info" LogFilePath="$(SolutionPackageLogFilePath)" LocalTemplate="Auto" Localize="$(SolutionPackageEnableLocalization)" UseUnmanagedFileForMissingManaged="true" />
+        <InvokeSolutionPackager Action="Pack" PackageType="$(SolutionPackageType)" MappingFilePath="$(SolutionPackageMapFilePath)" SolutionRootDirectory="$(DataverseSolutionSourceFolderFullPath)" PathToZipFile="$(SolutionPackageZipFilePath)" ErrorLevel="Info" LogFilePath="$(SolutionPackageLogFilePath)" LocalTemplate="Auto" Localize="$(SolutionPackageEnableLocalization)" UseUnmanagedFileForMissingManaged="true" />
         <Message Importance="High" Text="Solution: $(SolutionPackageZipFilePath) packed successfully" />
     </Target>
 </Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/ValidateDuplicateGuids.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/ValidateDuplicateGuids.targets
@@ -18,6 +18,8 @@
             <_GuidCheckFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\SdkMessageProcessingSteps\*.xml" />
             <_GuidCheckFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\Dialogs\*.xml" />
             <_GuidCheckFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\environmentvariabledefinitions\**\*.xml" />
+            <_GuidCheckFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\Roles\*.xml" />
+            <_GuidCheckFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\OptionSets\**\*.xml" />
             <_GuidCheckFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\Other\ConnectionRoles.xml"
                              Condition="Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\ConnectionRoles.xml')" />
         </ItemGroup>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/ValidateDuplicateGuids.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/ValidateDuplicateGuids.targets
@@ -1,0 +1,28 @@
+<Project>
+    <Target Name="ValidateDuplicateGuids">
+        <!--
+          Collect files using direct globs evaluated at target execution time,
+          not from static item groups (which are evaluated during project load,
+          before CopyCdsSolutionContent copies files to the metadata folder).
+        -->
+        <ItemGroup>
+            <_GuidCheckFiles Remove="@(_GuidCheckFiles)" />
+            <_GuidCheckFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\Other\Solution.xml"
+                             Condition="Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\Solution.xml')" />
+            <_GuidCheckFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\AppModules\*\*.xml" />
+            <_GuidCheckFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\Entities\*\FormXml\*\*.xml" />
+            <_GuidCheckFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\Entities\*\SavedQueries\*.xml" />
+            <_GuidCheckFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\WebResources\**\*.data.xml" />
+            <_GuidCheckFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\PluginAssemblies\*\*.dll.data.xml" />
+            <_GuidCheckFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\Workflows\*.data.xml" />
+            <_GuidCheckFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\SdkMessageProcessingSteps\*.xml" />
+            <_GuidCheckFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\Dialogs\*.xml" />
+            <_GuidCheckFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\environmentvariabledefinitions\**\*.xml" />
+            <_GuidCheckFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\Other\ConnectionRoles.xml"
+                             Condition="Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\ConnectionRoles.xml')" />
+        </ItemGroup>
+        <Message Text="Checking for duplicate GUIDs across solution metadata files..." Importance="high" />
+        <ValidateDuplicateGuids FilesForValidation="@(_GuidCheckFiles)" Condition="'@(_GuidCheckFiles)' != ''" />
+        <Message Text="Duplicate GUID check finished." Importance="high" />
+    </Target>
+</Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/ValidateQuickFindViews.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/ValidateQuickFindViews.targets
@@ -1,0 +1,15 @@
+<Project>
+    <Target Name="ValidateQuickFindViews">
+        <!--
+          Collect SavedQuery files using direct globs at target execution time,
+          after CopyCdsSolutionContent has populated the metadata folder.
+        -->
+        <ItemGroup>
+            <_QuickFindCheckFiles Remove="@(_QuickFindCheckFiles)" />
+            <_QuickFindCheckFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\Entities\*\SavedQueries\*.xml" />
+        </ItemGroup>
+        <Message Text="Validating Quick Find views..." Importance="high" />
+        <ValidateQuickFindViews FilesForValidation="@(_QuickFindCheckFiles)" Condition="'@(_QuickFindCheckFiles)' != ''" />
+        <Message Text="Quick Find view validation finished." Importance="high" />
+    </Target>
+</Project>

--- a/src/Sdk/README.md
+++ b/src/Sdk/README.md
@@ -33,7 +33,7 @@ The `TALXISDevKitDataversePackageName` property can be set explicitly to overrid
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `TargetFramework` | `net462` | Default target framework. Override by setting `<TargetFramework>` in your csproj. Not applied if `TargetFrameworks` (multi-targeting) is set. |
+| `TargetFramework` | `net472` | Default target framework. Override by setting `<TargetFramework>` in your csproj. Not applied if `TargetFrameworks` (multi-targeting) is set. |
 | `ProjectType` | _(none)_ | Selects the package to reference (e.g. `Solution`, `Plugin`, `Pcf`). |
 | `TALXISDevKitDataversePackageBase` | `TALXIS.DevKit.Build.Dataverse` | Base package name combined with `ProjectType`. |
 | `TALXISDevKitDataversePackageVersion` | `0.0.0.1` | Version used in the auto-generated package reference. |

--- a/src/Sdk/README.md
+++ b/src/Sdk/README.md
@@ -16,12 +16,12 @@ This is an MSBuild SDK, used differently from a regular NuGet package.
 
 ## How It Works
 
-- **Sdk.props** imports `Microsoft.NET.Sdk` props and defines default values for `TALXISDevKitDataversePackageBase` and `TALXISDevKitDataversePackageVersion`.
+- **Sdk.props** imports `Microsoft.NET.Sdk` props, sets `TargetFramework` to `net472` by default (overridable), and defines default values for `TALXISDevKitDataversePackageBase` and `TALXISDevKitDataversePackageVersion`.
 - **Sdk.targets** imports `Microsoft.NET.Sdk` targets, then constructs `TALXISDevKitDataversePackageName` from `$(TALXISDevKitDataversePackageBase).$(ProjectType)` when `ProjectType` is set. It adds a `PackageReference` for the resolved package with `PrivateAssets="All"`.
 
 ### Supported ProjectType values
 
-`Solution`, `Plugin`, `Pcf`, `ScriptLibrary`, `PdPackage`, `WorkflowActivity`
+`Solution`, `Plugin`, `Pcf`, `ScriptLibrary`, `CodeApp`, `PdPackage`, `WorkflowActivity`
 
 The `TALXISDevKitDataversePackageName` property can be set explicitly to override the auto-resolution for advanced scenarios.
 
@@ -33,6 +33,7 @@ The `TALXISDevKitDataversePackageName` property can be set explicitly to overrid
 
 | Property | Default | Description |
 |----------|---------|-------------|
+| `TargetFramework` | `net462` | Default target framework. Override by setting `<TargetFramework>` in your csproj. Not applied if `TargetFrameworks` (multi-targeting) is set. |
 | `ProjectType` | _(none)_ | Selects the package to reference (e.g. `Solution`, `Plugin`, `Pcf`). |
 | `TALXISDevKitDataversePackageBase` | `TALXIS.DevKit.Build.Dataverse` | Base package name combined with `ProjectType`. |
 | `TALXISDevKitDataversePackageVersion` | `0.0.0.1` | Version used in the auto-generated package reference. |
@@ -46,5 +47,6 @@ This is the entry point to the TALXIS.DevKit.Build ecosystem. Based on `ProjectT
 - `TALXIS.DevKit.Build.Dataverse.Plugin`
 - `TALXIS.DevKit.Build.Dataverse.Pcf`
 - `TALXIS.DevKit.Build.Dataverse.ScriptLibrary`
+- `TALXIS.DevKit.Build.Dataverse.CodeApp`
 - `TALXIS.DevKit.Build.Dataverse.PdPackage`
 - `TALXIS.DevKit.Build.Dataverse.WorkflowActivity`

--- a/src/Sdk/Sdk/Sdk.props
+++ b/src/Sdk/Sdk/Sdk.props
@@ -3,7 +3,10 @@
 
   <Target Name="GetProjectOutputPath" Returns="@(_ProjectOutputPath)" />
   <PropertyGroup>
+    <!-- Default target framework. Consumers can override by setting <TargetFramework> in their csproj. -->
+    <TargetFramework Condition="'$(TargetFramework)' == '' and '$(TargetFrameworks)' == ''">net472</TargetFramework>
     <TALXISDevKitDataversePackageBase Condition="'$(TALXISDevKitDataversePackageBase)' == ''">TALXIS.DevKit.Build.Dataverse</TALXISDevKitDataversePackageBase>
+    
     <!-- Resolve SDK version from NuGet cache path: .../{id}/{version}/Sdk/Sdk.props -->
     <_TALXISDevKitBuildSdkDir>$([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory.TrimEnd('\/'))))</_TALXISDevKitBuildSdkDir>
     <TALXISDevKitDataversePackageVersion Condition="'$(TALXISDevKitDataversePackageVersion)' == ''">$([System.IO.Path]::GetFileName($(_TALXISDevKitBuildSdkDir)))</TALXISDevKitDataversePackageVersion>


### PR DESCRIPTION
List of changes:

Support for code-first apps in Power Apps. The Solution automatically adds a RootComponent type=300 and a CanvasApps node in Customizations.xml.

New validations
1. ValidateDuplicateGuids - scans for duplicate GUIDs across all solution metadata (forms, views, workflows, plugins, etc.). Error code TALXISGUID001. Disabled via TalxisSkipDuplicateGuidValidation.
2. ValidateQuickFindViews - verifies that Quick Find views have search attributes configured (<filter isquickfindfields="1"> with <condition>). Warning TALXISQF001. Disabled via TalxisSkipQuickFindValidation.
3. ValidatePcfDependencies -  verifies that all PCF controls referenced in forms have a provider (RootComponent type=66). Warning TALXISPCF001. Disabled via TalxisSkipPcfDependencyValidation.
4. EnsureAllCustomizationsNodes - automatically adds missing nodes to Customizations.xml if the corresponding files/folders exist in the project.

PDPackage
macOS support: ILRepack runs via mono on non-Windows platforms.
System.ComponentModel.Composition is automatically wired in for .NET Framework.
All ProjectReference entries default to ReferenceOutputAssembly=false.

Solution
ScriptLibrary projects are now removed from @(ProjectReference) after discovery so they are not built twice (once via ResolveProjectReferences and again via the explicit BuildScriptLibraries). Added EnsureCustomizationsNode for WebResources during the copy into metadata.
InvokeSolutionPackager
Changed the pac lookup priority: standalone Power Platform CLI is now preferred, then .dotnet/tools.

SDK
Default TargetFramework=net472.

XSD schemas update

README files updated