### PR TITLE
feat: add GenPage build support for generative pages

### DIFF
--- a/TALXIS.DevKit.Build.slnx
+++ b/TALXIS.DevKit.Build.slnx
@@ -8,6 +8,7 @@
   <Project Path="src/Dataverse/Pcf/TALXIS.DevKit.Build.Dataverse.Pcf.csproj" />
   <Project Path="src\Dataverse\CodeApp\TALXIS.DevKit.Build.Dataverse.CodeApp.csproj" />
   <Project Path="src/Dataverse/ScriptLibrary/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.csproj" />
+  <Project Path="src/Dataverse/GenPage/TALXIS.DevKit.Build.Dataverse.GenPage.csproj" />
   <Project Path="src/Dataverse/PDPackage/TALXIS.DevKit.Build.Dataverse.PdPackage.csproj" />
   <Project Path="src/Sdk/TALXIS.DevKit.Build.Sdk.csproj" />
   <Project Path="src\Dataverse\WorkflowActivity\TALXIS.DevKit.Build.Dataverse.WorkflowActivity.csproj" />

--- a/src/Dataverse/GenPage/README.md
+++ b/src/Dataverse/GenPage/README.md
@@ -1,0 +1,63 @@
+# TALXIS.DevKit.Build.Dataverse.GenPage
+
+MSBuild integration for Dataverse generative page (GenPage) projects. Transpiles TSX source files via TypeScript, patches in RuntimeTypes, generates config metadata, and exposes output targets for Solution projects to discover and integrate GenPages as `uxagentprojects`.
+
+## Installation
+
+```xml
+<PackageReference Include="TALXIS.DevKit.Build.Dataverse.GenPage" Version="0.0.0.1" PrivateAssets="All" />
+```
+
+Or use the SDK approach:
+
+```xml
+<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.1">
+  <PropertyGroup>
+    <ProjectType>GenPage</ProjectType>
+    <GenPageId>{your-genpage-guid}</GenPageId>
+    <GenPageDataSources>datasource1,datasource2</GenPageDataSources>
+  </PropertyGroup>
+</Project>
+```
+
+## Prerequisites
+
+- **Node.js** must be available on `PATH`
+- **npx** must be available on `PATH`
+
+The build will fail with a descriptive error if either is missing.
+
+## How It Works
+
+The package sets `ProjectType` to `GenPage` and disables `GenerateAssemblyInfo` by default since this is not a traditional .NET assembly project.
+
+### Build-time targets
+
+1. **CheckGenPagePrereqs** — validates that the main TSX file exists and `node`/`npx` are on `PATH`.
+2. **TranspileGenPage** (runs before `Build`) — executes `tsc` via `npx` to transpile TSX to JS, then patches the output by stripping `RuntimeTypes` imports and prepending `RuntimeTypes.js` content if present.
+3. **GenerateGenPageConfig** — generates `config.json` from project properties (`GenPageDataSources`).
+4. **CopyGenPageOutputs** (runs after `Build`) — copies `page.tsx`, `page.compiled`, and `config.json` to the output directory.
+
+### Integration targets
+
+Called by `TALXIS.DevKit.Build.Dataverse.Solution` via `ProjectReference`:
+
+- **GetProjectType** — returns `GenPage`.
+- **GetGenPageOutputs** — exposes the compiled output folder and metadata for the solution to copy into `uxagentprojects/`.
+
+## MSBuild Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `ProjectType` | `GenPage` | Marks the project for reference discovery by Solution projects. |
+| `GenPageMainFile` | `page.tsx` | Main TSX source file to transpile. |
+| `GenPageName` | `$(MSBuildProjectName)` | Name used for the output folder and metadata. |
+| `GenPageId` | _(required)_ | GUID identifying this GenPage in Dataverse. |
+| `GenPageDataSources` | _(empty)_ | Comma-separated list of data source identifiers. |
+| `LangVersion` | `latest` | C# language version for the project. |
+| `GenerateAssemblyInfo` | `false` | Disables auto-generated assembly info. |
+
+## Related Packages
+
+- **Depends on**: `TALXIS.DevKit.Build.Dataverse.Tasks`
+- **Consumed by**: `TALXIS.DevKit.Build.Dataverse.Solution` projects via `ProjectReference`

--- a/src/Dataverse/GenPage/TALXIS.DevKit.Build.Dataverse.GenPage.csproj
+++ b/src/Dataverse/GenPage/TALXIS.DevKit.Build.Dataverse.GenPage.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version Condition="'$(Version)'==''">0.0.1</Version>
+    <NuspecFile>TALXIS.DevKit.Build.Dataverse.GenPage.nuspec</NuspecFile>
+    <NuspecProperties>
+      Version=$(Version)
+    </NuspecProperties>
+  </PropertyGroup>
+
+</Project>

--- a/src/Dataverse/GenPage/TALXIS.DevKit.Build.Dataverse.GenPage.nuspec
+++ b/src/Dataverse/GenPage/TALXIS.DevKit.Build.Dataverse.GenPage.nuspec
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>TALXIS.DevKit.Build.Dataverse.GenPage</id>
+    <version>$Version$</version>
+    <authors>TALXIS</authors>
+    <developmentDependency>true</developmentDependency>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <icon>package-icon.png</icon>
+    <readme>README.md</readme>
+    <projectUrl>https://github.com/TALXIS/tools-devkit-build</projectUrl>
+    <description>Dataverse MSBuild GenPage — build support for generative pages in model-driven apps</description>
+    <releaseNotes>https://github.com/TALXIS/tools-devkit-build/releases</releaseNotes>
+    <copyright>2025 NETWORG</copyright>
+    <repository type="git" url="https://github.com/TALXIS/tools-devkit-build" branch="master" />
+    <dependencies>
+      <dependency id="TALXIS.DevKit.Build.Dataverse.Tasks" version="$Version$" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\..\package-icon.png" target="" />
+    <file src="msbuild\tasks\*.*" target="tasks" />
+    <file src="msbuild\build\*.*" target="build" />
+    <file src="README.md" target="" />
+  </files>
+</package>

--- a/src/Dataverse/GenPage/msbuild/build/TALXIS.DevKit.Build.Dataverse.GenPage.props
+++ b/src/Dataverse/GenPage/msbuild/build/TALXIS.DevKit.Build.Dataverse.GenPage.props
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)..\tasks\$(MSBuildThisFile)" />
+</Project>

--- a/src/Dataverse/GenPage/msbuild/build/TALXIS.DevKit.Build.Dataverse.GenPage.targets
+++ b/src/Dataverse/GenPage/msbuild/build/TALXIS.DevKit.Build.Dataverse.GenPage.targets
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)..\tasks\$(MSBuildThisFile)" />
+</Project>

--- a/src/Dataverse/GenPage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.GenPage.props
+++ b/src/Dataverse/GenPage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.GenPage.props
@@ -1,0 +1,11 @@
+<Project>
+  <PropertyGroup>
+    <ProjectType Condition="'$(ProjectType)'==''">GenPage</ProjectType>
+    <GenPageMainFile Condition="'$(GenPageMainFile)'==''">page.tsx</GenPageMainFile>
+    <GenPageName Condition="'$(GenPageName)'==''">$(MSBuildProjectName)</GenPageName>
+    <GenPageId Condition="'$(GenPageId)'==''"></GenPageId>
+    <GenPageDataSources Condition="'$(GenPageDataSources)'==''"></GenPageDataSources>
+    <LangVersion Condition="'$(LangVersion)'==''">latest</LangVersion>
+    <GenerateAssemblyInfo Condition="'$(GenerateAssemblyInfo)'==''">false</GenerateAssemblyInfo>
+  </PropertyGroup>
+</Project>

--- a/src/Dataverse/GenPage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.GenPage.props
+++ b/src/Dataverse/GenPage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.GenPage.props
@@ -1,11 +1,5 @@
 <Project>
   <PropertyGroup>
     <ProjectType Condition="'$(ProjectType)'==''">GenPage</ProjectType>
-    <GenPageMainFile Condition="'$(GenPageMainFile)'==''">page.tsx</GenPageMainFile>
-    <GenPageName Condition="'$(GenPageName)'==''">$(MSBuildProjectName)</GenPageName>
-    <GenPageId Condition="'$(GenPageId)'==''"></GenPageId>
-    <GenPageDataSources Condition="'$(GenPageDataSources)'==''"></GenPageDataSources>
-    <LangVersion Condition="'$(LangVersion)'==''">latest</LangVersion>
-    <GenerateAssemblyInfo Condition="'$(GenerateAssemblyInfo)'==''">false</GenerateAssemblyInfo>
   </PropertyGroup>
 </Project>

--- a/src/Dataverse/GenPage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.GenPage.targets
+++ b/src/Dataverse/GenPage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.GenPage.targets
@@ -5,9 +5,7 @@
     <GenPageMainFile Condition="'$(GenPageMainFile)'==''">page.tsx</GenPageMainFile>
     <GenPageName Condition="'$(GenPageName)'==''">$(MSBuildProjectName)</GenPageName>
     <GenPageId Condition="'$(GenPageId)'==''"></GenPageId>
-    <GenPageDataSources Condition="'$(GenPageDataSources)'==''"></GenPageDataSources>
-    <LangVersion Condition="'$(LangVersion)'==''">latest</LangVersion>
-    <GenerateAssemblyInfo Condition="'$(GenerateAssemblyInfo)'==''">false</GenerateAssemblyInfo>
+    <GenPageConfigFile Condition="'$(GenPageConfigFile)'==''">genpage.config.json</GenPageConfigFile>
   </PropertyGroup>
 
   <Target Name="CheckGenPagePrereqs">
@@ -44,14 +42,6 @@
     <Delete Files="$(MSBuildProjectDirectory)/page.js" />
   </Target>
 
-  <Target Name="GenerateGenPageConfig"
-          BeforeTargets="CopyGenPageOutputs"
-          DependsOnTargets="TranspileGenPage">
-    <GenerateGenPageConfigJson
-        DataSources="$(GenPageDataSources)"
-        OutputPath="$(IntermediateOutputPath)config.json" />
-  </Target>
-
   <Target Name="CopyGenPageOutputs"
           AfterTargets="Build">
     <MakeDir Directories="$(OutputPath)$(GenPageName)/" />
@@ -64,9 +54,10 @@
           DestinationFiles="$(OutputPath)$(GenPageName)/page.compiled"
           SkipUnchangedFiles="true" />
 
-    <Copy SourceFiles="$(IntermediateOutputPath)config.json"
+    <Copy SourceFiles="$(MSBuildProjectDirectory)/$(GenPageConfigFile)"
           DestinationFiles="$(OutputPath)$(GenPageName)/config.json"
-          SkipUnchangedFiles="true" />
+          SkipUnchangedFiles="true"
+          Condition="Exists('$(MSBuildProjectDirectory)/$(GenPageConfigFile)')" />
   </Target>
 
   <Target Name="GetProjectType" Returns="@(_ProjectType)" Condition="'$(ProjectType)'!=''">
@@ -84,7 +75,7 @@
       <_GenPageOutputs Include="$(MSBuildProjectDirectory)/$(OutputPath)$(GenPageName)">
         <GenPageName>$(GenPageName)</GenPageName>
         <GenPageId>$(GenPageId)</GenPageId>
-        <GenPageDataSources>$(GenPageDataSources)</GenPageDataSources>
+        <GenPageConfigFile>$(MSBuildProjectDirectory)/$(GenPageConfigFile)</GenPageConfigFile>
       </_GenPageOutputs>
     </ItemGroup>
   </Target>

--- a/src/Dataverse/GenPage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.GenPage.targets
+++ b/src/Dataverse/GenPage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.GenPage.targets
@@ -1,14 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <GenPageMainFile Condition="'$(GenPageMainFile)'==''">page.tsx</GenPageMainFile>
+    <GenPageName Condition="'$(GenPageName)'==''">$(MSBuildProjectName)</GenPageName>
+    <GenPageId Condition="'$(GenPageId)'==''"></GenPageId>
+    <GenPageDataSources Condition="'$(GenPageDataSources)'==''"></GenPageDataSources>
+    <LangVersion Condition="'$(LangVersion)'==''">latest</LangVersion>
+    <GenerateAssemblyInfo Condition="'$(GenerateAssemblyInfo)'==''">false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
   <Target Name="CheckGenPagePrereqs">
     <Error Condition="'$(GenPageId)'==''"
            Text="GenPageId must be set in the project file. This GUID identifies the page in Dataverse and the solution." />
     <Error Condition="!Exists('$(MSBuildProjectDirectory)/$(GenPageMainFile)')"
            Text="GenPage main file not found: $(MSBuildProjectDirectory)/$(GenPageMainFile)" />
-    <Exec Command="node --version" IgnoreExitCode="true" />
-    <Error Condition="'$(MSBuildLastTaskResult)'!='True'"
-           Text="Node.js not found in PATH. Install Node.js to build GenPage." />
     <Exec Command="npx --version" IgnoreExitCode="true" />
     <Error Condition="'$(MSBuildLastTaskResult)'!='True'"
            Text="npx not found in PATH. Install Node.js (includes npx) to build GenPage." />
@@ -26,7 +32,10 @@
     <MakeDir Directories="$(IntermediateOutputPath)" />
 
     <!-- Patch: strip RuntimeTypes import and prepend RuntimeTypes.js content -->
-    <Exec Command="node -e &quot;const fs = require('fs'); const jsPath = '$(MSBuildProjectDirectory)/page.js'; const rtPath = '$(MSBuildProjectDirectory)/RuntimeTypes.js'; let js = fs.readFileSync(jsPath, 'utf8'); js = js.replace(/import\s+[^;'\n]+['\&quot;]\.\/RuntimeTypes['\&quot;];?\s*/g, ''); let result = js; if (fs.existsSync(rtPath)) { const rt = fs.readFileSync(rtPath, 'utf8'); result = '// --- BEGIN GENERATED RUNTIME TYPES ---\n\n' + rt + '\n// --- END GENERATED RUNTIME TYPES ---\n\n' + js; } fs.writeFileSync('$(IntermediateOutputPath)page.compiled', result);&quot;" />
+    <PatchGenPageCompiledCode
+        CompiledJsPath="$(MSBuildProjectDirectory)/page.js"
+        RuntimeTypesJsPath="$(MSBuildProjectDirectory)/RuntimeTypes.js"
+        OutputPath="$(IntermediateOutputPath)page.compiled" />
 
     <!-- Clean up intermediate page.js -->
     <Delete Files="$(MSBuildProjectDirectory)/page.js" />
@@ -35,7 +44,9 @@
   <Target Name="GenerateGenPageConfig"
           BeforeTargets="CopyGenPageOutputs"
           DependsOnTargets="TranspileGenPage">
-    <Exec Command="node -e &quot;const fs = require('fs'); const ds = '$(GenPageDataSources)'.split(',').map(s => s.trim()).filter(Boolean); const config = { dataSources: ds, model: '' }; fs.writeFileSync('$(IntermediateOutputPath)config.json', JSON.stringify(config, null, 2));&quot;" />
+    <GenerateGenPageConfigJson
+        DataSources="$(GenPageDataSources)"
+        OutputPath="$(IntermediateOutputPath)config.json" />
   </Target>
 
   <Target Name="CopyGenPageOutputs"

--- a/src/Dataverse/GenPage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.GenPage.targets
+++ b/src/Dataverse/GenPage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.GenPage.targets
@@ -25,9 +25,12 @@
           DependsOnTargets="CheckGenPagePrereqs">
     <Message Text="Transpiling GenPage $(GenPageMainFile) in $(MSBuildProjectDirectory)" Importance="High" />
 
-    <!-- Transpile TSX to JS -->
+    <!-- Transpile TSX to JS (IgnoreExitCode: tsc returns non-zero for type errors but still produces output with --noEmit false) -->
     <Exec WorkingDirectory="$(MSBuildProjectDirectory)"
-          Command="npx --yes -p typescript@5.3.2 tsc &quot;$(GenPageMainFile)&quot; --target ES5 --module ES2020 --jsx react --lib ES2015,DOM --skipLibCheck --noEmit false" />
+          Command="npx --yes -p typescript@5.3.2 tsc &quot;$(GenPageMainFile)&quot; --target ES5 --module ES2020 --jsx react --lib ES2015,DOM --skipLibCheck --noEmit false"
+          IgnoreExitCode="true" />
+    <Error Condition="!Exists('$(MSBuildProjectDirectory)/page.js')"
+           Text="TypeScript transpilation failed to produce page.js. Check tsc output above for errors." />
 
     <MakeDir Directories="$(IntermediateOutputPath)" />
 
@@ -78,7 +81,7 @@
           DependsOnTargets="Build"
           Returns="@(_GenPageOutputs)">
     <ItemGroup>
-      <_GenPageOutputs Include="$(OutputPath)$(GenPageName)">
+      <_GenPageOutputs Include="$(MSBuildProjectDirectory)/$(OutputPath)$(GenPageName)">
         <GenPageName>$(GenPageName)</GenPageName>
         <GenPageId>$(GenPageId)</GenPageId>
         <GenPageDataSources>$(GenPageDataSources)</GenPageDataSources>

--- a/src/Dataverse/GenPage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.GenPage.targets
+++ b/src/Dataverse/GenPage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.GenPage.targets
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="CheckGenPagePrereqs">
+    <Error Condition="'$(GenPageId)'==''"
+           Text="GenPageId must be set in the project file. This GUID identifies the page in Dataverse and the solution." />
+    <Error Condition="!Exists('$(MSBuildProjectDirectory)/$(GenPageMainFile)')"
+           Text="GenPage main file not found: $(MSBuildProjectDirectory)/$(GenPageMainFile)" />
+    <Exec Command="node --version" IgnoreExitCode="true" />
+    <Error Condition="'$(MSBuildLastTaskResult)'!='True'"
+           Text="Node.js not found in PATH. Install Node.js to build GenPage." />
+    <Exec Command="npx --version" IgnoreExitCode="true" />
+    <Error Condition="'$(MSBuildLastTaskResult)'!='True'"
+           Text="npx not found in PATH. Install Node.js (includes npx) to build GenPage." />
+  </Target>
+
+  <Target Name="TranspileGenPage"
+          BeforeTargets="Build"
+          DependsOnTargets="CheckGenPagePrereqs">
+    <Message Text="Transpiling GenPage $(GenPageMainFile) in $(MSBuildProjectDirectory)" Importance="High" />
+
+    <!-- Transpile TSX to JS -->
+    <Exec WorkingDirectory="$(MSBuildProjectDirectory)"
+          Command="npx --yes -p typescript@5.3.2 tsc &quot;$(GenPageMainFile)&quot; --target ES5 --module ES2020 --jsx react --lib ES2015,DOM --skipLibCheck --noEmit false" />
+
+    <MakeDir Directories="$(IntermediateOutputPath)" />
+
+    <!-- Patch: strip RuntimeTypes import and prepend RuntimeTypes.js content -->
+    <Exec Command="node -e &quot;const fs = require('fs'); const jsPath = '$(MSBuildProjectDirectory)/page.js'; const rtPath = '$(MSBuildProjectDirectory)/RuntimeTypes.js'; let js = fs.readFileSync(jsPath, 'utf8'); js = js.replace(/import\s+[^;'\n]+['\&quot;]\.\/RuntimeTypes['\&quot;];?\s*/g, ''); let result = js; if (fs.existsSync(rtPath)) { const rt = fs.readFileSync(rtPath, 'utf8'); result = '// --- BEGIN GENERATED RUNTIME TYPES ---\n\n' + rt + '\n// --- END GENERATED RUNTIME TYPES ---\n\n' + js; } fs.writeFileSync('$(IntermediateOutputPath)page.compiled', result);&quot;" />
+
+    <!-- Clean up intermediate page.js -->
+    <Delete Files="$(MSBuildProjectDirectory)/page.js" />
+  </Target>
+
+  <Target Name="GenerateGenPageConfig"
+          BeforeTargets="CopyGenPageOutputs"
+          DependsOnTargets="TranspileGenPage">
+    <Exec Command="node -e &quot;const fs = require('fs'); const ds = '$(GenPageDataSources)'.split(',').map(s => s.trim()).filter(Boolean); const config = { dataSources: ds, model: '' }; fs.writeFileSync('$(IntermediateOutputPath)config.json', JSON.stringify(config, null, 2));&quot;" />
+  </Target>
+
+  <Target Name="CopyGenPageOutputs"
+          AfterTargets="Build">
+    <MakeDir Directories="$(OutputPath)$(GenPageName)/" />
+
+    <Copy SourceFiles="$(MSBuildProjectDirectory)/$(GenPageMainFile)"
+          DestinationFiles="$(OutputPath)$(GenPageName)/page.tsx"
+          SkipUnchangedFiles="true" />
+
+    <Copy SourceFiles="$(IntermediateOutputPath)page.compiled"
+          DestinationFiles="$(OutputPath)$(GenPageName)/page.compiled"
+          SkipUnchangedFiles="true" />
+
+    <Copy SourceFiles="$(IntermediateOutputPath)config.json"
+          DestinationFiles="$(OutputPath)$(GenPageName)/config.json"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+  <Target Name="GetProjectType" Returns="@(_ProjectType)" Condition="'$(ProjectType)'!=''">
+    <ItemGroup>
+      <_ProjectType Include="$(MSBuildProjectFullPath)">
+        <ProjectType>$(ProjectType)</ProjectType>
+      </_ProjectType>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GetGenPageOutputs"
+          DependsOnTargets="Build"
+          Returns="@(_GenPageOutputs)">
+    <ItemGroup>
+      <_GenPageOutputs Include="$(OutputPath)$(GenPageName)">
+        <GenPageName>$(GenPageName)</GenPageName>
+        <GenPageId>$(GenPageId)</GenPageId>
+        <GenPageDataSources>$(GenPageDataSources)</GenPageDataSources>
+      </_GenPageOutputs>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Dataverse/GenPage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.GenPage.targets
+++ b/src/Dataverse/GenPage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.GenPage.targets
@@ -3,14 +3,16 @@
 
   <PropertyGroup>
     <GenPageMainFile Condition="'$(GenPageMainFile)'==''">page.tsx</GenPageMainFile>
+    <GenPageCompiledJsFile>$([System.IO.Path]::ChangeExtension('$(GenPageMainFile)', '.js'))</GenPageCompiledJsFile>
     <GenPageName Condition="'$(GenPageName)'==''">$(MSBuildProjectName)</GenPageName>
     <GenPageId Condition="'$(GenPageId)'==''"></GenPageId>
+    <_NormalizedGenPageId>$([System.String]::Copy('$(GenPageId)').Trim().Replace('{','').Replace('}','').ToLowerInvariant())</_NormalizedGenPageId>
     <GenPageConfigFile Condition="'$(GenPageConfigFile)'==''">genpage.config.json</GenPageConfigFile>
   </PropertyGroup>
 
   <Target Name="CheckGenPagePrereqs">
-    <Error Condition="'$(GenPageId)'==''"
-           Text="GenPageId must be set in the project file. This GUID identifies the page in Dataverse and the solution." />
+    <Error Condition="'$(GenPageId)'=='' or '$(_NormalizedGenPageId)'=='' or $(_NormalizedGenPageId.Length)!=36"
+           Text="GenPageId must be a valid GUID. This GUID identifies the page in Dataverse and the solution." />
     <Error Condition="!Exists('$(MSBuildProjectDirectory)/$(GenPageMainFile)')"
            Text="GenPage main file not found: $(MSBuildProjectDirectory)/$(GenPageMainFile)" />
     <Exec Command="npx --version" IgnoreExitCode="true" />
@@ -23,23 +25,20 @@
           DependsOnTargets="CheckGenPagePrereqs">
     <Message Text="Transpiling GenPage $(GenPageMainFile) in $(MSBuildProjectDirectory)" Importance="High" />
 
+    <MakeDir Directories="$(IntermediateOutputPath)" />
+
     <!-- Transpile TSX to JS (IgnoreExitCode: tsc returns non-zero for type errors but still produces output with --noEmit false) -->
     <Exec WorkingDirectory="$(MSBuildProjectDirectory)"
-          Command="npx --yes -p typescript@5.3.2 tsc &quot;$(GenPageMainFile)&quot; --target ES5 --module ES2020 --jsx react --lib ES2015,DOM --skipLibCheck --noEmit false"
+          Command="npx --yes -p typescript@5.3.2 tsc &quot;$(GenPageMainFile)&quot; --target ES5 --module ES2020 --jsx react --lib ES2015,DOM --skipLibCheck --noEmit false --outDir &quot;$(IntermediateOutputPath)&quot;"
           IgnoreExitCode="true" />
-    <Error Condition="!Exists('$(MSBuildProjectDirectory)/page.js')"
-           Text="TypeScript transpilation failed to produce page.js. Check tsc output above for errors." />
-
-    <MakeDir Directories="$(IntermediateOutputPath)" />
+    <Error Condition="!Exists('$(IntermediateOutputPath)$(GenPageCompiledJsFile)')"
+           Text="TypeScript transpilation failed to produce $(GenPageCompiledJsFile). Check tsc output above for errors." />
 
     <!-- Patch: strip RuntimeTypes import and prepend RuntimeTypes.js content -->
     <PatchGenPageCompiledCode
-        CompiledJsPath="$(MSBuildProjectDirectory)/page.js"
+        CompiledJsPath="$(IntermediateOutputPath)$(GenPageCompiledJsFile)"
         RuntimeTypesJsPath="$(MSBuildProjectDirectory)/RuntimeTypes.js"
         OutputPath="$(IntermediateOutputPath)page.compiled" />
-
-    <!-- Clean up intermediate page.js -->
-    <Delete Files="$(MSBuildProjectDirectory)/page.js" />
   </Target>
 
   <Target Name="CopyGenPageOutputs"
@@ -74,7 +73,7 @@
     <ItemGroup>
       <_GenPageOutputs Include="$(MSBuildProjectDirectory)/$(OutputPath)$(GenPageName)">
         <GenPageName>$(GenPageName)</GenPageName>
-        <GenPageId>$(GenPageId)</GenPageId>
+        <GenPageId>$(_NormalizedGenPageId)</GenPageId>
         <GenPageConfigFile>$(MSBuildProjectDirectory)/$(GenPageConfigFile)</GenPageConfigFile>
       </_GenPageOutputs>
     </ItemGroup>

--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.GenPages.targets
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.GenPages.targets
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="ProbeGenPages"
+          BeforeTargets="PrepareProjectReferences;ResolveProjectReferences;BuildGenPages"
+          Condition="'@(ProjectReference)'!='' and '@(_GenPageProjects)'==''">
+
+    <!-- Reset accumulators: <Output ItemName="..."> appends across target
+         invocations, and ProbeGenPages is registered via multiple
+         BeforeTargets, so without a reset we'd grow the lists every fire. -->
+    <ItemGroup>
+      <_ProjectTypeFromReferences Remove="@(_ProjectTypeFromReferences)" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(ProjectReference->'%(FullPath)')"
+             Targets="GetProjectType"
+             Properties="Configuration=$(Configuration)"
+             BuildInParallel="true"
+             SkipNonexistentTargets="true">
+      <Output TaskParameter="TargetOutputs" ItemName="_ProjectTypeFromReferences" />
+    </MSBuild>
+
+    <ItemGroup>
+      <_GenPageProjects Remove="@(_GenPageProjects)" />
+      <_GenPageProjects Include="@(_ProjectTypeFromReferences)"
+                        Condition="'%(ProjectType)'=='GenPage'"
+                        KeepDuplicates="false" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_GenPageProjectsList>;@(_GenPageProjects->'%(Identity)');</_GenPageProjectsList>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Remove="@(ProjectReference)"
+                        Condition="$([System.String]::Copy('$(_GenPageProjectsList)').ToLowerInvariant().Contains($([System.String]::Copy(';%(FullPath);').ToLowerInvariant())))" />
+    </ItemGroup>
+
+    <Message Importance="high"
+             Text="Detected GenPage projects: @(_GenPageProjects)"
+             Condition="'@(_GenPageProjects)'!=''" />
+  </Target>
+
+  <Target Name="BuildGenPages"
+          BeforeTargets="CoreCompile"
+          DependsOnTargets="ProbeGenPages"
+          Condition="'@(_GenPageProjects)'!=''">
+
+    <MSBuild Projects="@(_GenPageProjects)"
+             Targets="GetGenPageOutputs"
+             Properties="Configuration=$(Configuration)"
+             BuildInParallel="true">
+      <Output TaskParameter="TargetOutputs" ItemName="_GenPageOutputs" />
+    </MSBuild>
+
+    <Message Importance="high"
+             Text="GenPage outputs: @(_GenPageOutputs->'%(Identity) [GenPageName=%(GenPageName)]')"
+             Condition="'@(_GenPageOutputs)'!=''" />
+  </Target>
+
+  <Target Name="CopyGenPagesToMetadata"
+          AfterTargets="CopyCdsSolutionContent"
+          BeforeTargets="ProcessCdsProjectReferencesOutputs"
+          DependsOnTargets="BuildGenPages"
+          Condition="'@(_GenPageOutputs)'!=''">
+
+    <PropertyGroup>
+      <_MetadataUxAgentProjectsDir>$(SolutionPackagerMetadataWorkingDirectory)/uxagentprojects/</_MetadataUxAgentProjectsDir>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(_MetadataUxAgentProjectsDir)" />
+
+    <EnsureCustomizationsNode
+        CustomizationsXmlFile="$(SolutionPackagerMetadataWorkingDirectory)/Other/Customizations.xml"
+        NodeName="uxagentprojects" />
+
+    <Message Importance="high"
+             Text="Generating GenPage metadata for %(GenPageName) [%(GenPageId)] in $(_MetadataUxAgentProjectsDir)" />
+
+    <!-- Generate uxagentproject XML, file metadata, and copy files using node -->
+    <Exec Command="node -e &quot;
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const outputsDir = '%(_GenPageOutputs.Identity)';
+const genPageName = '%(_GenPageOutputs.GenPageName)';
+const genPageId = '%(_GenPageOutputs.GenPageId)';
+const metadataDir = '$(_MetadataUxAgentProjectsDir)';
+
+// Deterministic GUID v5-style from a seed string
+function deterministicGuid(seed) {
+  const hash = crypto.createHash('md5').update(seed).digest('hex');
+  return hash.substring(0,8) + '-' + hash.substring(8,12) + '-' + hash.substring(12,16) + '-' + hash.substring(16,20) + '-' + hash.substring(20,32);
+}
+
+// Create uxagentproject directory
+const projectDir = path.join(metadataDir, genPageId);
+fs.mkdirSync(projectDir, { recursive: true });
+
+// Write uxagentproject.xml
+const projectXml = [
+  '&lt;uxagentproject uxagentprojectid=\&quot;' + genPageId + '\&quot;&gt;',
+  '  &lt;iscustomizable&gt;1&lt;/iscustomizable&gt;',
+  '  &lt;name&gt;' + genPageName + '&lt;/name&gt;',
+  '  &lt;statecode&gt;0&lt;/statecode&gt;',
+  '  &lt;statuscode&gt;1&lt;/statuscode&gt;',
+  '&lt;/uxagentproject&gt;'
+].join('\n');
+fs.writeFileSync(path.join(projectDir, 'uxagentproject.xml'), projectXml);
+
+// File definitions
+const files = [
+  { src: 'page.tsx', filename: 'src/pages/page.tsx', filetype: '200000000', mimetype: 'application/octet-stream' },
+  { src: 'page.compiled', filename: 'src/pages/page.compiled', filetype: '200000001', mimetype: 'application/octet-stream' },
+  { src: 'config.json', filename: 'config.json', filetype: '200000000', mimetype: 'application/json' }
+];
+
+files.forEach(f => {
+  const srcPath = path.join(outputsDir, f.src);
+  if (!fs.existsSync(srcPath)) {
+    console.log('Warning: ' + srcPath + ' not found, skipping');
+    return;
+  }
+
+  const fileGuid = deterministicGuid(genPageId + '-' + f.src);
+  const fileDir = path.join(projectDir, fileGuid);
+  const fileContentDir = path.join(fileDir, 'filecontent');
+  fs.mkdirSync(fileContentDir, { recursive: true });
+
+  // Copy file content
+  fs.copyFileSync(srcPath, path.join(fileContentDir, f.src));
+
+  // Write uxagentprojectfile.xml
+  const fileXml = [
+    '&lt;uxagentprojectfile uxagentprojectfileid=\&quot;' + fileGuid + '\&quot;&gt;',
+    '  &lt;filecontent mimetype=\&quot;' + f.mimetype + '\&quot;&gt;' + f.src + '&lt;/filecontent&gt;',
+    '  &lt;filename&gt;' + f.filename + '&lt;/filename&gt;',
+    '  &lt;filetype&gt;' + f.filetype + '&lt;/filetype&gt;',
+    '  &lt;iscustomizable&gt;1&lt;/iscustomizable&gt;',
+    '  &lt;statecode&gt;0&lt;/statecode&gt;',
+    '  &lt;statuscode&gt;1&lt;/statuscode&gt;',
+    '&lt;/uxagentprojectfile&gt;'
+  ].join('\n');
+  fs.writeFileSync(path.join(fileDir, 'uxagentprojectfile.xml'), fileXml);
+});
+
+console.log('GenPage metadata generated for ' + genPageName + ' (' + genPageId + ')');
+&quot;" />
+
+  </Target>
+
+</Project>

--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.GenPages.targets
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.GenPages.targets
@@ -76,78 +76,40 @@
         NodeName="uxagentprojects" />
 
     <Message Importance="high"
-             Text="Generating GenPage metadata for %(GenPageName) [%(GenPageId)] in $(_MetadataUxAgentProjectsDir)" />
+             Text="Generating GenPage metadata for %(_GenPageOutputs.GenPageName) [%(_GenPageOutputs.GenPageId)] in $(_MetadataUxAgentProjectsDir)" />
 
-    <!-- Generate uxagentproject XML, file metadata, and copy files using node -->
-    <Exec Command="node -e &quot;
-const fs = require('fs');
-const path = require('path');
-const crypto = require('crypto');
+    <!-- Generate uxagentproject.xml -->
+    <GenerateGenPageProjectXml
+        ProjectId="%(_GenPageOutputs.GenPageId)"
+        PageName="%(_GenPageOutputs.GenPageName)"
+        OutputDir="$(_MetadataUxAgentProjectsDir)%(_GenPageOutputs.GenPageId)" />
 
-const outputsDir = '%(_GenPageOutputs.Identity)';
-const genPageName = '%(_GenPageOutputs.GenPageName)';
-const genPageId = '%(_GenPageOutputs.GenPageId)';
-const metadataDir = '$(_MetadataUxAgentProjectsDir)';
+    <!-- Generate file metadata and copy: page.tsx -->
+    <GenerateGenPageFileXml
+        ProjectId="%(_GenPageOutputs.GenPageId)"
+        SourceFilePath="%(_GenPageOutputs.Identity)/page.tsx"
+        FileName="src/pages/page.tsx"
+        FileType="200000000"
+        MimeType="application/octet-stream"
+        OutputDir="$(_MetadataUxAgentProjectsDir)%(_GenPageOutputs.GenPageId)" />
 
-// Deterministic GUID v5-style from a seed string
-function deterministicGuid(seed) {
-  const hash = crypto.createHash('md5').update(seed).digest('hex');
-  return hash.substring(0,8) + '-' + hash.substring(8,12) + '-' + hash.substring(12,16) + '-' + hash.substring(16,20) + '-' + hash.substring(20,32);
-}
+    <!-- Generate file metadata and copy: page.compiled -->
+    <GenerateGenPageFileXml
+        ProjectId="%(_GenPageOutputs.GenPageId)"
+        SourceFilePath="%(_GenPageOutputs.Identity)/page.compiled"
+        FileName="src/pages/page.compiled"
+        FileType="200000001"
+        MimeType="application/octet-stream"
+        OutputDir="$(_MetadataUxAgentProjectsDir)%(_GenPageOutputs.GenPageId)" />
 
-// Create uxagentproject directory
-const projectDir = path.join(metadataDir, genPageId);
-fs.mkdirSync(projectDir, { recursive: true });
-
-// Write uxagentproject.xml
-const projectXml = [
-  '&lt;uxagentproject uxagentprojectid=\&quot;' + genPageId + '\&quot;&gt;',
-  '  &lt;iscustomizable&gt;1&lt;/iscustomizable&gt;',
-  '  &lt;name&gt;' + genPageName + '&lt;/name&gt;',
-  '  &lt;statecode&gt;0&lt;/statecode&gt;',
-  '  &lt;statuscode&gt;1&lt;/statuscode&gt;',
-  '&lt;/uxagentproject&gt;'
-].join('\n');
-fs.writeFileSync(path.join(projectDir, 'uxagentproject.xml'), projectXml);
-
-// File definitions
-const files = [
-  { src: 'page.tsx', filename: 'src/pages/page.tsx', filetype: '200000000', mimetype: 'application/octet-stream' },
-  { src: 'page.compiled', filename: 'src/pages/page.compiled', filetype: '200000001', mimetype: 'application/octet-stream' },
-  { src: 'config.json', filename: 'config.json', filetype: '200000000', mimetype: 'application/json' }
-];
-
-files.forEach(f => {
-  const srcPath = path.join(outputsDir, f.src);
-  if (!fs.existsSync(srcPath)) {
-    console.log('Warning: ' + srcPath + ' not found, skipping');
-    return;
-  }
-
-  const fileGuid = deterministicGuid(genPageId + '-' + f.src);
-  const fileDir = path.join(projectDir, fileGuid);
-  const fileContentDir = path.join(fileDir, 'filecontent');
-  fs.mkdirSync(fileContentDir, { recursive: true });
-
-  // Copy file content
-  fs.copyFileSync(srcPath, path.join(fileContentDir, f.src));
-
-  // Write uxagentprojectfile.xml
-  const fileXml = [
-    '&lt;uxagentprojectfile uxagentprojectfileid=\&quot;' + fileGuid + '\&quot;&gt;',
-    '  &lt;filecontent mimetype=\&quot;' + f.mimetype + '\&quot;&gt;' + f.src + '&lt;/filecontent&gt;',
-    '  &lt;filename&gt;' + f.filename + '&lt;/filename&gt;',
-    '  &lt;filetype&gt;' + f.filetype + '&lt;/filetype&gt;',
-    '  &lt;iscustomizable&gt;1&lt;/iscustomizable&gt;',
-    '  &lt;statecode&gt;0&lt;/statecode&gt;',
-    '  &lt;statuscode&gt;1&lt;/statuscode&gt;',
-    '&lt;/uxagentprojectfile&gt;'
-  ].join('\n');
-  fs.writeFileSync(path.join(fileDir, 'uxagentprojectfile.xml'), fileXml);
-});
-
-console.log('GenPage metadata generated for ' + genPageName + ' (' + genPageId + ')');
-&quot;" />
+    <!-- Generate file metadata and copy: config.json -->
+    <GenerateGenPageFileXml
+        ProjectId="%(_GenPageOutputs.GenPageId)"
+        SourceFilePath="%(_GenPageOutputs.Identity)/config.json"
+        FileName="config.json"
+        FileType="200000000"
+        MimeType="application/json"
+        OutputDir="$(_MetadataUxAgentProjectsDir)%(_GenPageOutputs.GenPageId)" />
 
   </Target>
 

--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.targets
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.targets
@@ -79,6 +79,10 @@
   <Import Project="$(MSBuildThisFileDirectory)TALXIS.DevKit.Build.Dataverse.Solution.CodeApps.targets"
           Condition="Exists('$(MSBuildThisFileDirectory)TALXIS.DevKit.Build.Dataverse.Solution.CodeApps.targets')" />
 
+  <!--  GenPage logic (detect, build, copy to uxagentprojects) -->
+  <Import Project="$(MSBuildThisFileDirectory)TALXIS.DevKit.Build.Dataverse.Solution.GenPages.targets"
+          Condition="Exists('$(MSBuildThisFileDirectory)TALXIS.DevKit.Build.Dataverse.Solution.GenPages.targets')" />
+
   <!--  PluginLibrary logic (detect, generate data xml) -->
   <Import Project="$(MSBuildThisFileDirectory)TALXIS.DevKit.Build.Dataverse.Solution.Plugin.targets"
           Condition="Exists('$(MSBuildThisFileDirectory)TALXIS.DevKit.Build.Dataverse.Solution.Plugin.targets')" />

--- a/src/Dataverse/Tasks/Tasks/GenerateGenPageConfigJson.cs
+++ b/src/Dataverse/Tasks/Tasks/GenerateGenPageConfigJson.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+public class GenerateGenPageConfigJson : Task
+{
+    public string DataSources { get; set; }
+
+    [Required]
+    public string OutputPath { get; set; }
+
+    public override bool Execute()
+    {
+        try
+        {
+            var sources = new JArray();
+
+            if (!string.IsNullOrWhiteSpace(DataSources))
+            {
+                var items = DataSources
+                    .Split(',')
+                    .Select(s => s.Trim())
+                    .Where(s => s.Length > 0);
+
+                foreach (var item in items)
+                {
+                    sources.Add(item);
+                }
+            }
+
+            var config = new JObject
+            {
+                ["dataSources"] = sources,
+                ["model"] = ""
+            };
+
+            var directory = Path.GetDirectoryName(OutputPath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllText(OutputPath, config.ToString(Formatting.Indented), new UTF8Encoding(false));
+
+            Log.LogMessage(MessageImportance.High, $"Generated GenPage config.json: {OutputPath}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.LogErrorFromException(ex, true);
+            return false;
+        }
+    }
+}

--- a/src/Dataverse/Tasks/Tasks/GenerateGenPageFileXml.cs
+++ b/src/Dataverse/Tasks/Tasks/GenerateGenPageFileXml.cs
@@ -1,0 +1,110 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+public class GenerateGenPageFileXml : Task
+{
+    [Required]
+    public string ProjectId { get; set; }
+
+    [Required]
+    public string SourceFilePath { get; set; }
+
+    [Required]
+    public string FileName { get; set; }
+
+    [Required]
+    public string FileType { get; set; }
+
+    [Required]
+    public string MimeType { get; set; }
+
+    [Required]
+    public string OutputDir { get; set; }
+
+    [Output]
+    public string GeneratedFileId { get; set; }
+
+    public override bool Execute()
+    {
+        try
+        {
+            if (!File.Exists(SourceFilePath))
+            {
+                Log.LogError($"Source file not found: {SourceFilePath}");
+                return false;
+            }
+
+            // Generate deterministic GUID from ProjectId + FileName
+            var seed = ProjectId + "-" + FileName;
+            GeneratedFileId = DeterministicGuid(seed);
+
+            var fileDir = Path.Combine(OutputDir, GeneratedFileId);
+            var fileContentDir = Path.Combine(fileDir, "filecontent");
+            Directory.CreateDirectory(fileContentDir);
+
+            // Copy source file preserving original filename
+            var sourceFileName = Path.GetFileName(SourceFilePath);
+            var destPath = Path.Combine(fileContentDir, sourceFileName);
+            File.Copy(SourceFilePath, destPath, true);
+
+            // Generate uxagentprojectfile.xml
+            var doc = new XDocument(
+                new XElement("uxagentprojectfile",
+                    new XAttribute("uxagentprojectfileid", GeneratedFileId),
+                    new XElement("filecontent",
+                        new XAttribute("mimetype", MimeType),
+                        sourceFileName),
+                    new XElement("filename", FileName),
+                    new XElement("filetype", FileType),
+                    new XElement("iscustomizable", "1"),
+                    new XElement("statecode", "0"),
+                    new XElement("statuscode", "1")
+                )
+            );
+
+            var xmlPath = Path.Combine(fileDir, "uxagentprojectfile.xml");
+
+            var settings = new XmlWriterSettings
+            {
+                Encoding = new UTF8Encoding(false),
+                Indent = true,
+                OmitXmlDeclaration = true,
+                NewLineChars = Environment.NewLine,
+                NewLineHandling = NewLineHandling.Replace
+            };
+
+            using (var writer = XmlWriter.Create(xmlPath, settings))
+            {
+                doc.Save(writer);
+            }
+
+            Log.LogMessage(MessageImportance.High, $"Generated GenPage file XML: {xmlPath} (FileId={GeneratedFileId})");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.LogErrorFromException(ex, true);
+            return false;
+        }
+    }
+
+    private static string DeterministicGuid(string seed)
+    {
+        using (var md5 = MD5.Create())
+        {
+            var hash = md5.ComputeHash(Encoding.UTF8.GetBytes(seed));
+            var hex = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+            return hex.Substring(0, 8) + "-"
+                 + hex.Substring(8, 4) + "-"
+                 + hex.Substring(12, 4) + "-"
+                 + hex.Substring(16, 4) + "-"
+                 + hex.Substring(20, 12);
+        }
+    }
+}

--- a/src/Dataverse/Tasks/Tasks/GenerateGenPageFileXml.cs
+++ b/src/Dataverse/Tasks/Tasks/GenerateGenPageFileXml.cs
@@ -40,8 +40,10 @@ public class GenerateGenPageFileXml : Task
                 return false;
             }
 
+            var normalizedId = ProjectId.Trim().Trim('{', '}').ToLowerInvariant();
+
             // Generate deterministic GUID from ProjectId + FileName
-            var seed = ProjectId + "-" + FileName;
+            var seed = normalizedId + "-" + FileName;
             GeneratedFileId = DeterministicGuid(seed);
 
             var fileDir = Path.Combine(OutputDir, GeneratedFileId);

--- a/src/Dataverse/Tasks/Tasks/GenerateGenPageProjectXml.cs
+++ b/src/Dataverse/Tasks/Tasks/GenerateGenPageProjectXml.cs
@@ -23,9 +23,11 @@ public class GenerateGenPageProjectXml : Task
         {
             Directory.CreateDirectory(OutputDir);
 
+            var normalizedId = ProjectId.Trim().Trim('{', '}').ToLowerInvariant();
+
             var doc = new XDocument(
                 new XElement("uxagentproject",
-                    new XAttribute("uxagentprojectid", ProjectId),
+                    new XAttribute("uxagentprojectid", normalizedId),
                     new XElement("iscustomizable", "1"),
                     new XElement("name", PageName),
                     new XElement("statecode", "0"),

--- a/src/Dataverse/Tasks/Tasks/GenerateGenPageProjectXml.cs
+++ b/src/Dataverse/Tasks/Tasks/GenerateGenPageProjectXml.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+public class GenerateGenPageProjectXml : Task
+{
+    [Required]
+    public string ProjectId { get; set; }
+
+    [Required]
+    public string PageName { get; set; }
+
+    [Required]
+    public string OutputDir { get; set; }
+
+    public override bool Execute()
+    {
+        try
+        {
+            Directory.CreateDirectory(OutputDir);
+
+            var doc = new XDocument(
+                new XElement("uxagentproject",
+                    new XAttribute("uxagentprojectid", ProjectId),
+                    new XElement("iscustomizable", "1"),
+                    new XElement("name", PageName),
+                    new XElement("statecode", "0"),
+                    new XElement("statuscode", "1")
+                )
+            );
+
+            var outputPath = Path.Combine(OutputDir, "uxagentproject.xml");
+
+            var settings = new XmlWriterSettings
+            {
+                Encoding = new UTF8Encoding(false),
+                Indent = true,
+                OmitXmlDeclaration = true,
+                NewLineChars = Environment.NewLine,
+                NewLineHandling = NewLineHandling.Replace
+            };
+
+            using (var writer = XmlWriter.Create(outputPath, settings))
+            {
+                doc.Save(writer);
+            }
+
+            Log.LogMessage(MessageImportance.High, $"Generated GenPage project XML: {outputPath}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.LogErrorFromException(ex, true);
+            return false;
+        }
+    }
+}

--- a/src/Dataverse/Tasks/Tasks/PatchGenPageCompiledCode.cs
+++ b/src/Dataverse/Tasks/Tasks/PatchGenPageCompiledCode.cs
@@ -28,7 +28,7 @@ public class PatchGenPageCompiledCode : Task
             var js = File.ReadAllText(CompiledJsPath, Encoding.UTF8);
 
             // Strip RuntimeTypes import lines (single or double quotes)
-            js = Regex.Replace(js, @"import\s+[^;'\n]+['""]\.\/RuntimeTypes['""];?\s*", "");
+            js = Regex.Replace(js, @"import\s+.*?from\s+['""]\.\/RuntimeTypes['""];?\s*", "");
 
             var result = js;
 

--- a/src/Dataverse/Tasks/Tasks/PatchGenPageCompiledCode.cs
+++ b/src/Dataverse/Tasks/Tasks/PatchGenPageCompiledCode.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+public class PatchGenPageCompiledCode : Task
+{
+    [Required]
+    public string CompiledJsPath { get; set; }
+
+    public string RuntimeTypesJsPath { get; set; }
+
+    [Required]
+    public string OutputPath { get; set; }
+
+    public override bool Execute()
+    {
+        try
+        {
+            if (!File.Exists(CompiledJsPath))
+            {
+                Log.LogError($"Compiled JS file not found: {CompiledJsPath}");
+                return false;
+            }
+
+            var js = File.ReadAllText(CompiledJsPath, Encoding.UTF8);
+
+            // Strip RuntimeTypes import lines (single or double quotes)
+            js = Regex.Replace(js, @"import\s+[^;'\n]+['""]\.\/RuntimeTypes['""];?\s*", "");
+
+            var result = js;
+
+            if (!string.IsNullOrEmpty(RuntimeTypesJsPath) && File.Exists(RuntimeTypesJsPath))
+            {
+                var rt = File.ReadAllText(RuntimeTypesJsPath, Encoding.UTF8);
+                result = "// --- BEGIN GENERATED RUNTIME TYPES ---\n\n"
+                       + rt
+                       + "\n// --- END GENERATED RUNTIME TYPES ---\n\n"
+                       + js;
+            }
+
+            var directory = Path.GetDirectoryName(OutputPath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllText(OutputPath, result, new UTF8Encoding(false));
+
+            Log.LogMessage(MessageImportance.High, $"Patched GenPage compiled code: {OutputPath}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.LogErrorFromException(ex, true);
+            return false;
+        }
+    }
+}

--- a/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.targets
@@ -40,4 +40,8 @@
     <UsingTask TaskName="EnsureAllCustomizationsNodes" AssemblyFile="$(TasksAssembly)" />
     <UsingTask TaskName="ValidatePcfDependencies" AssemblyFile="$(TasksAssembly)" />
     <UsingTask TaskName="ValidateWorkspace" AssemblyFile="$(TasksAssembly)" />
+    <UsingTask TaskName="PatchGenPageCompiledCode" AssemblyFile="$(TasksAssembly)" />
+    <UsingTask TaskName="GenerateGenPageConfigJson" AssemblyFile="$(TasksAssembly)" />
+    <UsingTask TaskName="GenerateGenPageProjectXml" AssemblyFile="$(TasksAssembly)" />
+    <UsingTask TaskName="GenerateGenPageFileXml" AssemblyFile="$(TasksAssembly)" />
 </Project>


### PR DESCRIPTION
## Summary

Add new `GenPage` project type for Power Platform generative pages (React 17 + Fluent UI V9 pages inside model-driven apps).

### Build package (`src/Dataverse/GenPage/`)
- `GenPage.props`: `ProjectType=GenPage` (minimal, matches CodeApp pattern)
- `GenPage.targets`: transpiles TSX via `tsc --outDir` to intermediate output, patches compiled JS via C# task, copies `genpage.config.json` as source file
- Validates `GenPageId` as proper GUID with normalization (strip braces, lowercase)
- Derives JS output filename from `GenPageMainFile` (not hardcoded)
- `IgnoreExitCode` on tsc (type errors don't prevent JS output with `--noEmit false`)

### C# MSBuild tasks (`src/Dataverse/Tasks/Tasks/`)
- `PatchGenPageCompiledCode`: strips RuntimeTypes imports (handles both quote types), prepends RuntimeTypes JS enums
- `GenerateGenPageProjectXml`: generates `uxagentproject.xml` via XDocument
- `GenerateGenPageFileXml`: generates `uxagentprojectfile.xml`, copies file content, deterministic MD5-based GUIDs with normalized ProjectId

### Solution integration (`Solution.GenPages.targets`)
- Probes ProjectReferences for `ProjectType==GenPage`
- Generates `uxagentprojects/` metadata directory matching SolutionPackager format
- Files: `page.tsx` (source), `page.compiled` (transpiled JS), `config.json` (data sources)

### Key design decisions
- **Zero PAC CLI dependency** — transpilation uses `npx -p typescript@5.3.2 tsc` with exact flags matching Microsoft's implementation
- **Compiled JS is a build artifact** — not stored in source control
- **`genpage.config.json` is a source file** — edited by developer (like CodeApp's `power.config.json`), not generated from csproj property
- **firstPrompt.json omitted** — not needed at runtime (proven by testing)

### Testing
Verified end-to-end: template scaffold → tsc transpile → solution pack → import to Dataverse → generative page renders in model-driven app. Tested with fresh GUIDs never uploaded via PAC CLI.