### PR TITLE
chore: Upgrade build SDK from net6.0/net8.0 to net10.0

### DIFF
--- a/src/Dataverse/CodeApp/TALXIS.DevKit.Build.Dataverse.CodeApp.csproj
+++ b/src/Dataverse/CodeApp/TALXIS.DevKit.Build.Dataverse.CodeApp.csproj
@@ -3,7 +3,7 @@
         <AssemblyName>TALXIS.DevKit.Build.Dataverse.CodeApp</AssemblyName>
         <!-- https://github.com/dotnet/vscode-csharp/issues/5786 -->
         <!-- <TargetFrameworks>net462;$(NetMinimum);$(NetCurrent)</TargetFrameworks> -->
-        <TargetFrameworks>net472;net6.0</TargetFrameworks>
+        <TargetFrameworks>net472;net10.0</TargetFrameworks>
         <!-- Pack settings -->
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <IsPackable>true</IsPackable>

--- a/src/Dataverse/PDPackage/TALXIS.DevKit.Build.Dataverse.PdPackage.csproj
+++ b/src/Dataverse/PDPackage/TALXIS.DevKit.Build.Dataverse.PdPackage.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Version Condition="'$(Version)'==''">0.0.0.1</Version>
         <ILRepackVersion Condition="'$(ILRepackVersion)'==''">2.0.18</ILRepackVersion>

--- a/src/Dataverse/Pcf/TALXIS.DevKit.Build.Dataverse.Pcf.csproj
+++ b/src/Dataverse/Pcf/TALXIS.DevKit.Build.Dataverse.Pcf.csproj
@@ -3,7 +3,7 @@
         <AssemblyName>TALXIS.DevKit.Build.Dataverse.Pcf</AssemblyName>
         <!-- https://github.com/dotnet/vscode-csharp/issues/5786 -->
         <!-- <TargetFrameworks>net462;$(NetMinimum);$(NetCurrent)</TargetFrameworks> -->
-        <TargetFrameworks>net472;net6.0</TargetFrameworks>
+        <TargetFrameworks>net472;net10.0</TargetFrameworks>
         <!-- Pack settings -->
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <IsPackable>true</IsPackable>

--- a/src/Dataverse/Plugin/TALXIS.DevKit.Build.Dataverse.Plugin.csproj
+++ b/src/Dataverse/Plugin/TALXIS.DevKit.Build.Dataverse.Plugin.csproj
@@ -3,7 +3,7 @@
         <AssemblyName>TALXIS.DevKit.Build.Dataverse.Plugin</AssemblyName>
         <!-- https://github.com/dotnet/vscode-csharp/issues/5786 -->
         <!-- <TargetFrameworks>net462;$(NetMinimum);$(NetCurrent)</TargetFrameworks> -->
-        <TargetFrameworks>net472;net6.0</TargetFrameworks>
+        <TargetFrameworks>net472;net10.0</TargetFrameworks>
         <!-- Pack settings -->
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <IsPackable>true</IsPackable>

--- a/src/Dataverse/ScriptLibrary/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.csproj
+++ b/src/Dataverse/ScriptLibrary/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version Condition="'$(Version)'==''">0.0.0.1</Version>
     <NuspecFile>TALXIS.DevKit.Build.Dataverse.ScriptLibrary.nuspec</NuspecFile>

--- a/src/Dataverse/Solution/TALXIS.DevKit.Build.Dataverse.Solution.csproj
+++ b/src/Dataverse/Solution/TALXIS.DevKit.Build.Dataverse.Solution.csproj
@@ -3,7 +3,7 @@
         <AssemblyName>TALXIS.DevKit.Build.Dataverse.Solution</AssemblyName>
         <!-- https://github.com/dotnet/vscode-csharp/issues/5786 -->
         <!-- <TargetFrameworks>net462;$(NetMinimum);$(NetCurrent)</TargetFrameworks> -->
-        <TargetFrameworks>net472;net6.0</TargetFrameworks>
+        <TargetFrameworks>net472;net10.0</TargetFrameworks>
         <!-- Pack settings -->
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <IsPackable>true</IsPackable>

--- a/src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj
+++ b/src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj
@@ -4,7 +4,7 @@
         <AssemblyName>TALXIS.DevKit.Build.Dataverse.Tasks</AssemblyName>
         <!-- https://github.com/dotnet/vscode-csharp/issues/5786 -->
         <!-- <TargetFrameworks>net462;$(NetMinimum);$(NetCurrent)</TargetFrameworks> -->
-        <TargetFrameworks>net472;net6.0</TargetFrameworks>
+        <TargetFrameworks>net472;net10.0</TargetFrameworks>
         <!-- Pack settings -->
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <IsPackable>true</IsPackable>

--- a/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.targets
@@ -6,7 +6,7 @@
     <PropertyGroup>
         <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
 
-        <ThisPackageBuildExtensionsDirectory Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)net6.0\</ThisPackageBuildExtensionsDirectory>
+        <ThisPackageBuildExtensionsDirectory Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)net10.0\</ThisPackageBuildExtensionsDirectory>
         <ThisPackageBuildExtensionsDirectory Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)net472\</ThisPackageBuildExtensionsDirectory>
     </PropertyGroup>
 

--- a/src/Dataverse/WorkflowActivity/TALXIS.DevKit.Build.Dataverse.WorkflowActivity.csproj
+++ b/src/Dataverse/WorkflowActivity/TALXIS.DevKit.Build.Dataverse.WorkflowActivity.csproj
@@ -3,7 +3,7 @@
         <AssemblyName>TALXIS.DevKit.Build.Dataverse.WorkflowActivity</AssemblyName>
         <!-- https://github.com/dotnet/vscode-csharp/issues/5786 -->
         <!-- <TargetFrameworks>net462;$(NetMinimum);$(NetCurrent)</TargetFrameworks> -->
-        <TargetFrameworks>net472;net6.0</TargetFrameworks>
+        <TargetFrameworks>net472;net10.0</TargetFrameworks>
         <!-- Pack settings -->
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <IsPackable>true</IsPackable>

--- a/src/Sdk/TALXIS.DevKit.Build.Sdk.csproj
+++ b/src/Sdk/TALXIS.DevKit.Build.Sdk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version Condition="'$(Version)'==''">0.0.0.1</Version>
     <NuspecFile>TALXIS.DevKit.Build.Sdk.nuspec</NuspecFile>


### PR DESCRIPTION
## Summary

Upgrade all project target frameworks as outlined in #33:

| Project | Before | After |
|---|---|---|
| Tasks, Pcf, Plugin, Solution, WorkflowActivity, CodeApp | `net472;net6.0` | `net472;net10.0` |
| ScriptLibrary | `net8.0` | `net10.0` |
| PdPackage | `net8.0` | `net10.0` |
| Sdk | `net8.0` | `net10.0` |

### Changes
- Updated `TargetFrameworks` in all 9 `.csproj` files
- Updated MSBuild task assembly path in `TALXIS.DevKit.Build.Dataverse.Tasks.targets` from `net6.0\\` to `net10.0\\`
- Retained `net472` for .NET Framework MSBuild host compatibility

### Breaking Change
The NuGet package now ships tasks in `tasks/net10.0/` instead of `tasks/net6.0/`. Consumers referencing the old path directly will need to update.

### Notes
- .NET 6 reached EOL November 2024
- .NET 8 reaches EOL November 2026
- .NET 10 is the current target

Closes #33