### PR TITLE
chore: bump TALXIS.Platform.Metadata to v0.2.0

### DIFF
--- a/src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj
+++ b/src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj
@@ -27,8 +27,8 @@
         <PackageReference Include="Microsoft.Build" Version="16.11.6" />
         <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.11.6" />
         <!-- <PackageReference Include="Microsoft.PowerApps.CLI.Core.osx-x64" Version="*" /> -->
-        <PackageReference Include="TALXIS.Platform.Metadata" Version="0.1.3" />
-        <PackageReference Include="TALXIS.Platform.Metadata.Validation" Version="0.1.3" />
+        <PackageReference Include="TALXIS.Platform.Metadata" Version="0.2.0" />
+        <PackageReference Include="TALXIS.Platform.Metadata.Validation" Version="0.2.0" />
 
         <!-- Do not add any of the dependencies above to nuspec -->
         <PackageReference Update="@(PackageReference)" PrivateAssets="All" />


### PR DESCRIPTION
Bumps platform-metadata packages from 0.1.3 to 0.2.0.

v0.2.0 adds: 12 new model types, expanded reader/writer, label fixes, solution layering, merge engine, error reporting via Workspace.LoadErrors.