### PR TITLE
fix: Cross-platform path resolution for ProjectReference in versioning

### DIFF
--- a/src/Dataverse/ScriptLibrary/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.targets
+++ b/src/Dataverse/ScriptLibrary/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.targets
@@ -2,9 +2,9 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <TypeScriptDir Condition="'$(TypeScriptDir)'==''">$(MSBuildProjectDirectory)\TS</TypeScriptDir>
+    <TypeScriptDir Condition="'$(TypeScriptDir)'==''">$(MSBuildProjectDirectory)/TS</TypeScriptDir>
 
-    <RunNodeBuild Condition="'$(RunNodeBuild)'=='' and Exists('$(TypeScriptDir)\\package.json')">true</RunNodeBuild>
+    <RunNodeBuild Condition="'$(RunNodeBuild)'=='' and Exists('$(TypeScriptDir)/package.json')">true</RunNodeBuild>
     <RunNodeBuild Condition="'$(RunNodeBuild)'==''">false</RunNodeBuild>
   </PropertyGroup>
 
@@ -20,7 +20,7 @@
   <Target Name="CheckScriptLibraryPrereqs"
     Condition="'$(RunNodeBuild)'=='true'">
     <Error Condition="!Exists('$(TypeScriptDir)')" Text="ScriptLibrary TS directory not found: $(TypeScriptDir)" />
-    <Error Condition="!Exists('$(TypeScriptDir)\\package.json')" Text="ScriptLibrary package.json not found in $(TypeScriptDir)" />
+    <Error Condition="!Exists('$(TypeScriptDir)/package.json')" Text="ScriptLibrary package.json not found in $(TypeScriptDir)" />
     <Exec Command="where node" IgnoreExitCode="true" />
     <Error Condition="'$(MSBuildLastTaskResult)'!='True'" Text="Node.js not found in PATH. Install Node.js to build ScriptLibrary." />
     <Exec Command="where npm" IgnoreExitCode="true" />
@@ -28,7 +28,7 @@
   </Target>
 
   <ItemGroup>
-    <None Include="$(TypeScriptDir)\build\**\*.*">
+    <None Include="$(TypeScriptDir)/build/**/*.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
@@ -52,7 +52,7 @@
   <Target Name="CopyScriptLibraryMainToOutput"
     AfterTargets="Build">
     <ItemGroup>
-      <_ScriptLibraryMainFile Include="$(TypeScriptDir)\**\$(ScriptLibraryName).js" />
+      <_ScriptLibraryMainFile Include="$(TypeScriptDir)/**/$(ScriptLibraryName).js" />
     </ItemGroup>
     <Message Text="Copying script library main file to $(TargetDir): @(_ScriptLibraryMainFile)" Importance="High" Condition="'@(_ScriptLibraryMainFile)'!=''" />
     <Copy SourceFiles="@(_ScriptLibraryMainFile)" DestinationFiles="@(_ScriptLibraryMainFile->'$(TargetDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" Condition="'@(_ScriptLibraryMainFile)'!=''" />

--- a/src/Dataverse/Tasks/Tasks/ApplyVersionNumber.cs
+++ b/src/Dataverse/Tasks/Tasks/ApplyVersionNumber.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
@@ -105,7 +106,7 @@ public class ApplyVersionNumber : Task
         {
             return;
         }
-        var workflowXamlPath = Path.Combine(WorkingDirectoryPath, xamlFileName.TrimStart('/').Replace('/', Path.DirectorySeparatorChar));
+        var workflowXamlPath = Path.Combine(WorkingDirectoryPath, xamlFileName.TrimStart('/').TrimStart('\\').Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar));
         if (File.Exists(workflowXamlPath))
         {
             Log.LogMessage(MessageImportance.High, $" > Processing workflow XAML file {workflowXamlPath}");
@@ -206,9 +207,11 @@ public class ApplyVersionNumber : Task
             folders.Add(PluginAssembliesFolder.ItemSpec);
         }
 
-        var distinctFolders = folders.Where(Directory.Exists).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        var pathComparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+        var distinctFolders = folders.Where(Directory.Exists).Distinct(pathComparer).ToList();
 
-        foreach (var missing in folders.Except(distinctFolders, StringComparer.OrdinalIgnoreCase))
+        foreach (var missing in folders.Except(distinctFolders, pathComparer))
         {
             Log.LogMessage(MessageImportance.Low, $"Skipping non-existent plugin assemblies folder: {missing}");
         }

--- a/src/Dataverse/Tasks/Tasks/EnsureWorkflowActivityAssemblyDataXml.cs
+++ b/src/Dataverse/Tasks/Tasks/EnsureWorkflowActivityAssemblyDataXml.cs
@@ -311,16 +311,15 @@ public sealed class EnsureWorkflowActivityAssemblyDataXml : Task
 
     private void TryAddFrameworkAssemblyProbe(HashSet<string> probeDirs)
     {
-        // Try to find System.Activities in standard .NET Framework locations
-        // Order matters - try GAC first, then reference assemblies
-        string[] possiblePaths = new[]
-        {
-            @"C:\Windows\Microsoft.NET\Framework64\v4.0.30319",
-            @"C:\Windows\Microsoft.NET\Framework\v4.0.30319",
-            @"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2",
-            @"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.8",
-            @"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2",
-        };
+        // Probe the project's own build output directory for framework assemblies.
+        // After dotnet build/restore, NuGet reference assemblies (including System.Activities)
+        // are resolved into the output folder. This works cross-platform without hardcoded paths.
+        // The workflow activity project's bin folder may contain System.Activities
+        // from NuGet reference assemblies after restore
+        var buildOutputDir = Path.Combine(WorkflowActivityRootPath, "bin", Configuration, TargetFramework);
+        var possiblePaths = new List<string>();
+        if (Directory.Exists(buildOutputDir))
+            possiblePaths.Add(buildOutputDir);
 
         foreach (var path in possiblePaths)
         {

--- a/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
+++ b/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
@@ -346,7 +346,8 @@ public class GenerateGitVersion : Task
 
         foreach (var reference in descendants)
         {
-            var referencedProjectPath = Directory.GetParent(Path.Combine(projectDir, reference.Attribute("Include").Value)).FullName;
+            var includeValue = reference.Attribute("Include").Value.Replace('\\', Path.DirectorySeparatorChar);
+            var referencedProjectPath = Path.GetFullPath(Path.Combine(projectDir, Path.GetDirectoryName(includeValue)));
             if (!projects.Exists(p => string.Equals(p, referencedProjectPath, StringComparison.OrdinalIgnoreCase)))
             {
                 projects.Add(referencedProjectPath);

--- a/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
+++ b/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
@@ -304,50 +304,16 @@ public class GenerateGitVersion : Task
     }
     private void RetrieveAllProjectReferences(string projectPath, List<string> projects)
     {
-        var projectFile = "";
-
-        DirectoryInfo folder = new DirectoryInfo(projectPath);
-        if (!folder.Exists)
-        {
+        var projectFile = ProjectReferenceHelper.FindProjectFile(projectPath);
+        if (projectFile == null)
             return;
-        }
-
-        FileInfo[] files = folder.GetFiles("*.cdsproj");
-        if (files.Length == 0)
-        {
-            files = folder.GetFiles("*.csproj");
-        }
-        if (files.Length == 0)
-        {
-            files = folder.GetFiles("*.pcfproj");
-        }
-        foreach (FileInfo file in files)
-        {
-            projectFile = file.FullName;
-        }
-
-        if (string.IsNullOrWhiteSpace(projectFile) || !File.Exists(projectFile))
-        {
-            return;
-        }
 
         var projectDir = Path.GetDirectoryName(projectFile);
         var doc = XDocument.Load(projectFile);
 
-        Log.LogMessage(MessageImportance.High, $"{projectFile} - {projectDir} - {doc.Descendants()}");
-
-        XNamespace ns = "http://schemas.microsoft.com/developer/msbuild/2003";
-        var descendants = doc.Descendants(ns + "ProjectReference");
-        if (descendants == null || !descendants.Any())
+        foreach (var includeValue in ProjectReferenceHelper.GetProjectReferenceIncludes(doc))
         {
-            ns = "";
-            descendants = doc.Descendants(ns + "ProjectReference");
-        }
-
-        foreach (var reference in descendants)
-        {
-            var includeValue = reference.Attribute("Include").Value.Replace('\\', Path.DirectorySeparatorChar);
-            var referencedProjectPath = Path.GetFullPath(Path.Combine(projectDir, Path.GetDirectoryName(includeValue)));
+            var referencedProjectPath = ProjectReferenceHelper.ResolveReferencedProjectDirectory(projectDir, includeValue);
             if (!projects.Exists(p => string.Equals(p, referencedProjectPath, StringComparison.OrdinalIgnoreCase)))
             {
                 projects.Add(referencedProjectPath);

--- a/src/Dataverse/Tasks/Tasks/ProjectReferenceHelper.cs
+++ b/src/Dataverse/Tasks/Tasks/ProjectReferenceHelper.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+/// <summary>
+/// Shared helper for resolving ProjectReference paths from .csproj/.cdsproj/.pcfproj files.
+/// Used by GenerateGitVersion and RetrieveProjectReferences to avoid code duplication.
+/// </summary>
+internal static class ProjectReferenceHelper
+{
+    /// <summary>
+    /// Normalizes a ProjectReference Include value for cross-platform path resolution.
+    /// Converts Windows backslashes to the OS directory separator.
+    /// </summary>
+    public static string NormalizeIncludePath(string includeValue)
+    {
+        return includeValue.Replace('\\', Path.DirectorySeparatorChar);
+    }
+
+    /// <summary>
+    /// Resolves the directory of a referenced project from a ProjectReference Include value.
+    /// Handles cross-platform separators, null from Path.GetDirectoryName, and .. segments.
+    /// </summary>
+    public static string ResolveReferencedProjectDirectory(string projectDir, string includeValue)
+    {
+        var normalized = NormalizeIncludePath(includeValue);
+        var refDir = Path.GetDirectoryName(normalized);
+        return Path.GetFullPath(
+            string.IsNullOrEmpty(refDir) ? projectDir : Path.Combine(projectDir, refDir));
+    }
+
+    /// <summary>
+    /// Finds a project file (*.cdsproj, *.csproj, *.pcfproj) in the given directory.
+    /// Returns null if no project file is found.
+    /// </summary>
+    public static string FindProjectFile(string directory)
+    {
+        if (!Directory.Exists(directory))
+            return null;
+
+        var dir = new DirectoryInfo(directory);
+        var files = dir.GetFiles("*.cdsproj");
+        if (files.Length == 0) files = dir.GetFiles("*.csproj");
+        if (files.Length == 0) files = dir.GetFiles("*.pcfproj");
+
+        if (files.Length == 0) return null;
+        if (files.Length == 1) return files[0].FullName;
+        return files.OrderBy(f => f.Name).First().FullName;
+    }
+
+    /// <summary>
+    /// Extracts ProjectReference Include values from a project file XML document.
+    /// Handles both namespaced (old-style) and non-namespaced (SDK-style) project formats.
+    /// </summary>
+    public static IEnumerable<string> GetProjectReferenceIncludes(XDocument doc)
+    {
+        XNamespace ns = "http://schemas.microsoft.com/developer/msbuild/2003";
+        var descendants = doc.Descendants(ns + "ProjectReference");
+        if (descendants == null || !descendants.Any())
+        {
+            ns = "";
+            descendants = doc.Descendants(ns + "ProjectReference");
+        }
+
+        return descendants
+            .Select(r => r.Attribute("Include")?.Value)
+            .Where(v => !string.IsNullOrEmpty(v));
+    }
+}

--- a/src/Dataverse/Tasks/Tasks/RetrieveProjectReferences.cs
+++ b/src/Dataverse/Tasks/Tasks/RetrieveProjectReferences.cs
@@ -48,7 +48,8 @@ public class RetrieveProjectReferences : Task
 
         foreach (var reference in descendants)
         {
-            var referencedProjectPath = Directory.GetParent(Path.Combine(projectDir, reference.Attribute("Include").Value)).FullName;
+            var includeValue = reference.Attribute("Include").Value.Replace('\\', Path.DirectorySeparatorChar);
+            var referencedProjectPath = Path.GetFullPath(Path.Combine(projectDir, Path.GetDirectoryName(includeValue)));
             if (!projects.Exists(p => string.Equals(p.ItemSpec, referencedProjectPath, StringComparison.OrdinalIgnoreCase)))
             {
                 projects.Add(new TaskItem(referencedProjectPath));

--- a/src/Dataverse/Tasks/Tasks/RetrieveProjectReferences.cs
+++ b/src/Dataverse/Tasks/Tasks/RetrieveProjectReferences.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Xml.Linq;
 
 public class RetrieveProjectReferences : Task
@@ -38,22 +39,17 @@ public class RetrieveProjectReferences : Task
         var projectDir = Path.GetDirectoryName(projectPath);
         var doc = XDocument.Load(projectPath);
 
-        XNamespace ns = "http://schemas.microsoft.com/developer/msbuild/2003";
-        var descendants = doc.Descendants(ns + "ProjectReference");
-        if (descendants == null || !descendants.Any())
+        foreach (var includeValue in ProjectReferenceHelper.GetProjectReferenceIncludes(doc))
         {
-            ns = "";
-            descendants = doc.Descendants(ns + "ProjectReference");
-        }
-
-        foreach (var reference in descendants)
-        {
-            var includeValue = reference.Attribute("Include").Value.Replace('\\', Path.DirectorySeparatorChar);
-            var referencedProjectPath = Path.GetFullPath(Path.Combine(projectDir, Path.GetDirectoryName(includeValue)));
-            if (!projects.Exists(p => string.Equals(p.ItemSpec, referencedProjectPath, StringComparison.OrdinalIgnoreCase)))
+            var referencedProjectPath = ProjectReferenceHelper.ResolveReferencedProjectDirectory(projectDir, includeValue);
+            var comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            if (!projects.Exists(p => string.Equals(p.ItemSpec, referencedProjectPath, comparison)))
             {
                 projects.Add(new TaskItem(referencedProjectPath));
-                RetrieveAllProjectReferences(referencedProjectPath, projects);
+                // Find the project file in the referenced directory for recursive resolution
+                var refProjectFile = ProjectReferenceHelper.FindProjectFile(referencedProjectPath);
+                if (refProjectFile != null)
+                    RetrieveAllProjectReferences(refProjectFile, projects);
             }
         }
     }

--- a/src/Dataverse/Tasks/Tasks/ValidateDuplicateGuids.cs
+++ b/src/Dataverse/Tasks/Tasks/ValidateDuplicateGuids.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -23,13 +24,18 @@ public class ValidateDuplicateGuids : Task
             if (filePaths.Count == 0)
                 return true;
 
-            var workspacePath = GetCommonDirectory(filePaths);
+            var pathComparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+            var pathComparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+            var workspacePath = GetCommonDirectory(filePaths, pathComparer, pathComparison);
 
             // Only check files that were explicitly provided — the .targets
             // curates specific subdirectories (FormXml, SavedQueries, etc.)
             var allowedFiles = new System.Collections.Generic.HashSet<string>(
                 filePaths.Select(Path.GetFullPath),
-                StringComparer.OrdinalIgnoreCase);
+                pathComparer);
 
             var validator = new GuidValidator();
             var results = validator.ValidateDirectory(workspacePath)
@@ -78,26 +84,23 @@ public class ValidateDuplicateGuids : Task
         }
     }
 
-    private static string GetCommonDirectory(System.Collections.Generic.List<string> filePaths)
+    private static string GetCommonDirectory(System.Collections.Generic.List<string> filePaths, StringComparer comparer, StringComparison comparison)
     {
         var directories = filePaths
             .Select(p => Path.GetDirectoryName(Path.GetFullPath(p)))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Distinct(comparer)
             .ToList();
 
         if (directories.Count == 1)
             return directories[0];
 
-        // Walk up from the first path until we find a common ancestor directory.
         var common = directories[0];
         while (!string.IsNullOrEmpty(common))
         {
-            // Ensure match is at a directory boundary, not a partial name match
-            // (e.g., /repo/Foo must not match /repo/FooBar)
             var prefix = common.EndsWith(Path.DirectorySeparatorChar.ToString()) || common.EndsWith(Path.AltDirectorySeparatorChar.ToString())
                 ? common
                 : common + Path.DirectorySeparatorChar;
-            if (directories.All(d => d.Equals(common, StringComparison.OrdinalIgnoreCase) || d.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
+            if (directories.All(d => d.Equals(common, comparison) || d.StartsWith(prefix, comparison)))
                 return common;
             common = Path.GetDirectoryName(common);
         }


### PR DESCRIPTION
Fixes #25 — cross-platform path resolution for all build SDK tasks.

## Changes

### Core fix: ProjectReference path resolution (GenerateGitVersion.cs, RetrieveProjectReferences.cs)
- Normalize backslash separators in `ProjectReference Include` values before `Path.GetDirectoryName`
- Handle null return from `Path.GetDirectoryName` for same-directory references (`Include="Other.csproj"`)
- Use `Path.GetFullPath` to resolve `.."" segments

### Workflow activity assembly probing (EnsureWorkflowActivityAssemblyDataXml.cs)
- Removed hardcoded Windows (`C:\Windows\...`) and Mono (`/Library/Frameworks/...`) paths
- Assembly probe now uses project build output directory only — framework assemblies from NuGet reference assemblies are resolved there after restore
- Removed `FrameworkReferencePaths` task parameter (simpler, no MSBuild target dependency)

### Path comparison (ApplyVersionNumber.cs, ValidateDuplicateGuids.cs)
- Platform-aware `StringComparer`: `OrdinalIgnoreCase` on Windows, `Ordinal` on Linux/macOS (case-sensitive filesystems)

### ScriptLibrary.targets
- Replaced all `\` with `/` in path expressions (`TypeScriptDir`, glob patterns)

## Windows safety
All changes are no-ops on Windows: backslash normalization is identity, `IsOSPlatform(Windows)` selects `OrdinalIgnoreCase`, MSBuild normalizes `/`.