### PR TITLE
fix: XSD schema updates, nil normalization, circular dependency removal

### DIFF
--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.targets
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.targets
@@ -49,10 +49,9 @@
         MetadataWorkingDirectory="$(SolutionPackagerMetadataWorkingDirectory)" />
   </Target>
   
-<!-- XSD schema validation of solution components. Not wired automatically -->
-  <Target Name="ValidateSolutionComponentSchema"
-          DependsOnTargets="ValidateSolutionComponentSchema"
-          Condition="Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\Solution.xml')" />
+<!-- XSD schema validation of solution components. Not wired automatically.
+       Invoke explicitly: dotnet msbuild -t:InitializeSolutionPackagerWorkingDirectory;ValidateSolutionComponentSchema
+       The actual validation logic is defined in the Tasks package (ValidateSolutionComponentSchema.targets). -->
 
   <!-- Detect duplicate GUIDs across all solution metadata files. -->
   <Target Name="TalxisValidateDuplicateGuids"

--- a/src/Dataverse/Tasks/Tasks/ValidateXmlFiles.cs
+++ b/src/Dataverse/Tasks/Tasks/ValidateXmlFiles.cs
@@ -133,7 +133,20 @@ public class ValidateXmlFiles : Task
 
         try
         {
-            using (var reader = XmlReader.Create(xmlFilePath, settings))
+            // Normalize xsi:nil elements before validation — Dataverse exports and templates
+            // produce <Elem xsi:nil="true">\n</Elem> which is technically invalid (nil elements
+            // must be empty). Stripping their content avoids false positives.
+            var doc = new XmlDocument { PreserveWhitespace = false };
+            doc.Load(xmlFilePath);
+            var nsMgr = new XmlNamespaceManager(doc.NameTable);
+            nsMgr.AddNamespace("xsi", "http://www.w3.org/2001/XMLSchema-instance");
+            foreach (XmlElement el in doc.SelectNodes("//*[@xsi:nil='true']", nsMgr))
+            {
+                el.IsEmpty = true;
+            }
+
+            using (var nodeReader = new XmlNodeReader(doc))
+            using (var reader = XmlReader.Create(nodeReader, settings))
             {
                 while (reader.Read()) { /* drives validation */ }
             }

--- a/src/Dataverse/Tasks/ValidationSchema/Entity.xsd
+++ b/src/Dataverse/Tasks/ValidationSchema/Entity.xsd
@@ -204,6 +204,7 @@
 												<xs:element name="IsFilterable" type="TrueFalse01Type" minOccurs="0" maxOccurs="1" />
 												<xs:element name="IsRetrievable" type="TrueFalse01Type" minOccurs="0" maxOccurs="1" />
 												<xs:element name="IsLocalizable" type="TrueFalse01Type" minOccurs="0" maxOccurs="1" />
+												<xs:element name="DateTimeFormat" type="xs:string" minOccurs="0" maxOccurs="1" />
 											</xs:all>
 											<xs:attribute name="PhysicalName" use="required" type="EntityAttributeNameBaseType" />
 											<xs:attribute name="unmodified" use="optional" type="TrueFalse01Type" />

--- a/src/Dataverse/Tasks/ValidationSchema/Solution.xsd
+++ b/src/Dataverse/Tasks/ValidationSchema/Solution.xsd
@@ -7,7 +7,13 @@
                 <xs:element name="SolutionManifest">
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element type="xs:string" name="UniqueName"/>
+                            <xs:element name="UniqueName">
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:pattern value="[A-Za-z_][A-Za-z0-9_]*"/>
+                                    </xs:restriction>
+                                </xs:simpleType>
+                            </xs:element>
                             <xs:element name="LocalizedNames">
                                 <xs:complexType>
                                     <xs:sequence>
@@ -30,7 +36,13 @@
                             <xs:element name="Publisher">
                                 <xs:complexType>
                                     <xs:sequence>
-                                        <xs:element type="xs:string" name="UniqueName"/>
+                                        <xs:element name="UniqueName">
+                                            <xs:simpleType>
+                                                <xs:restriction base="xs:string">
+                                                    <xs:pattern value="[A-Za-z_][A-Za-z0-9_]*"/>
+                                                </xs:restriction>
+                                            </xs:simpleType>
+                                        </xs:element>
                                         <xs:element name="LocalizedNames">
                                             <xs:complexType>
                                                 <xs:sequence>
@@ -63,8 +75,8 @@
                                                 </xs:sequence>
                                             </xs:complexType>
                                         </xs:element>
-                                        <xs:element type="xs:string" name="EMailAddress" />
-                                        <xs:element type="xs:string" name="SupportingWebsiteUrl" />
+                                        <xs:element type="xs:string" name="EMailAddress" nillable="true" />
+                                        <xs:element type="xs:string" name="SupportingWebsiteUrl" nillable="true" />
                                         <xs:element type="xs:string" name="CustomizationPrefix"/>
                                         <xs:element type="xs:int" name="CustomizationOptionValuePrefix"/>
                                         <xs:element name="Addresses">
@@ -75,30 +87,30 @@
                                                             <xs:sequence>
                                                                 <xs:element type="xs:byte" name="AddressNumber" minOccurs="0" maxOccurs="1" />
                                                                 <xs:element type="xs:byte" name="AddressTypeCode" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="City" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="County" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Country" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Fax" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="FreightTermsCode" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="ImportSequenceNumber" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Latitude" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Line1" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Line2" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Line3" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Longitude" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Name" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="PostalCode" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="PostOfficeBox" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="PrimaryContactName" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="City" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="County" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Country" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Fax" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="FreightTermsCode" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="ImportSequenceNumber" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Latitude" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Line1" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Line2" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Line3" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Longitude" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Name" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="PostalCode" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="PostOfficeBox" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="PrimaryContactName" nillable="true" minOccurs="0" maxOccurs="1" />
                                                                 <xs:element type="xs:byte" name="ShippingMethodCode"  minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="StateOrProvince" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Telephone1" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Telephone2" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="Telephone3" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="TimeZoneRuleVersionNumber" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="UPSZone" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="UTCOffset" minOccurs="0" maxOccurs="1" />
-                                                                <xs:element type="xs:string" name="UTCConversionTimeZoneCode" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="StateOrProvince" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Telephone1" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Telephone2" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="Telephone3" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="TimeZoneRuleVersionNumber" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="UPSZone" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="UTCOffset" nillable="true" minOccurs="0" maxOccurs="1" />
+                                                                <xs:element type="xs:string" name="UTCConversionTimeZoneCode" nillable="true" minOccurs="0" maxOccurs="1" />
                                                             </xs:sequence>
                                                         </xs:complexType>
                                                     </xs:element>


### PR DESCRIPTION
## Summary

Fixes schema validation to work correctly with template-generated and Dataverse-exported XML.

### XSD Updates
- **Solution.xsd**: Added `nillable="true"` to publisher Address elements + `EMailAddress`/`SupportingWebsiteUrl` — templates and PAC CLI export these with `xsi:nil="true"`
- **Solution.xsd**: Added `xs:pattern` restriction on `UniqueName` elements — catches invalid characters (dots, spaces) at build time instead of at import time
- **Entity.xsd**: Added `DateTimeFormat` element to the attribute `xs:all` group

### Validator Improvements
- **ValidateXmlFiles.cs**: Normalizes `xsi:nil` elements before validation — strips whitespace content from nil elements since templates produce `<Elem xsi:nil="true">\n</Elem>` which is technically invalid per XSD but standard in Dataverse

### Build Target Fix
- Removed circular dependency in `ValidateSolutionComponentSchema` target — the Solution package wrapper had `DependsOnTargets` pointing to itself

### Invocation
```bash
dotnet msbuild -t:InitializeSolutionPackagerWorkingDirectory;ValidateSolutionComponentSchema
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>