### PR TITLE
feat: use TALXIS.Platform.Metadata.Packaging library for solution pack/unpack

### DIFF
--- a/src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj
+++ b/src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj
@@ -23,23 +23,13 @@
         <!--<PackageReference Include="LibGit2Sharp" Version="0.26.2" />-->
         <PackageReference Include="Microsoft.Build" Version="18.0.2" />
         <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
-        <PackageReference Include="Microsoft.PowerApps.CLI.Core.linux-x64" Version="2.6.4" GeneratePathProperty="true" ExcludeAssets="all" />
         <PackageReference Include="TALXIS.Platform.Metadata" Version="0.6.0" />
         <PackageReference Include="TALXIS.Platform.Metadata.Validation" Version="0.6.0" />
         <PackageReference Include="TALXIS.Platform.Metadata.Serialization.Xml" Version="0.6.0" />
+        <PackageReference Include="TALXIS.Platform.Metadata.Packaging" Version="0.7.0" />
 
         <!-- Do not add any of the dependencies above to nuspec -->
         <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
-    </ItemGroup>
-    <ItemGroup>
-        <Reference Include="SolutionPackagerLib">
-            <HintPath>$(PkgMicrosoft_PowerApps_CLI_Core_linux-x64)\tools\SolutionPackagerLib.dll</HintPath>
-            <Private>true</Private>
-        </Reference>
-        <Reference Include="System.IO.Packaging">
-            <HintPath>$(PkgMicrosoft_PowerApps_CLI_Core_linux-x64)\tools\System.IO.Packaging.dll</HintPath>
-            <Private>true</Private>
-        </Reference>
     </ItemGroup>
     <PropertyGroup>
         <Authors>TALXIS</Authors>

--- a/src/Dataverse/Tasks/Tasks/InvokeSolutionPackager.cs
+++ b/src/Dataverse/Tasks/Tasks/InvokeSolutionPackager.cs
@@ -71,7 +71,7 @@ public class InvokeSolutionPackager : Task
         }
     }
 
-    private SolutionPackagerOptions? BuildOptions()
+    private SolutionPackagerOptions BuildOptions()
     {
         if (!TryParseManaged(out var managed))
         {
@@ -84,18 +84,36 @@ public class InvokeSolutionPackager : Task
             return null;
         }
 
-        return new SolutionPackagerOptions
+        var options = new SolutionPackagerOptions
         {
             Managed = managed,
             ErrorLevel = errorLevel,
-            LogFilePath = LogFilePath,
-            MappingFilePath = MappingFilePath,
             Localize = Localize,
-            SourceLocale = LocalTemplate,
             UseUnmanagedFileForMissingManaged = UseUnmanagedFileForMissingManaged,
-            AllowDeletes = true,
-            AllowWrites = true
         };
+
+        if (!string.IsNullOrWhiteSpace(LogFilePath))
+        {
+            options.LogFilePath = LogFilePath;
+        }
+
+        if (!string.IsNullOrWhiteSpace(MappingFilePath))
+        {
+            options.MappingFilePath = MappingFilePath;
+        }
+
+        if (!string.IsNullOrWhiteSpace(LocalTemplate))
+        {
+            options.SourceLocale = LocalTemplate;
+        }
+
+        if (string.Equals(Action, "unpack", StringComparison.OrdinalIgnoreCase))
+        {
+            options.AllowDeletes = true;
+            options.AllowWrites = true;
+        }
+
+        return options;
     }
 
     private bool TryParseManaged(out bool managed)

--- a/src/Dataverse/Tasks/Tasks/InvokeSolutionPackager.cs
+++ b/src/Dataverse/Tasks/Tasks/InvokeSolutionPackager.cs
@@ -2,7 +2,7 @@ using System;
 using System.Diagnostics;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using Microsoft.Crm.Tools.SolutionPackager;
+using TALXIS.Platform.Metadata.Packaging;
 
 public class InvokeSolutionPackager : Task
 {
@@ -32,15 +32,30 @@ public class InvokeSolutionPackager : Task
     {
         try
         {
-            var arguments = BuildArguments();
-            if (arguments == null)
+            var options = BuildOptions();
+            if (options == null)
             {
                 return false;
             }
 
-            var packager = new SolutionPackager(arguments);
-            packager.Run();
-            return true;
+            var packager = new SolutionPackagerService();
+
+            switch (Action.ToLowerInvariant())
+            {
+                case "pack":
+                    Log.LogMessage(MessageImportance.High, $"Packing solution from '{SolutionRootDirectory}' to '{PathToZipFile}'...");
+                    packager.Pack(SolutionRootDirectory, PathToZipFile, options);
+                    Log.LogMessage(MessageImportance.High, "Solution packed successfully.");
+                    return true;
+                case "unpack":
+                    Log.LogMessage(MessageImportance.High, $"Unpacking solution from '{PathToZipFile}' to '{SolutionRootDirectory}'...");
+                    packager.Unpack(PathToZipFile, SolutionRootDirectory, options);
+                    Log.LogMessage(MessageImportance.High, "Solution unpacked successfully.");
+                    return true;
+                default:
+                    Log.LogError($"Unsupported action: {Action}");
+                    return false;
+            }
         }
         catch (Exception ex)
         {
@@ -56,9 +71,9 @@ public class InvokeSolutionPackager : Task
         }
     }
 
-    private PackagerArguments BuildArguments()
+    private SolutionPackagerOptions? BuildOptions()
     {
-        if (!TryParsePackageType(out var packageType))
+        if (!TryParseManaged(out var managed))
         {
             return null;
         }
@@ -69,75 +84,37 @@ public class InvokeSolutionPackager : Task
             return null;
         }
 
-        PackagerArguments arguments;
-
-        switch (Action.ToLowerInvariant())
+        return new SolutionPackagerOptions
         {
-            case "pack":
-                arguments = new PackagerArguments
-                {
-                    Action = CommandAction.Pack,
-                    PathToZipFile = PathToZipFile,
-                    Folder = SolutionRootDirectory,
-                    PackageType = packageType,
-                    ErrorLevel = errorLevel,
-                    Localize = Localize,
-                    UseUnmanagedFileForManaged = UseUnmanagedFileForMissingManaged,
-                };
-                break;
-            case "unpack":
-                arguments = new PackagerArguments
-                {
-                    Action = CommandAction.Extract,
-                    PathToZipFile = PathToZipFile,
-                    Folder = SolutionRootDirectory,
-                    PackageType = packageType,
-                    AllowDeletes = AllowDelete.Yes,
-                    AllowWrites = AllowWrite.Yes,
-                    ErrorLevel = errorLevel,
-                    Localize = Localize,
-                };
-                break;
-            default:
-                Log.LogError($"Unsupported action: {Action}");
-                return null;
-        }
-
-        if (!string.IsNullOrWhiteSpace(MappingFilePath))
-        {
-            arguments.MappingFile = MappingFilePath;
-        }
-
-        if (!string.IsNullOrWhiteSpace(LogFilePath))
-        {
-            arguments.LogFile = LogFilePath;
-        }
-
-        if (!string.IsNullOrWhiteSpace(LocalTemplate))
-        {
-            arguments.LocaleTemplate = LocalTemplate;
-        }
-
-        return arguments;
+            Managed = managed,
+            ErrorLevel = errorLevel,
+            LogFilePath = LogFilePath,
+            MappingFilePath = MappingFilePath,
+            Localize = Localize,
+            SourceLocale = LocalTemplate,
+            UseUnmanagedFileForMissingManaged = UseUnmanagedFileForMissingManaged,
+            AllowDeletes = true,
+            AllowWrites = true
+        };
     }
 
-    private bool TryParsePackageType(out SolutionPackageType packageType)
+    private bool TryParseManaged(out bool managed)
     {
         if (string.IsNullOrWhiteSpace(PackageType) ||
             string.Equals(PackageType, "Unmanaged", StringComparison.OrdinalIgnoreCase))
         {
-            packageType = SolutionPackageType.Unmanaged;
+            managed = false;
             return true;
         }
 
         if (string.Equals(PackageType, "Managed", StringComparison.OrdinalIgnoreCase))
         {
-            packageType = SolutionPackageType.Managed;
+            managed = true;
             return true;
         }
 
         Log.LogError($"Unsupported package type: {PackageType}");
-        packageType = default;
+        managed = false;
         return false;
     }
 }


### PR DESCRIPTION
## Summary

Refreshes `InvokeSolutionPackager` to use the published **TALXIS.Platform.Metadata.Packaging** package instead of the direct in-project `SolutionPackagerLib` integration introduced by the net10 host migration.

## Baseline / context

- `TALXIS/platform-metadata` `v0.7.0` is published and provides `TALXIS.Platform.Metadata.Packaging` `0.7.0`
- `tools-devkit-build` PR #65 already moved the Dataverse tasks host to **.NET 10 / MSBuild 18+**
- Because of that, the older `net472` fallback design is no longer the target architecture for this PR

## Changes

- Keep the Dataverse tasks project on the current **net10.0** host baseline from PR #65
- Add `TALXIS.Platform.Metadata.Packaging` `0.7.0` to `TALXIS.DevKit.Build.Dataverse.Tasks.csproj`
- Remove the direct `Microsoft.PowerApps.CLI.Core.linux-x64` / `SolutionPackagerLib` assembly wiring from the tasks project
- Update `InvokeSolutionPackager` to delegate pack/unpack to `TALXIS.Platform.Metadata.Packaging.SolutionPackagerService`
- Preserve the existing MSBuild task surface:
  - `Action`
  - `PackageType`
  - `SolutionRootDirectory`
  - `PathToZipFile`
  - `ErrorLevel`
  - `LogFilePath`
  - `MappingFilePath`
  - `Localize`
  - `LocalTemplate`
  - `UseUnmanagedFileForMissingManaged`
- Keep task logging/error reporting and surface stack traces on failure

## Validation

- `dotnet build TALXIS.DevKit.Build.slnx -c Release`
- `dotnet build src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj -c Release`
- `dotnet pack src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj -c Release`
- Verified task project output and packed `.nupkg` contain the required packaging runtime DLLs:
  - `TALXIS.Platform.Metadata.Packaging.dll`
  - `SolutionPackagerLib.dll`
  - `System.IO.Packaging.dll`
  - related runtime dependencies under `tasks/net10.0/`

## Related

- Published package source: `TALXIS/platform-metadata` `v0.7.0`
- Related CLI consumer migration: `TALXIS/tools-cli` PR #80 (merged)
