### PR TITLE
fix: register ValidateWorkspace MSBuild task (#37)

### DIFF
--- a/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.targets
@@ -39,4 +39,5 @@
     <UsingTask TaskName="ValidateQuickFindViews" AssemblyFile="$(TasksAssembly)" />
     <UsingTask TaskName="EnsureAllCustomizationsNodes" AssemblyFile="$(TasksAssembly)" />
     <UsingTask TaskName="ValidatePcfDependencies" AssemblyFile="$(TasksAssembly)" />
+    <UsingTask TaskName="ValidateWorkspace" AssemblyFile="$(TasksAssembly)" />
 </Project>


### PR DESCRIPTION
Fixes #37

The `ValidateWorkspace` C# task existed but was missing its `UsingTask` declaration in `TALXIS.DevKit.Build.Dataverse.Tasks.targets`, causing MSBuild to fail at runtime with a task-not-found error.

This adds the missing registration line.