### PR TITLE
Add GenerateWebResources and ApplyPublisherPrefixToWebResource flags

### DIFF
--- a/src/Dataverse/Solution/msbuild/build/TALXIS.DevKit.Build.Dataverse.Solution.props
+++ b/src/Dataverse/Solution/msbuild/build/TALXIS.DevKit.Build.Dataverse.Solution.props
@@ -4,5 +4,7 @@
   <PropertyGroup>
     <ProjectType Condition="'$(ProjectType)'==''">Solution</ProjectType>
     <GeneratePluginAssembly Condition="'$(GeneratePluginAssembly)'==''">true</GeneratePluginAssembly>
+    <GenerateWebResources Condition="'$(GenerateWebResources)'==''">true</GenerateWebResources>
+    <ApplyPublisherPrefixToWebResource Condition="'$(ApplyPublisherPrefixToWebResource)'==''">true</ApplyPublisherPrefixToWebResource>
   </PropertyGroup>
 </Project>

--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.ScriptLibraries.targets
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.ScriptLibraries.targets
@@ -110,7 +110,8 @@
     <MakeDir Directories="$(WebResourcesDir)" />
 
     <ResolveWebResourceName Files="@(_ScriptLibraryOutputs)"
-                            PublisherPrefix="$(PublisherPrefix)">
+                            PublisherPrefix="$(PublisherPrefix)"
+                            ApplyPrefix="$(ApplyPublisherPrefixToWebResource)">
       <Output TaskParameter="ResolvedFiles" ItemName="_ResolvedScriptFiles" />
     </ResolveWebResourceName>
 
@@ -123,7 +124,7 @@
       </_ScriptFilesToCopy>
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(GenerateWebResources)'=='true'">
       <_ScriptFilesMissingDataXml Include="@(_ScriptFilesToCopy)"
                                   Condition="!Exists('%(DataXmlFile)')">
       </_ScriptFilesMissingDataXml>
@@ -131,18 +132,19 @@
 
     <Message Importance="high"
              Text="Generate webresource data.xml: @(_ScriptFilesMissingDataXml->'%(DataXmlFile)', ', ')"
-             Condition="'@(_ScriptFilesMissingDataXml)'!=''" />
+             Condition="'@(_ScriptFilesMissingDataXml)'!='' and '$(GenerateWebResources)'=='true'" />
 
     <EnsureWebResourceDataXml DataXmlFile="%(_ScriptFilesMissingDataXml.DataXmlFile)"
                               WebResourceName="%(_ScriptFilesMissingDataXml.WebResourceName)"
                               DisplayName="%(_ScriptFilesMissingDataXml.DisplayName)"
-                              Condition="'@(_ScriptFilesMissingDataXml)'!=''" />
+                              Condition="'@(_ScriptFilesMissingDataXml)'!='' and '$(GenerateWebResources)'=='true'" />
 
     <AddRootComponentToSolution
         SolutionPath="$(ProjectDir)$(SolutionRootPath)\Other\Solution.xml"
         Type="61"
         SchemaName="%(_ScriptFilesToCopy.WebResourceName)"
         Behavior="0"
+        Condition="'$(GenerateWebResources)'=='true'"
       />
   </Target>
 

--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.props
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.props
@@ -3,5 +3,7 @@
   <PropertyGroup>
     <ProjectType Condition="'$(ProjectType)'==''">Solution</ProjectType>
     <GeneratePluginAssembly Condition="'$(GeneratePluginAssembly)'==''">true</GeneratePluginAssembly>
+    <GenerateWebResources Condition="'$(GenerateWebResources)'==''">true</GenerateWebResources>
+    <ApplyPublisherPrefixToWebResource Condition="'$(ApplyPublisherPrefixToWebResource)'==''">true</ApplyPublisherPrefixToWebResource>
   </PropertyGroup>
 </Project>

--- a/src/Dataverse/Tasks/Tasks/ResolveWebResourceName.cs
+++ b/src/Dataverse/Tasks/Tasks/ResolveWebResourceName.cs
@@ -11,6 +11,8 @@ public class ResolveWebResourceName : Task
     [Required]
     public string PublisherPrefix { get; set; } = "";
 
+    public bool ApplyPrefix { get; set; } = true;
+
     [Output]
     public ITaskItem[] ResolvedFiles { get; set; } = Array.Empty<ITaskItem>();
 
@@ -28,6 +30,19 @@ public class ResolveWebResourceName : Task
 
                 string resolvedName;
                 string displayName;
+
+                if (!ApplyPrefix)
+                {
+                    resolvedName = fileName;
+                    displayName = fileName;
+
+                    var rawItem = new TaskItem(filePath);
+                    rawItem.SetMetadata("ResolvedName", resolvedName);
+                    rawItem.SetMetadata("DisplayName", displayName);
+                    results.Add(rawItem);
+
+                    continue;
+                }
 
                 int underscoreIndex = fileName.IndexOf('_');
 


### PR DESCRIPTION
Adds two MSBuild flags to the Solution so you can control how script libraries get turned into web resources.

ApplyPublisherPrefixToWebResource (default true) controls naming. When it's off, ResolveWebResourceName keeps the original file name as-is instead of splitting on the first underscore and forcing the publisher prefix

GenerateWebResources (default true) gates the whole data.xml + root-component step. Set it to false and the build skips writing the generated data.xml files and stops adding the web resources to Solution.xml