### PR TITLE
feat: upgrade Dataverse tasks to net10 host

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Project dependency folders are analyzed for Git changes to be reflected in gener
 |---------|-------------|
 | [TALXIS.DevKit.Build.Sdk](src\Sdk\README.md) | MSBuild SDK that auto-resolves the correct package based on `ProjectType`. Entry point for new projects. |
 | [TALXIS.DevKit.Build.Dataverse.Tasks](src/Dataverse/Tasks/README.md) | Core MSBuild tasks shared by all packages: Git versioning, schema validation, solution packaging, CMT data merging. |
-| [TALXIS.DevKit.Build.Dataverse.Solution](src/Dataverse/Solution/README.md) | Orchestrates the full Dataverse solution build: component discovery, XML patching, PAC solution packager, NuGet packing. |
+| [TALXIS.DevKit.Build.Dataverse.Solution](src/Dataverse/Solution/README.md) | Orchestrates the full Dataverse solution build: component discovery, XML patching, SolutionPackagerLib-based packaging, NuGet packing. |
 | [TALXIS.DevKit.Build.Dataverse.Plugin](src/Dataverse/Plugin/README.md) | MSBuild integration for Dataverse plugin assemblies with auto-versioning and metadata exposure for Solution projects. |
 | [TALXIS.DevKit.Build.Dataverse.Pcf](src/Dataverse/Pcf/README.md) | MSBuild integration for PCF controls. Wraps `Microsoft.PowerApps.MSBuild.Pcf` with Git-based versioning. |
 | [TALXIS.DevKit.Build.Dataverse.WorkflowActivity](src/Dataverse/WorkflowActivity/README.md) | MSBuild integration for custom workflow activity assemblies with auto-versioning and Solution project integration. |
@@ -115,7 +115,7 @@ The publish workflow builds all NuGet packages with the tag version and pushes t
 
 ### Work in progress
 
-- **Solution Packaging**: Facilitates the use of the PAC CLI for running the solution packager, simplifying the packaging process.
+- **Solution Packaging**: Uses a modern .NET MSBuild task host and SolutionPackagerLib to run solution packaging without invoking `pac.exe`.
     * Currently provided by `Microsoft.PowerApps.MSBuild.Solution` package.
 
 ## Contact us

--- a/src/Dataverse/CodeApp/TALXIS.DevKit.Build.Dataverse.CodeApp.csproj
+++ b/src/Dataverse/CodeApp/TALXIS.DevKit.Build.Dataverse.CodeApp.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <AssemblyName>TALXIS.DevKit.Build.Dataverse.CodeApp</AssemblyName>
-        <!-- https://github.com/dotnet/vscode-csharp/issues/5786 -->
-        <!-- <TargetFrameworks>net462;$(NetMinimum);$(NetCurrent)</TargetFrameworks> -->
-        <TargetFrameworks>net472;net6.0</TargetFrameworks>
+        <TargetFramework>net10.0</TargetFramework>
         <!-- Pack settings -->
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <IsPackable>true</IsPackable>
@@ -17,8 +15,8 @@
         <NuspecProperties>Version=$(Version);MicrosoftPowerAppsTargetsVersion=$(MicrosoftPowerAppsTargetsVersion)</NuspecProperties>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build" Version="16.11.6" />
-        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.11.6" />
+        <PackageReference Include="Microsoft.Build" Version="18.0.2" />
+        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
         <!-- Do not add any of the dependencies above to nuspec -->
         <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
     </ItemGroup>

--- a/src/Dataverse/PDPackage/TALXIS.DevKit.Build.Dataverse.PdPackage.csproj
+++ b/src/Dataverse/PDPackage/TALXIS.DevKit.Build.Dataverse.PdPackage.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Version Condition="'$(Version)'==''">0.0.1</Version>
         <ILRepackVersion Condition="'$(ILRepackVersion)'==''">2.0.18</ILRepackVersion>

--- a/src/Dataverse/Pcf/TALXIS.DevKit.Build.Dataverse.Pcf.csproj
+++ b/src/Dataverse/Pcf/TALXIS.DevKit.Build.Dataverse.Pcf.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <AssemblyName>TALXIS.DevKit.Build.Dataverse.Pcf</AssemblyName>
-        <!-- https://github.com/dotnet/vscode-csharp/issues/5786 -->
-        <!-- <TargetFrameworks>net462;$(NetMinimum);$(NetCurrent)</TargetFrameworks> -->
-        <TargetFrameworks>net472;net6.0</TargetFrameworks>
+        <TargetFramework>net10.0</TargetFramework>
         <!-- Pack settings -->
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <IsPackable>true</IsPackable>
@@ -17,8 +15,8 @@
         <NuspecProperties>Version=$(Version);MicrosoftPowerAppsTargetsVersion=$(MicrosoftPowerAppsTargetsVersion)</NuspecProperties>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build" Version="16.11.6" />
-        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.11.6" />
+        <PackageReference Include="Microsoft.Build" Version="18.0.2" />
+        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
         <!-- Do not add any of the dependencies above to nuspec -->
         <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
     </ItemGroup>

--- a/src/Dataverse/Plugin/TALXIS.DevKit.Build.Dataverse.Plugin.csproj
+++ b/src/Dataverse/Plugin/TALXIS.DevKit.Build.Dataverse.Plugin.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <AssemblyName>TALXIS.DevKit.Build.Dataverse.Plugin</AssemblyName>
-        <!-- https://github.com/dotnet/vscode-csharp/issues/5786 -->
-        <!-- <TargetFrameworks>net462;$(NetMinimum);$(NetCurrent)</TargetFrameworks> -->
-        <TargetFrameworks>net472;net6.0</TargetFrameworks>
+        <TargetFramework>net10.0</TargetFramework>
         <!-- Pack settings -->
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <IsPackable>true</IsPackable>
@@ -17,8 +15,8 @@
         <NuspecProperties>Version=$(Version);MicrosoftPowerAppsTargetsVersion=$(MicrosoftPowerAppsTargetsVersion)</NuspecProperties>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build" Version="16.11.6" />
-        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.11.6" />
+        <PackageReference Include="Microsoft.Build" Version="18.0.2" />
+        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
         <!-- Do not add any of the dependencies above to nuspec -->
         <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
     </ItemGroup>

--- a/src/Dataverse/ScriptLibrary/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.csproj
+++ b/src/Dataverse/ScriptLibrary/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version Condition="'$(Version)'==''">0.0.1</Version>
     <NuspecFile>TALXIS.DevKit.Build.Dataverse.ScriptLibrary.nuspec</NuspecFile>

--- a/src/Dataverse/Solution/README.md
+++ b/src/Dataverse/Solution/README.md
@@ -1,6 +1,6 @@
 # TALXIS.DevKit.Build.Dataverse.Solution
 
-MSBuild integration for building complete Dataverse solutions. Orchestrates the entire solution build pipeline: discovers and builds referenced Plugin, WorkflowActivity, ScriptLibrary, CodeApp, and PCF projects; patches solution XML with version, publisher, and managed state; supports manual invocation of schema validation targets for solution metadata against XSD/JSON schemas; runs the PAC solution packager to produce a `.zip` file; and supports `dotnet pack` to generate a NuGet package containing the solution zip.
+MSBuild integration for building complete Dataverse solutions. Orchestrates the entire solution build pipeline: discovers and builds referenced Plugin, WorkflowActivity, ScriptLibrary, CodeApp, and PCF projects; patches solution XML with version, publisher, and managed state; supports manual invocation of schema validation targets for solution metadata against XSD/JSON schemas; runs the shared tasks package's SolutionPackagerLib-based packager to produce a `.zip` file; and supports `dotnet pack` to generate a NuGet package containing the solution zip.
 
 ## Installation
 
@@ -41,9 +41,9 @@ The package sets `ProjectType` to `Solution` and imports `Microsoft.PowerApps.MS
 
 `PatchSolutionXml` writes `Version` (use `ApplyVersionNumber` instead, see below), `Managed`, `PublisherName`, and `PublisherPrefix` into `Solution.xml` (all optional).
 
-### 5. PAC override and versioning
+### 5. Solution packaging override and versioning
 
-`ProcessCdsProjectReferencesOutputs` replaces the Microsoft default to filter ScriptLibrary, CodeApp, and WorkflowActivity references from PAC processing. Then `GenerateVersionNumber` and `ApplyVersionNumber` patch the version across all solution metadata.
+`ProcessCdsProjectReferencesOutputs` replaces the Microsoft default to filter ScriptLibrary, CodeApp, and WorkflowActivity references from solution packaging processing. Then `GenerateVersionNumber` and `ApplyVersionNumber` patch the version across all solution metadata.
 
 ### 6. Schema validation (manual)
 
@@ -54,7 +54,7 @@ The package sets `ProjectType` to `Solution` and imports `Microsoft.PowerApps.MS
 
 ### 7. Solution packaging
 
-`PowerAppsPackage` invokes the PAC solution packager to produce the output `.zip`.
+`PowerAppsPackage` invokes the tasks package's SolutionPackagerLib-based packager to produce the output `.zip`.
 
 ### 8. NuGet packing
 
@@ -93,7 +93,7 @@ The package sets `ProjectType` to `Solution` and imports `Microsoft.PowerApps.MS
 | Property | Default | Description |
 |----------|---------|-------------|
 | `WebResourcesDir` | `$(MSBuildProjectDirectory)\$(SolutionRootPath)\WebResources\` | Destination folder for script library web resources. |
-| `PcfForceUpdate` | _(none)_ | Forwarded to PAC `ProcessCdsProjectReferencesOutputs` to force PCF updates. |
+| `PcfForceUpdate` | _(none)_ | Forwarded to `ProcessCdsProjectReferencesOutputs` to force PCF updates before solution packaging. |
 
 ### Validation
 

--- a/src/Dataverse/Solution/TALXIS.DevKit.Build.Dataverse.Solution.csproj
+++ b/src/Dataverse/Solution/TALXIS.DevKit.Build.Dataverse.Solution.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <AssemblyName>TALXIS.DevKit.Build.Dataverse.Solution</AssemblyName>
-        <!-- https://github.com/dotnet/vscode-csharp/issues/5786 -->
-        <!-- <TargetFrameworks>net462;$(NetMinimum);$(NetCurrent)</TargetFrameworks> -->
-        <TargetFrameworks>net472;net6.0</TargetFrameworks>
+        <TargetFramework>net10.0</TargetFramework>
         <!-- Pack settings -->
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <IsPackable>true</IsPackable>
@@ -17,8 +15,8 @@
         <NuspecProperties>Version=$(Version);MicrosoftPowerAppsTargetsVersion=$(MicrosoftPowerAppsTargetsVersion)</NuspecProperties>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build" Version="16.11.6" />
-        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.11.6" />
+        <PackageReference Include="Microsoft.Build" Version="18.0.2" />
+        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
         <!-- Do not add any of the dependencies above to nuspec -->
         <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
     </ItemGroup>

--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.OverridePAC.targets
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.OverridePAC.targets
@@ -60,7 +60,7 @@
              Condition="'@(_CodeAppProjects)'!=''" />
 
     <Message Importance="high"
-             Text="PAC refs after filtering: @(_CdsRefs->'%(FullPath)', ', ')"
+             Text="Solution packaging refs after filtering: @(_CdsRefs->'%(FullPath)', ', ')"
              Condition="'@(_CdsRefs)'!=''" />
 
     <ItemGroup>

--- a/src/Dataverse/Tasks/README.md
+++ b/src/Dataverse/Tasks/README.md
@@ -1,6 +1,6 @@
 # TALXIS.DevKit.Build.Dataverse.Tasks
 
-Core MSBuild tasks and targets library shared by all `TALXIS.DevKit.Build.Dataverse.*` packages. Provides custom C# MSBuild tasks for Git-based version generation, solution XML patching, solution packaging via PAC CLI, schema validation, CMT data merging, code app metadata generation, and web resource management. Most users do not reference this package directly -- it is pulled in as a dependency of the higher-level packages (`Plugin`, `Solution`, `Pcf`, etc.).
+Core MSBuild tasks and targets library shared by all `TALXIS.DevKit.Build.Dataverse.*` packages. Provides custom C# MSBuild tasks for Git-based version generation, solution XML patching, solution packaging via SolutionPackagerLib, schema validation, CMT data merging, code app metadata generation, and web resource management. Most users do not reference this package directly -- it is pulled in as a dependency of the higher-level packages (`Plugin`, `Solution`, `Pcf`, etc.).
 
 ## Installation
 
@@ -12,7 +12,7 @@ Typically this package is referenced transitively through one of the component p
 
 ## How It Works
 
-The package ships compiled task assemblies for `net472` and `net6.0`. At build time, the correct assembly is selected based on `MSBuildRuntimeType` (Core vs Full Framework).
+The package ships a single `net10.0` task assembly and requires an MSBuild 18+ .NET task host. The bundled targets register each task with `Runtime="NET"` so packaging and validation always execute in the modern .NET host.
 
 ### Registered MSBuild tasks
 
@@ -30,7 +30,7 @@ The package ships compiled task assemblies for `net472` and `net6.0`. At build t
 - **GenerateVersionNumber** -- requires the `Version` property. Runs `GenerateGitVersion` using the major/minor from `Version`, the current Git branch, and `GitVersionNumberBranches` rules to produce a full four-part version number.
 - **ApplyVersionNumber** -- patches the generated version into solution metadata folders (`SolutionXml`, `PluginAssemblies`, `Workflows`, `Controls`, `SdkMessageProcessingSteps`).
 - **ApplyPcfVersionNumber** -- updates the version in `ControlManifest.xml` for PCF controls.
-- **PackDataverseSolution** -- invokes the PAC solution packager to produce a `.zip` from the working directory.
+- **PackDataverseSolution** -- invokes SolutionPackagerLib to produce a `.zip` from the working directory without shelling out to `pac.exe`.
 - **ValidateSolutionComponentSchema** -- validates all solution XML files against bundled XSD schemas (22 schemas covering Solution, Entity, Form, Ribbon, Relationship, AppModule, Sitemap, OptionSet, Workflow, PluginAssembly, and more) and JSON files against JSON schemas (`Flow.schema.json` for Power Automate flows). Runs in batch mode -- collects all errors across all files before failing the build, with MSBuild-canonical error format (`file(line,col): error CODE: message`) for IDE click-through support.
 - **InitializeSolutionPackagerWorkingDirectory** -- copies solution source files into the intermediate working directory for packaging.
 - **CleanupWorkingDirectory** -- removes temporary localization and working directories after build.

--- a/src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj
+++ b/src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj
@@ -36,6 +36,10 @@
             <HintPath>$(PkgMicrosoft_PowerApps_CLI_Core_linux-x64)\tools\SolutionPackagerLib.dll</HintPath>
             <Private>true</Private>
         </Reference>
+        <Reference Include="System.IO.Packaging">
+            <HintPath>$(PkgMicrosoft_PowerApps_CLI_Core_linux-x64)\tools\System.IO.Packaging.dll</HintPath>
+            <Private>true</Private>
+        </Reference>
     </ItemGroup>
     <PropertyGroup>
         <Authors>TALXIS</Authors>

--- a/src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj
+++ b/src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj
@@ -2,9 +2,7 @@
     <!-- Based on https://github.com/GitTools/GitVersion/blob/b874c3fcd4064f883897a27cedc1b89930e10670/src/GitVersion.MsBuild/GitVersion.MsBuild.csproj -->
     <PropertyGroup>
         <AssemblyName>TALXIS.DevKit.Build.Dataverse.Tasks</AssemblyName>
-        <!-- https://github.com/dotnet/vscode-csharp/issues/5786 -->
-        <!-- <TargetFrameworks>net462;$(NetMinimum);$(NetCurrent)</TargetFrameworks> -->
-        <TargetFrameworks>net472;net6.0</TargetFrameworks>
+        <TargetFramework>net10.0</TargetFramework>
         <!-- Pack settings -->
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <IsPackable>true</IsPackable>
@@ -19,20 +17,25 @@
         <LangVersion>latest</LangVersion>
 
         <IncludeBuildOutput>false</IncludeBuildOutput>
-        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
     <ItemGroup>
         <!--<PackageReference Include="LibGit2Sharp" Version="0.26.2" />-->
-        <PackageReference Include="Microsoft.Build" Version="16.11.6" />
-        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.11.6" />
-        <!-- <PackageReference Include="Microsoft.PowerApps.CLI.Core.osx-x64" Version="*" /> -->
+        <PackageReference Include="Microsoft.Build" Version="18.0.2" />
+        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
+        <PackageReference Include="Microsoft.PowerApps.CLI.Core.linux-x64" Version="2.6.4" GeneratePathProperty="true" ExcludeAssets="all" />
         <PackageReference Include="TALXIS.Platform.Metadata" Version="0.6.0" />
         <PackageReference Include="TALXIS.Platform.Metadata.Validation" Version="0.6.0" />
         <PackageReference Include="TALXIS.Platform.Metadata.Serialization.Xml" Version="0.6.0" />
 
         <!-- Do not add any of the dependencies above to nuspec -->
         <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
+    </ItemGroup>
+    <ItemGroup>
+        <Reference Include="SolutionPackagerLib">
+            <HintPath>$(PkgMicrosoft_PowerApps_CLI_Core_linux-x64)\tools\SolutionPackagerLib.dll</HintPath>
+            <Private>true</Private>
+        </Reference>
     </ItemGroup>
     <PropertyGroup>
         <Authors>TALXIS</Authors>

--- a/src/Dataverse/Tasks/Tasks/GenerateCodeAppMetaXml.cs
+++ b/src/Dataverse/Tasks/Tasks/GenerateCodeAppMetaXml.cs
@@ -277,7 +277,7 @@ public sealed class GenerateCodeAppMetaXml : Task
     }
 
     /// <summary>
-    /// Compatible replacement for Path.GetRelativePath (not available in net472).
+    /// Portable replacement for Path.GetRelativePath to preserve existing behavior.
     /// </summary>
     private static string MakeRelativePath(string basePath, string fullPath)
     {

--- a/src/Dataverse/Tasks/Tasks/InvokeSolutionPackager.cs
+++ b/src/Dataverse/Tasks/Tasks/InvokeSolutionPackager.cs
@@ -1,243 +1,144 @@
+using System;
+using System.Diagnostics;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
+using Microsoft.Crm.Tools.SolutionPackager;
 
 public class InvokeSolutionPackager : Task
 {
-	[Required]
-	public string Action { get; set; }
+    [Required]
+    public string Action { get; set; } = string.Empty;
 
-	public string PackageType { get; set; }
+    public string PackageType { get; set; } = string.Empty;
 
-	public string SolutionRootDirectory { get; set; }
+    public string SolutionRootDirectory { get; set; } = string.Empty;
 
-	[Required]
-	public string PathToZipFile { get; set; }
+    [Required]
+    public string PathToZipFile { get; set; } = string.Empty;
 
-	public string ErrorLevel { get; set; } = "Info";
+    public string ErrorLevel { get; set; } = nameof(TraceLevel.Info);
 
-	public string LogFilePath { get; set; }
+    public string LogFilePath { get; set; } = string.Empty;
 
-	public string MappingFilePath { get; set; }
+    public string MappingFilePath { get; set; } = string.Empty;
 
-	public bool Localize { get; set; }
+    public bool Localize { get; set; }
 
-	public string LocalTemplate { get; set; }
+    public string LocalTemplate { get; set; } = string.Empty;
 
-	public bool UseUnmanagedFileForMissingManaged { get; set; }
+    public bool UseUnmanagedFileForMissingManaged { get; set; }
 
-	private string ResolvePACFilePath()
-	{
-		bool isWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+    public override bool Execute()
+    {
+        try
+        {
+            var arguments = BuildArguments();
+            if (arguments == null)
+            {
+                return false;
+            }
 
-		var candidates = isWindows
-			? new[] { "pac.exe", "pac.cmd" }
-			: new[] { "pac" };
+            var packager = new SolutionPackager(arguments);
+            packager.Run();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.LogError($"SolutionPackager {Action.ToLowerInvariant()} failed: {ex.Message}");
 
-		// Check the standalone Power Platform CLI location first (preferred, supports latest versions)
-		if (isWindows)
-		{
-			var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-			foreach (var name in candidates)
-			{
-				var standalonePath = Path.Combine(localAppData, "Microsoft", "PowerAppsCLI", name);
-				if (File.Exists(standalonePath))
-					return standalonePath;
-			}
-		}
+            if (!string.IsNullOrWhiteSpace(LogFilePath) && System.IO.File.Exists(LogFilePath))
+            {
+                Log.LogError($"Full log available at: {LogFilePath}");
+            }
 
-		// Check the standard global tools location
-		var toolsDir = Path.Combine(
-			Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-			".dotnet", "tools");
+            return false;
+        }
+    }
 
-		foreach (var name in candidates)
-		{
-			var globalToolPath = Path.Combine(toolsDir, name);
-			if (File.Exists(globalToolPath))
-				return globalToolPath;
-		}
+    private PackagerArguments BuildArguments()
+    {
+        if (!TryParsePackageType(out var packageType))
+        {
+            return null;
+        }
 
-		// Fall back to searching PATH
-		var pathEnv = Environment.GetEnvironmentVariable("PATH");
-		
-		if (!string.IsNullOrEmpty(pathEnv))
-		{
-			var separator = isWindows ? ';' : ':';
-			
-			foreach (var name in candidates)
-			{
-				var found = pathEnv.Split(new[] { separator }, StringSplitOptions.RemoveEmptyEntries)
-					.Select(dir => dir.Trim().Trim('"'))
-					.Where(dir => dir.Length > 0 && Directory.Exists(dir))
-					.Select(dir => Path.Combine(dir, name))
-					.FirstOrDefault(File.Exists);
+        if (!Enum.TryParse(ErrorLevel, ignoreCase: true, out TraceLevel errorLevel))
+        {
+            Log.LogError($"Unsupported error level: {ErrorLevel}");
+            return null;
+        }
 
-				if (found != null)
-					return found;
-			}
-		}
+        PackagerArguments arguments;
 
-		return null;
-	}
+        switch (Action.ToLowerInvariant())
+        {
+            case "pack":
+                arguments = new PackagerArguments
+                {
+                    Action = CommandAction.Pack,
+                    PathToZipFile = PathToZipFile,
+                    Folder = SolutionRootDirectory,
+                    PackageType = packageType,
+                    ErrorLevel = errorLevel,
+                    Localize = Localize,
+                    ProcessCanvasApps = true,
+                    UseUnmanagedFileForManaged = UseUnmanagedFileForMissingManaged,
+                };
+                break;
+            case "unpack":
+                arguments = new PackagerArguments
+                {
+                    Action = CommandAction.Extract,
+                    PathToZipFile = PathToZipFile,
+                    Folder = SolutionRootDirectory,
+                    PackageType = packageType,
+                    AllowDeletes = AllowDelete.Yes,
+                    AllowWrites = AllowWrite.Yes,
+                    ErrorLevel = errorLevel,
+                    Localize = Localize,
+                    ProcessCanvasApps = true,
+                };
+                break;
+            default:
+                Log.LogError($"Unsupported action: {Action}");
+                return null;
+        }
 
-	public override bool Execute()
-	{
-		var pacPath = ResolvePACFilePath();
-		if (pacPath == null)
-		{
-			Log.LogError("The pac tool is not found. Please install it using 'dotnet tool install --global Microsoft.PowerApps.CLI.Tool'");
-			return false;
-		}
+        if (!string.IsNullOrWhiteSpace(MappingFilePath))
+        {
+            arguments.MappingFile = MappingFilePath;
+        }
 
-		var args = BuildArguments();
-		if (string.IsNullOrWhiteSpace(args))
-		{
-			Log.LogError("Failed to build arguments for pac command.");
-			return false;
-		}
+        if (!string.IsNullOrWhiteSpace(LogFilePath))
+        {
+            arguments.LogFile = LogFilePath;
+        }
 
-		return RunCommand(pacPath, args);
-	}
+        if (!string.IsNullOrWhiteSpace(LocalTemplate))
+        {
+            arguments.LocaleTemplate = LocalTemplate;
+        }
 
-	private string BuildArguments()
-	{
-		string args = string.Empty;
+        return arguments;
+    }
 
-		switch (Action.ToLower())
-		{
-			case "pack":
-				args += "solution pack";
-				break;
-			case "unpack":
-				args += "solution unpack";
-				break;
-			default:
-				Log.LogError($"Unsupported action: {Action}");
-				return null;
-		}
+    private bool TryParsePackageType(out SolutionPackageType packageType)
+    {
+        if (string.IsNullOrWhiteSpace(PackageType) ||
+            string.Equals(PackageType, "Unmanaged", StringComparison.OrdinalIgnoreCase))
+        {
+            packageType = SolutionPackageType.Unmanaged;
+            return true;
+        }
 
-		args += $" --zipfile \"{PathToZipFile}\"";
-		args += $" --folder \"{SolutionRootDirectory}\"";
-		args += $" --errorlevel {ErrorLevel}";
+        if (string.Equals(PackageType, "Managed", StringComparison.OrdinalIgnoreCase))
+        {
+            packageType = SolutionPackageType.Managed;
+            return true;
+        }
 
-		if (!string.IsNullOrWhiteSpace(PackageType))
-			args += $" --packagetype {PackageType}";
-
-		if (!string.IsNullOrWhiteSpace(LogFilePath))
-			args += $" --log \"{LogFilePath}\"";
-
-		if (!string.IsNullOrWhiteSpace(MappingFilePath))
-			args += $" --map \"{MappingFilePath}\"";
-
-		if (Localize)
-		{
-			args += " --localize";
-			if (!string.IsNullOrWhiteSpace(LocalTemplate))
-				args += $" --sourceLoc {LocalTemplate}";
-		}
-
-		if (UseUnmanagedFileForMissingManaged)
-			args += " --useUnmanagedFileForMissingManaged";
-
-		args += " --processCanvasApps";
-
-		return args;
-	}
-
-	private bool RunCommand(string fileName, string arguments)
-	{
-		try
-		{
-			var stdoutLines = new System.Collections.Generic.List<string>();
-			var stderrLines = new System.Collections.Generic.List<string>();
-
-			ProcessStartInfo processStartInfo = new ProcessStartInfo
-			{
-				FileName = fileName,
-				Arguments = arguments,
-				UseShellExecute = false,
-				RedirectStandardOutput = true,
-				RedirectStandardError = true,
-				CreateNoWindow = true
-			};
-
-			using (Process process = new Process { StartInfo = processStartInfo })
-			{
-				process.OutputDataReceived += (sender, e) =>
-				{
-					if (!string.IsNullOrWhiteSpace(e.Data))
-					{
-						stdoutLines.Add(e.Data);
-						Log.LogMessage(MessageImportance.High, e.Data);
-					}
-				};
-
-				process.ErrorDataReceived += (sender, e) =>
-				{
-					if (!string.IsNullOrWhiteSpace(e.Data))
-					{
-						stderrLines.Add(e.Data);
-						Log.LogWarning(e.Data);
-					}
-				};
-
-				process.Start();
-				process.BeginOutputReadLine();
-				process.BeginErrorReadLine();
-				process.WaitForExit();
-
-				if (process.ExitCode != 0)
-				{
-					var errorDetails = stderrLines.Count > 0
-						? string.Join(Environment.NewLine, stderrLines)
-						: null;
-
-					var outputErrors = stdoutLines
-						.Where(l => l.IndexOf("error", StringComparison.OrdinalIgnoreCase) >= 0
-							|| l.IndexOf("missing", StringComparison.OrdinalIgnoreCase) >= 0
-							|| l.IndexOf("failed", StringComparison.OrdinalIgnoreCase) >= 0
-							|| l.IndexOf("invalid", StringComparison.OrdinalIgnoreCase) >= 0
-							|| l.IndexOf("not found", StringComparison.OrdinalIgnoreCase) >= 0
-							|| l.IndexOf("exception", StringComparison.OrdinalIgnoreCase) >= 0)
-						.ToList();
-
-					if (outputErrors.Count > 0)
-					{
-						var relevantOutput = string.Join(Environment.NewLine, outputErrors);
-						errorDetails = errorDetails != null
-							? errorDetails + Environment.NewLine + relevantOutput
-							: relevantOutput;
-					}
-
-					if (!string.IsNullOrWhiteSpace(errorDetails))
-					{
-						Log.LogError($"PAC solution {Action.ToLower()} failed (exit code {process.ExitCode}):{Environment.NewLine}{errorDetails}");
-					}
-					else
-					{
-						Log.LogError($"PAC solution {Action.ToLower()} failed (exit code {process.ExitCode}). No error details captured from output.");
-					}
-
-					if (!string.IsNullOrWhiteSpace(LogFilePath) && File.Exists(LogFilePath))
-					{
-						Log.LogError($"Full log available at: {LogFilePath}");
-					}
-
-					return false;
-				}
-
-				return true;
-			}
-		}
-		catch (Exception ex)
-		{
-			Log.LogError($"Failed to run the PAC CLI command. Error: {ex.Message}");
-			return false;
-		}
-	}
+        Log.LogError($"Unsupported package type: {PackageType}");
+        packageType = default;
+        return false;
+    }
 }

--- a/src/Dataverse/Tasks/Tasks/InvokeSolutionPackager.cs
+++ b/src/Dataverse/Tasks/Tasks/InvokeSolutionPackager.cs
@@ -44,7 +44,8 @@ public class InvokeSolutionPackager : Task
         }
         catch (Exception ex)
         {
-            Log.LogError($"SolutionPackager {Action.ToLowerInvariant()} failed: {ex.Message}");
+            Log.LogError($"SolutionPackager {Action.ToLowerInvariant()} failed.");
+            Log.LogErrorFromException(ex, showStackTrace: true);
 
             if (!string.IsNullOrWhiteSpace(LogFilePath) && System.IO.File.Exists(LogFilePath))
             {
@@ -81,7 +82,6 @@ public class InvokeSolutionPackager : Task
                     PackageType = packageType,
                     ErrorLevel = errorLevel,
                     Localize = Localize,
-                    ProcessCanvasApps = true,
                     UseUnmanagedFileForManaged = UseUnmanagedFileForMissingManaged,
                 };
                 break;
@@ -96,7 +96,6 @@ public class InvokeSolutionPackager : Task
                     AllowWrites = AllowWrite.Yes,
                     ErrorLevel = errorLevel,
                     Localize = Localize,
-                    ProcessCanvasApps = true,
                 };
                 break;
             default:

--- a/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.targets
@@ -6,8 +6,7 @@
     <PropertyGroup>
         <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
 
-        <ThisPackageBuildExtensionsDirectory Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)net6.0\</ThisPackageBuildExtensionsDirectory>
-        <ThisPackageBuildExtensionsDirectory Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)net472\</ThisPackageBuildExtensionsDirectory>
+        <ThisPackageBuildExtensionsDirectory>$(MSBuildThisFileDirectory)net10.0\</ThisPackageBuildExtensionsDirectory>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -15,33 +14,33 @@
     </PropertyGroup>
 
 
-    <UsingTask TaskName="GenerateGitVersion" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ApplyVersionNumber" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ApplyPcfVersionNumber" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ApplyPluginVersionNumberInSolution" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="InvokeSolutionPackager" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ValidateXmlFiles" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ValidateJsonFiles" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="RetrieveProjectReferences" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="EnsureWebResourceDataXml" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="AddRootComponentToSolution" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="EnsurePluginAssemblyDataXml" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="EnsureWorkflowActivityAssemblyDataXml" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="EnsureCustomizationsNode" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="PatchSolutionXml" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="MergeCmtDataXml" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="MergeCmtDataSchemaXml" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="AppendCmtDataFileToImportConfig" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ResolveWebResourceName" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="PostProcessImportConfig" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="GenerateCodeAppMetaXml" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ValidateDuplicateGuids" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ValidateQuickFindViews" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="EnsureAllCustomizationsNodes" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ValidatePcfDependencies" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="ValidateWorkspace" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="PatchGenPageCompiledCode" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="GenerateGenPageConfigJson" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="GenerateGenPageProjectXml" AssemblyFile="$(TasksAssembly)" />
-    <UsingTask TaskName="GenerateGenPageFileXml" AssemblyFile="$(TasksAssembly)" />
+    <UsingTask TaskName="GenerateGitVersion" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ApplyVersionNumber" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ApplyPcfVersionNumber" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ApplyPluginVersionNumberInSolution" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="InvokeSolutionPackager" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ValidateXmlFiles" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ValidateJsonFiles" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="RetrieveProjectReferences" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="EnsureWebResourceDataXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="AddRootComponentToSolution" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="EnsurePluginAssemblyDataXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="EnsureWorkflowActivityAssemblyDataXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="EnsureCustomizationsNode" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="PatchSolutionXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="MergeCmtDataXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="MergeCmtDataSchemaXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="AppendCmtDataFileToImportConfig" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ResolveWebResourceName" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="PostProcessImportConfig" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="GenerateCodeAppMetaXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ValidateDuplicateGuids" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ValidateQuickFindViews" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="EnsureAllCustomizationsNodes" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ValidatePcfDependencies" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ValidateWorkspace" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="PatchGenPageCompiledCode" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="GenerateGenPageConfigJson" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="GenerateGenPageProjectXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="GenerateGenPageFileXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
 </Project>

--- a/src/Dataverse/WorkflowActivity/TALXIS.DevKit.Build.Dataverse.WorkflowActivity.csproj
+++ b/src/Dataverse/WorkflowActivity/TALXIS.DevKit.Build.Dataverse.WorkflowActivity.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <AssemblyName>TALXIS.DevKit.Build.Dataverse.WorkflowActivity</AssemblyName>
-        <!-- https://github.com/dotnet/vscode-csharp/issues/5786 -->
-        <!-- <TargetFrameworks>net462;$(NetMinimum);$(NetCurrent)</TargetFrameworks> -->
-        <TargetFrameworks>net472;net6.0</TargetFrameworks>
+        <TargetFramework>net10.0</TargetFramework>
         <!-- Pack settings -->
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <IsPackable>true</IsPackable>
@@ -17,8 +15,8 @@
         <NuspecProperties>Version=$(Version);MicrosoftPowerAppsTargetsVersion=$(MicrosoftPowerAppsTargetsVersion)</NuspecProperties>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build" Version="16.11.6" />
-        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.11.6" />
+        <PackageReference Include="Microsoft.Build" Version="18.0.2" />
+        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
         <!-- Do not add any of the dependencies above to nuspec -->
         <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
     </ItemGroup>

--- a/src/Sdk/TALXIS.DevKit.Build.Sdk.csproj
+++ b/src/Sdk/TALXIS.DevKit.Build.Sdk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version Condition="'$(Version)'==''">0.0.1</Version>
     <NuspecFile>TALXIS.DevKit.Build.Sdk.nuspec</NuspecFile>


### PR DESCRIPTION
## Summary
- move the Dataverse build packages to a `net10.0` / MSBuild 18 baseline
- register the tasks package for the modern .NET MSBuild host and remove the `net472`/`net6.0` split
- replace `pac.exe` process execution with direct `SolutionPackagerLib` invocation inside `InvokeSolutionPackager`
- refresh task and solution docs to describe the new host/runtime model

## Validation
- `git diff --check`
- `python3` XML parse of the modified `.csproj` and `.targets` files
- confirmed targeted upgrades landed with grep (`net472;net6.0` and `16.11.6` removed from the upgraded build packages)
- attempted repo build with .NET 10 / MSBuild 18, but restore is blocked in this environment by `NuGet-Migrations` trying to open `/tmp/.dotnet/shm` (`EPERM`)

## Remaining blocker
`TALXIS.Platform.Metadata.Packaging` from TALXIS/platform-metadata#48 and #66 still is not published on NuGet, so this repo cannot yet switch to that shared package dependency in a shippable way. This PR still removes the `pac.exe` dependency now by invoking `SolutionPackagerLib` directly, which keeps the build tasks aligned with the upstream packaging abstraction and unblocks the net10/MSBuild18 host upgrade.