### PR TITLE
fix: script library builds twice during solution build

### DIFF
--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.GenPages.targets
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.GenPages.targets
@@ -3,7 +3,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Target Name="ProbeGenPages"
-          BeforeTargets="PrepareProjectReferences;ResolveProjectReferences;BuildGenPages"
+          BeforeTargets="AssignProjectConfiguration;PrepareProjectReferences;ResolveProjectReferences;BuildGenPages"
           Condition="'@(ProjectReference)'!='' and '@(_GenPageProjects)'==''">
 
     <!-- Reset accumulators: <Output ItemName="..."> appends across target

--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.ScriptLibraries.targets
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.ScriptLibraries.targets
@@ -3,7 +3,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Target Name="ProbeScriptLibraries"
-          BeforeTargets="PrepareProjectReferences;ResolveProjectReferences;BuildScriptLibraries"
+          BeforeTargets="AssignProjectConfiguration;PrepareProjectReferences;ResolveProjectReferences;BuildScriptLibraries"
           Condition="'@(ProjectReference)'!='' and '@(_ScriptLibraryProjects)'==''">
 
     <!-- Reset accumulators: <Output ItemName="..."> appends across target


### PR DESCRIPTION
Script library projects were getting built twice when a solution referenced them. Once as a normal project reference, and again through GetScriptLibraryOutputs.

The probe target that pulls script libraries out of the reference list was running too late. By the time it removed them, AssignProjectConfiguration had already snapshotted the references, so the standard build picked them up anyway. Moved the probe to run before AssignProjectConfiguration so the removal actually sticks. 

Same fix applied to gen pages.