### PR TITLE
Auto-generate ImportConfig.xml and order solutions by csproj reference order

### DIFF
--- a/src/Dataverse/PDPackage/README.md
+++ b/src/Dataverse/PDPackage/README.md
@@ -36,6 +36,16 @@ All `ProjectReference` items default to `ReferenceOutputAssembly=false` via `Ite
 
 `_DetectPdProjectReferenceTypes` probes all `ProjectReference` items for `GetProjectType`. Solution-type references have `ReferenceOutputAssembly` set to `false` so their DLLs are not included in the package output.
 
+### ImportConfig auto-generation
+
+`ImportConfig.xml` is not required to exist in the project. If `<AssetsSrcDirectory>ImportConfig.xml` is missing, a skeleton (`<configdatastorage>` with empty `<solutions>`, `<filestoimport>`, `<filesmapstoimport>`) is generated in `$(IntermediateOutputPath)<FolderName>/ImportConfig.xml` before MS validation runs, and `@(PdImportConfig)` is rewired to point at it. `<FolderName>` is read from the `GetImportPackageDataFolderName` property of any `ImportExtension`-derived class found in the project's top-level `.cs` files (default `PkgAssets`).
+
+When `AutoGeneratePdImportConfig` is `true` (default) and the source `ImportConfig.xml` contains no `<configsolutionfile>` entries, the `<solutions>` section is generated automatically from the project's solution references. Both `<ProjectReference>` items pointing at Solution projects and `<PackageReference>` items pointing at `pp-solution` NuGet packages are picked up, and each one produces a `<configsolutionfile>` entry with `requiredimportmode="async"`.
+
+The generated entries appear in the **same order as the references are declared in the `.csproj` file**, walking `<PackageReference>` and `<ProjectReference>` items in document order (interleaved). A `PackageReference` is matched by its package id; a `ProjectReference` is matched by the csproj file name (without extension), which by convention equals the solution unique name. Any `<configsolutionfile>` element that can't be matched against a csproj reference is moved to the end while keeping its relative position.
+
+If you ship a hand-written `PkgAssets/ImportConfig.xml` with explicit `<configsolutionfile>` entries, auto-generation is skipped entirely and your file is used as-is.
+
 ### ILRepack
 
 `DataverseILRepack` (runs after `Build`) merges all non-Microsoft DLLs (excluding reference assemblies and `Newtonsoft.Json`) into the main output assembly using ILRepack.exe. Can be disabled with `DataversePackageRunILRepack=false` or `SkipPackageILRepack=true`.

--- a/src/Dataverse/PDPackage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.PdPackage.ImportConfig.targets
+++ b/src/Dataverse/PDPackage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.PdPackage.ImportConfig.targets
@@ -3,6 +3,37 @@
     <_TalxisSourceImportConfig>$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)','PkgAssets','ImportConfig.xml'))</_TalxisSourceImportConfig>
   </PropertyGroup>
 
+  <Target Name="TalxisEnsureImportConfigExists"
+          BeforeTargets="_CheckForInvalidPdProjectCore;PrepareForPdBuild;GeneratePdImportConfig">
+
+    <PropertyGroup>
+      <_TalxisCurrentPdImportConfig>@(PdImportConfig->'%(FullPath)')</_TalxisCurrentPdImportConfig>
+      <_TalxisSkipImportConfigSkeleton Condition="'$(_TalxisCurrentPdImportConfig)' != '' and Exists('$(_TalxisCurrentPdImportConfig)')">true</_TalxisSkipImportConfigSkeleton>
+    </PropertyGroup>
+
+    <ExtractPdPackageDataFolderName
+        ProjectDirectory="$(MSBuildProjectDirectory)"
+        DefaultFolderName="PkgAssets"
+        Condition="'$(_TalxisSkipImportConfigSkeleton)' != 'true'">
+      <Output TaskParameter="FolderName" PropertyName="_TalxisPdDataFolderName" />
+    </ExtractPdPackageDataFolderName>
+
+    <PropertyGroup Condition="'$(_TalxisSkipImportConfigSkeleton)' != 'true'">
+      <_TalxisGeneratedImportConfigDir>$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine('$(MSBuildProjectDirectory)','$(IntermediateOutputPath)','$(_TalxisPdDataFolderName)'))))</_TalxisGeneratedImportConfigDir>
+      <_TalxisGeneratedImportConfigPath>$([System.IO.Path]::Combine('$(_TalxisGeneratedImportConfigDir)','ImportConfig.xml'))</_TalxisGeneratedImportConfigPath>
+    </PropertyGroup>
+
+    <PostProcessImportConfig
+        ImportConfigPath="$(_TalxisGeneratedImportConfigPath)"
+        CreateSkeletonIfMissing="true"
+        Condition="'$(_TalxisSkipImportConfigSkeleton)' != 'true'" />
+
+    <ItemGroup Condition="'$(_TalxisSkipImportConfigSkeleton)' != 'true'">
+      <PdImportConfig Remove="@(PdImportConfig)" />
+      <PdImportConfig Include="$(_TalxisGeneratedImportConfigPath)" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="TalxisDetectCustomImportConfig"
           BeforeTargets="GeneratePdImportConfig"
           Condition="'$(AutoGeneratePdImportConfig)'=='true' and Exists('$(_TalxisSourceImportConfig)')">
@@ -34,6 +65,7 @@
     <PostProcessImportConfig
       ImportConfigPath="$(_GeneratedPdImportConfig)"
       Solutions="@(_AnnotatedSolution)"
-      CmtDataFileName="$(_TalxisCmtDataFileForImportConfig)" />
+      CmtDataFileName="$(_TalxisCmtDataFileForImportConfig)"
+      CsprojPath="$(MSBuildProjectFullPath)" />
   </Target>
 </Project>

--- a/src/Dataverse/Tasks/Tasks/ExtractPdPackageDataFolderName.cs
+++ b/src/Dataverse/Tasks/Tasks/ExtractPdPackageDataFolderName.cs
@@ -1,0 +1,63 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+public class ExtractPdPackageDataFolderName : Task
+{
+    [Required]
+    public string ProjectDirectory { get; set; } = "";
+
+    public string DefaultFolderName { get; set; } = "PkgAssets";
+
+    [Output]
+    public string FolderName { get; private set; } = "";
+
+    private static readonly Regex PropertyRegex = new Regex(
+        @"GetImportPackageDataFolderName\s*(?:=>\s*""([^""]+)""|\{[^}]*?return\s*""([^""]+)"")",
+        RegexOptions.Singleline | RegexOptions.Compiled);
+
+    public override bool Execute()
+    {
+        FolderName = string.IsNullOrWhiteSpace(DefaultFolderName) ? "PkgAssets" : DefaultFolderName;
+
+        try
+        {
+            var dir = (ProjectDirectory ?? "").Trim();
+            if (string.IsNullOrWhiteSpace(dir) || !Directory.Exists(dir))
+            {
+                Log.LogMessage(MessageImportance.Low,
+                    $"ProjectDirectory is empty or missing — using default folder name '{FolderName}'.");
+                return true;
+            }
+
+            foreach (var file in Directory.EnumerateFiles(dir, "*.cs", SearchOption.TopDirectoryOnly))
+            {
+                string content;
+                try { content = File.ReadAllText(file); }
+                catch { continue; }
+
+                var match = PropertyRegex.Match(content);
+                if (!match.Success) continue;
+
+                var value = match.Groups[1].Success ? match.Groups[1].Value : match.Groups[2].Value;
+                if (string.IsNullOrWhiteSpace(value)) continue;
+
+                FolderName = value;
+                Log.LogMessage(MessageImportance.Normal,
+                    $"Detected GetImportPackageDataFolderName='{FolderName}' from '{file}'.");
+                return true;
+            }
+
+            Log.LogMessage(MessageImportance.Low,
+                $"GetImportPackageDataFolderName not found in any .cs file under '{dir}'. Using default '{FolderName}'.");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.LogWarningFromException(ex);
+            return true;
+        }
+    }
+}

--- a/src/Dataverse/Tasks/Tasks/PostProcessImportConfig.cs
+++ b/src/Dataverse/Tasks/Tasks/PostProcessImportConfig.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Xml;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -12,6 +14,10 @@ public class PostProcessImportConfig : Task
     public ITaskItem[] Solutions { get; set; }
 
     public string CmtDataFileName { get; set; } = "";
+
+    public string CsprojPath { get; set; } = "";
+
+    public bool CreateSkeletonIfMissing { get; set; }
 
     [Output]
     public string UpdatedImportConfig { get; private set; } = "";
@@ -28,10 +34,24 @@ public class PostProcessImportConfig : Task
             }
 
             configPath = Path.GetFullPath(configPath);
+
             if (!File.Exists(configPath))
             {
+                if (CreateSkeletonIfMissing)
+                {
+                    WriteSkeleton(configPath);
+                    UpdatedImportConfig = configPath;
+                    return !Log.HasLoggedErrors;
+                }
+
                 Log.LogError($"ImportConfig file not found: {configPath}");
                 return false;
+            }
+
+            if (CreateSkeletonIfMissing)
+            {
+                UpdatedImportConfig = configPath;
+                return true;
             }
 
             var doc = new XmlDocument { PreserveWhitespace = true };
@@ -45,6 +65,7 @@ public class PostProcessImportConfig : Task
             }
 
             AnnotateSolutionFiles(doc, root);
+            ReorderSolutionFiles(root);
             SetCmtDataImportFile(root);
 
             doc.Save(configPath);
@@ -56,6 +77,40 @@ public class PostProcessImportConfig : Task
             Log.LogErrorFromException(ex, true, true, null);
             return false;
         }
+    }
+
+    private void WriteSkeleton(string configPath)
+    {
+        var dir = Path.GetDirectoryName(configPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        var doc = new XmlDocument();
+        var decl = doc.CreateXmlDeclaration("1.0", "utf-8", null);
+        doc.AppendChild(decl);
+
+        var root = doc.CreateElement("configdatastorage");
+        root.SetAttribute("installsampledata", "false");
+        root.SetAttribute("waitforsampledatatoinstall", "true");
+        doc.AppendChild(root);
+
+        root.AppendChild(doc.CreateElement("solutions"));
+        root.AppendChild(doc.CreateElement("filestoimport"));
+        root.AppendChild(doc.CreateElement("filesmapstoimport"));
+
+        var settings = new System.Xml.XmlWriterSettings
+        {
+            Indent = true,
+            IndentChars = "  ",
+            Encoding = new System.Text.UTF8Encoding(false),
+        };
+        using (var writer = System.Xml.XmlWriter.Create(configPath, settings))
+        {
+            doc.Save(writer);
+        }
+
+        Log.LogMessage(MessageImportance.High,
+            $"Generated skeleton ImportConfig.xml at: {configPath}");
     }
 
     private void AnnotateSolutionFiles(XmlDocument doc, XmlElement root)
@@ -112,6 +167,168 @@ public class PostProcessImportConfig : Task
         }
 
         return uniqueName + ".zip";
+    }
+
+    private void ReorderSolutionFiles(XmlElement root)
+    {
+        var csproj = (CsprojPath ?? "").Trim();
+        if (string.IsNullOrWhiteSpace(csproj) || !File.Exists(csproj))
+        {
+            Log.LogMessage(MessageImportance.Low,
+                "CsprojPath not provided or missing — skipping configsolutionfile reorder.");
+            return;
+        }
+
+        var orderedNames = ReadReferenceOrderFromCsproj(csproj);
+        if (orderedNames.Count == 0)
+            return;
+
+        var container = root.SelectSingleNode("solutions") as XmlElement;
+        if (container == null)
+            return;
+
+        var bundles = new List<Bundle>();
+        XmlNode pendingWhitespace = null;
+        XmlNode trailingWhitespace = null;
+
+        foreach (XmlNode child in container.ChildNodes)
+        {
+            if (child is XmlElement el &&
+                string.Equals(el.LocalName, "configsolutionfile", StringComparison.OrdinalIgnoreCase))
+            {
+                bundles.Add(new Bundle(pendingWhitespace, el));
+                pendingWhitespace = null;
+            }
+            else if (IsWhitespaceNode(child))
+            {
+                pendingWhitespace = child;
+            }
+        }
+        trailingWhitespace = pendingWhitespace;
+
+        if (bundles.Count == 0)
+            return;
+
+        var ordered = bundles
+            .Select((b, idx) => new
+            {
+                Bundle = b,
+                Rank = RankConfigSolutionFile(b.Element, orderedNames),
+                OriginalIndex = idx
+            })
+            .OrderBy(x => x.Rank)
+            .ThenBy(x => x.OriginalIndex)
+            .Select(x => x.Bundle)
+            .ToList();
+
+        bool alreadyOrdered = true;
+        for (int i = 0; i < bundles.Count; i++)
+        {
+            if (!ReferenceEquals(bundles[i].Element, ordered[i].Element))
+            {
+                alreadyOrdered = false;
+                break;
+            }
+        }
+        if (alreadyOrdered)
+            return;
+
+        foreach (var bundle in bundles)
+        {
+            if (bundle.Whitespace != null && bundle.Whitespace.ParentNode == container)
+                container.RemoveChild(bundle.Whitespace);
+            if (bundle.Element.ParentNode == container)
+                container.RemoveChild(bundle.Element);
+        }
+
+        foreach (var bundle in ordered)
+        {
+            if (bundle.Whitespace != null)
+                container.InsertBefore(bundle.Whitespace, trailingWhitespace);
+            container.InsertBefore(bundle.Element, trailingWhitespace);
+        }
+
+        Log.LogMessage(MessageImportance.High,
+            "Reordered configsolutionfile elements to match the order of " +
+            "PackageReference / ProjectReference items in the csproj.");
+    }
+
+    private static bool IsWhitespaceNode(XmlNode node)
+    {
+        if (node == null) return false;
+        return node.NodeType == XmlNodeType.Whitespace
+            || node.NodeType == XmlNodeType.SignificantWhitespace
+            || (node.NodeType == XmlNodeType.Text && string.IsNullOrWhiteSpace(node.Value));
+    }
+
+    private sealed class Bundle
+    {
+        public XmlNode Whitespace { get; }
+        public XmlElement Element { get; }
+        public Bundle(XmlNode whitespace, XmlElement element)
+        {
+            Whitespace = whitespace;
+            Element = element;
+        }
+    }
+
+    private static int RankConfigSolutionFile(XmlElement node, List<string> orderedNames)
+    {
+        var unique = ExtractUniqueName(node);
+        if (string.IsNullOrWhiteSpace(unique))
+            return int.MaxValue;
+
+        for (int i = 0; i < orderedNames.Count; i++)
+        {
+            if (string.Equals(orderedNames[i], unique, StringComparison.OrdinalIgnoreCase))
+                return i;
+        }
+        return int.MaxValue;
+    }
+
+    private static string ExtractUniqueName(XmlElement configSolutionFile)
+    {
+        var unique = configSolutionFile.GetAttribute("solutionpackageuniquename");
+        if (!string.IsNullOrWhiteSpace(unique))
+            return unique;
+
+        var filename = configSolutionFile.GetAttribute("solutionpackagefilename");
+        if (!string.IsNullOrWhiteSpace(filename))
+            return Path.GetFileNameWithoutExtension(filename);
+
+        return "";
+    }
+
+    private static List<string> ReadReferenceOrderFromCsproj(string csprojPath)
+    {
+        var result = new List<string>();
+        var doc = new XmlDocument();
+        doc.Load(csprojPath);
+
+        var itemGroups = doc.GetElementsByTagName("ItemGroup");
+        foreach (XmlNode ig in itemGroups)
+        {
+            foreach (XmlNode child in ig.ChildNodes)
+            {
+                if (!(child is XmlElement el))
+                    continue;
+
+                var include = el.GetAttribute("Include");
+                if (string.IsNullOrWhiteSpace(include))
+                    continue;
+
+                if (string.Equals(el.LocalName, "PackageReference", StringComparison.OrdinalIgnoreCase))
+                {
+                    result.Add(include);
+                }
+                else if (string.Equals(el.LocalName, "ProjectReference", StringComparison.OrdinalIgnoreCase))
+                {
+                    result.Add(Path.GetFileNameWithoutExtension(include));
+                }
+            }
+        }
+
+        return result;
     }
 
     private void SetCmtDataImportFile(XmlElement root)

--- a/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.targets
@@ -34,6 +34,7 @@
     <UsingTask TaskName="AppendCmtDataFileToImportConfig" AssemblyFile="$(TasksAssembly)" />
     <UsingTask TaskName="ResolveWebResourceName" AssemblyFile="$(TasksAssembly)" />
     <UsingTask TaskName="PostProcessImportConfig" AssemblyFile="$(TasksAssembly)" />
+    <UsingTask TaskName="ExtractPdPackageDataFolderName" AssemblyFile="$(TasksAssembly)" />
     <UsingTask TaskName="GenerateCodeAppMetaXml" AssemblyFile="$(TasksAssembly)" />
     <UsingTask TaskName="ValidateDuplicateGuids" AssemblyFile="$(TasksAssembly)" />
     <UsingTask TaskName="ValidateQuickFindViews" AssemblyFile="$(TasksAssembly)" />

--- a/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.targets
@@ -15,34 +15,34 @@
     </PropertyGroup>
 
 
-    <UsingTask TaskName="GenerateGitVersion" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ApplyVersionNumber" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ApplyPcfVersionNumber" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ApplyPluginVersionNumberInSolution" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="InvokeSolutionPackager" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ValidateXmlFiles" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ValidateJsonFiles" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="RetrieveProjectReferences" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="EnsureWebResourceDataXml" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="AddRootComponentToSolution" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="EnsurePluginAssemblyDataXml" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="EnsureWorkflowActivityAssemblyDataXml" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="EnsureCustomizationsNode" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="PatchSolutionXml" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="MergeCmtDataXml" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="MergeCmtDataSchemaXml" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="AppendCmtDataFileToImportConfig" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ResolveWebResourceName" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="PostProcessImportConfig" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ExtractPdPackageDataFolderName" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="GenerateCodeAppMetaXml" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ValidateDuplicateGuids" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ValidateQuickFindViews" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="EnsureAllCustomizationsNodes" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ValidatePcfDependencies" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ValidateWorkspace" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="PatchGenPageCompiledCode" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="GenerateGenPageConfigJson" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="GenerateGenPageProjectXml" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="GenerateGenPageFileXml" AssemblyFile="$(TasksAssembly)" />
+    <UsingTask TaskName="GenerateGitVersion" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ApplyVersionNumber" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ApplyPcfVersionNumber" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ApplyPluginVersionNumberInSolution" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="InvokeSolutionPackager" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ValidateXmlFiles" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ValidateJsonFiles" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="RetrieveProjectReferences" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="EnsureWebResourceDataXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="AddRootComponentToSolution" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="EnsurePluginAssemblyDataXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="EnsureWorkflowActivityAssemblyDataXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="EnsureCustomizationsNode" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="PatchSolutionXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="MergeCmtDataXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="MergeCmtDataSchemaXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="AppendCmtDataFileToImportConfig" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ResolveWebResourceName" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="PostProcessImportConfig" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="GenerateCodeAppMetaXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ValidateDuplicateGuids" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ValidateQuickFindViews" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="EnsureAllCustomizationsNodes" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ValidatePcfDependencies" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ValidateWorkspace" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="PatchGenPageCompiledCode" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="GenerateGenPageConfigJson" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="GenerateGenPageProjectXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="GenerateGenPageFileXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ExtractPdPackageDataFolderName" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
 </Project>


### PR DESCRIPTION
#59 
#58
`ImportConfig.xml` is no longer required. If the file is missing, the build generates a skeleton at `$(IntermediateOutputPath)<FolderName>/ImportConfig.xml` before MSBuild starts validating it, and rewires `@(PdImportConfig)` to point at the generated copy. The folder name is picked up from `GetImportPackageDataFolderName` on any `ImportExtension`-derived class in the project's top-level `.cs` files, defaulting to `PkgAssets`.

The solutions list is also derived from the `.csproj`. When `AutoGeneratePdImportConfig` is on and the source `ImportConfig.xml` has no `<configsolutionfile>` entries, the `<solutions>` block is built from `<PackageReference>` items (for `pp-solution` NuGets) and `<ProjectReference>` items, in the order they appear in the project file
If you ship a hand-written `ImportConfig.xml` with explicit `<configsolutionfile>` entries, nothing changes — your file is used as-is and auto-generation is skipped entirely.