### PR TITLE
refactor: float Validation to 0.6.* and slim ValidateDuplicateGuids

### DIFF
--- a/src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj
+++ b/src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj
@@ -23,9 +23,9 @@
         <!--<PackageReference Include="LibGit2Sharp" Version="0.26.2" />-->
         <PackageReference Include="Microsoft.Build" Version="18.0.2" />
         <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
-        <PackageReference Include="TALXIS.Platform.Metadata" Version="0.6.0" />
-        <PackageReference Include="TALXIS.Platform.Metadata.Validation" Version="0.6.0" />
-        <PackageReference Include="TALXIS.Platform.Metadata.Serialization.Xml" Version="0.6.0" />
+        <PackageReference Include="TALXIS.Platform.Metadata" Version="0.6.*" />
+        <PackageReference Include="TALXIS.Platform.Metadata.Validation" Version="0.6.*" />
+        <PackageReference Include="TALXIS.Platform.Metadata.Serialization.Xml" Version="0.6.*" />
         <PackageReference Include="TALXIS.Platform.Metadata.Packaging" Version="0.7.0" />
 
         <!-- Do not add any of the dependencies above to nuspec -->

--- a/src/Dataverse/Tasks/Tasks/ValidateDuplicateGuids.cs
+++ b/src/Dataverse/Tasks/Tasks/ValidateDuplicateGuids.cs
@@ -8,8 +8,6 @@ using TALXIS.Platform.Metadata.Validation;
 
 public class ValidateDuplicateGuids : Task
 {
-    private const string _managedSuffix = "_managed";
-
     [Required]
     public ITaskItem[] FilesForValidation { get; set; }
 
@@ -42,7 +40,6 @@ public class ValidateDuplicateGuids : Task
             var validator = new GuidValidator();
             var results = validator.ValidateDirectory(workspacePath)
                 .Where(r => r.FilePath == null || allowedFiles.Contains(Path.GetFullPath(r.FilePath)))
-                .Where(r => r.FilePath == null || !HasManagedUnmanagedTwin(r.FilePath))
                 .ToList();
 
             foreach (var result in results)
@@ -85,38 +82,6 @@ public class ValidateDuplicateGuids : Task
             Log.LogErrorFromException(ex);
             return false;
         }
-    }
-
-    /// <summary>
-    /// Returns true if <paramref name="filePath"/> is one half of a
-    /// managed/unmanaged pair, i.e. the corresponding `*_managed.xml` (or
-    /// non-managed `*.xml`) sibling exists next to it in the same directory.
-    /// </summary>
-    private static bool HasManagedUnmanagedTwin(string filePath)
-    {
-        if (string.IsNullOrEmpty(filePath)) return false;
-
-        var directory = Path.GetDirectoryName(filePath);
-
-        if (string.IsNullOrEmpty(directory)) return false;
-
-        var nameNoExt = Path.GetFileNameWithoutExtension(filePath);
-        var ext = Path.GetExtension(filePath);
-
-        string twinName;
-
-        if (nameNoExt.EndsWith(_managedSuffix, StringComparison.OrdinalIgnoreCase))
-        {
-            twinName = nameNoExt.Substring(0, nameNoExt.Length - _managedSuffix.Length);
-        }
-        else
-        {
-            twinName = nameNoExt + _managedSuffix;
-        }
-
-        var twinPath = Path.Combine(directory, twinName + ext);
-
-        return File.Exists(twinPath);
     }
 
     private static string GetCommonDirectory(System.Collections.Generic.List<string> filePaths, StringComparer comparer, StringComparison comparison)


### PR DESCRIPTION
The managed/unmanaged twin filtering moved into GuidValidator in the [platform-metadata](https://github.com/TALXIS/platform-metadata/pull/69) so the ValidateDuplicateGuids task doesn't need its own copy. Drops the local validation and just consumes the library result.

Floats the TALXIS.Platform.Metadata reference to 0.6.* so it picks up that fix, plus the schema and relationship changes, once the library ships.