### PR TITLE
fix: GetCommonDirectory path boundary check

### DIFF
--- a/src/Dataverse/Tasks/Tasks/ValidateDuplicateGuids.cs
+++ b/src/Dataverse/Tasks/Tasks/ValidateDuplicateGuids.cs
@@ -88,11 +88,16 @@ public class ValidateDuplicateGuids : Task
         if (directories.Count == 1)
             return directories[0];
 
-        // Walk up from the first path until we find a common prefix.
+        // Walk up from the first path until we find a common ancestor directory.
         var common = directories[0];
         while (!string.IsNullOrEmpty(common))
         {
-            if (directories.All(d => d.StartsWith(common, StringComparison.OrdinalIgnoreCase)))
+            // Ensure match is at a directory boundary, not a partial name match
+            // (e.g., /repo/Foo must not match /repo/FooBar)
+            var prefix = common.EndsWith(Path.DirectorySeparatorChar.ToString()) || common.EndsWith(Path.AltDirectorySeparatorChar.ToString())
+                ? common
+                : common + Path.DirectorySeparatorChar;
+            if (directories.All(d => d.Equals(common, StringComparison.OrdinalIgnoreCase) || d.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
                 return common;
             common = Path.GetDirectoryName(common);
         }


### PR DESCRIPTION
StartsWith without separator check could match /repo/Foo against /repo/FooBar. Found in post-merge review.