### PR TITLE
fix: Invalid XML comment breaks GenPage build

### DIFF
--- a/src/Dataverse/GenPage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.GenPage.targets
+++ b/src/Dataverse/GenPage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.GenPage.targets
@@ -27,7 +27,7 @@
 
     <MakeDir Directories="$(IntermediateOutputPath)" />
 
-    <!-- Transpile TSX to JS (IgnoreExitCode: tsc returns non-zero for type errors but still produces output with --noEmit false) -->
+    <!-- Transpile TSX to JS (IgnoreExitCode: tsc returns non-zero for type errors but still produces output with noEmit=false) -->
     <Exec WorkingDirectory="$(MSBuildProjectDirectory)"
           Command="npx --yes -p typescript@5.3.2 tsc &quot;$(GenPageMainFile)&quot; --target ES5 --module ES2020 --jsx react --lib ES2015,DOM --skipLibCheck --noEmit false --outDir &quot;$(IntermediateOutputPath)&quot;"
           IgnoreExitCode="true" />

--- a/src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj
+++ b/src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj
@@ -53,6 +53,7 @@
         <None Include="msbuild/tasks/**/*" Pack="true" PackagePath="tasks" />
         <None Include="msbuild/build/*.*" Pack="true" PackagePath="build" />
         <None Include="msbuild/buildMultiTargeting/*.*" Pack="true" PackagePath="buildMultiTargeting" />
+        <None Include="msbuild/buildTransitive/*.*" Pack="true" PackagePath="buildTransitive" />
         <None Include="..\..\package-icon.png" Pack="true" PackagePath="" Link="package-icon.png" />
         <None Include="README.md" Pack="true" PackagePath="\" />
     </ItemGroup>

--- a/src/Dataverse/Tasks/msbuild/buildTransitive/TALXIS.DevKit.Build.Dataverse.Tasks.props
+++ b/src/Dataverse/Tasks/msbuild/buildTransitive/TALXIS.DevKit.Build.Dataverse.Tasks.props
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$(MSBuildThisFileDirectory)..\tasks\$(MSBuildThisFile)" />
+</Project>

--- a/src/Dataverse/Tasks/msbuild/buildTransitive/TALXIS.DevKit.Build.Dataverse.Tasks.targets
+++ b/src/Dataverse/Tasks/msbuild/buildTransitive/TALXIS.DevKit.Build.Dataverse.Tasks.targets
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$(MSBuildThisFileDirectory)..\tasks\$(MSBuildThisFile)" />
+</Project>


### PR DESCRIPTION
## Problem

Two bugs in the GenPage build pipeline:

### 1. Invalid XML comment (MSBuild parse failure)

### 2. `PatchGenPageCompiledCode` task not found
NuGet PackageReference only imports `build/` assets from **direct** dependencies. The Tasks package (which registers all `UsingTask` declarations) only has `build/` — no `buildTransitive/`. When GenPage depends on Tasks transitively, the `UsingTask` registrations are never imported, so MSBuild can't find `PatchGenPageCompiledCode`.

This affects any package that consumes Tasks transitively (GenPage, and potentially Solution/Plugin if the consumer doesn't have Tasks as a direct reference).

## Fixes

1. **XML comment**: replaced `--noEmit false` with `noEmit=false` in the comment text (tsc command unchanged)
2. **buildTransitive**: added `buildTransitive/` folder to the Tasks NuGet package with redirectors to `tasks/` — ensures `UsingTask` declarations are imported for transitive consumers