### PR TITLE
fix: detect .git file in TryFindGitRoot for worktree support

### DIFF
--- a/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
+++ b/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
@@ -292,7 +292,8 @@ public class GenerateGitVersion : Task
         var directory = new DirectoryInfo(path);
         while (directory != null)
         {
-            if (Directory.Exists(Path.Combine(directory.FullName, ".git")))
+            var gitPath = Path.Combine(directory.FullName, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 gitRoot = directory.FullName;
                 return true;


### PR DESCRIPTION
## Summary

Fixes #72 — `GenerateGitVersion` fails silently in git worktrees.

## Root cause

`TryFindGitRoot` traversed parent directories checking only `Directory.Exists(.git)`. In a git worktree, `.git` is a **file** (containing a `gitdir:` pointer), not a directory, so the check always failed and versioning silently fell back to `GitVersionNumberFallback`.

## Change

```csharp
// Before
if (Directory.Exists(Path.Combine(directory.FullName, ".git")))

// After
var gitPath = Path.Combine(directory.FullName, ".git");
if (Directory.Exists(gitPath) || File.Exists(gitPath))
```

One additional line to also check `File.Exists`. Git commands themselves were already working correctly in worktrees (since they use `WorkingDirectory = projectPath`); only root discovery was broken.

## Impact

- ✅ Normal checkouts: unchanged behavior
- ✅ Worktrees: git root now correctly detected, versioning works as expected