### PR TITLE
feat: allow overriding branch name for GenerateGitVersion via MSBuild property

### DIFF
--- a/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
+++ b/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
@@ -25,6 +25,7 @@ public class GenerateGitVersion : Task
     public string Version { get; set; }
     public string GitVersionNumberBranches { get; set; } // template "master;hotfix;develop:1;pr:3;other:0"
     public string GitVersionNumberFallback { get; set; }
+    public string GitVersionBranch { get; set; }
 
     [Output]
     public string VersionOutput { get; private set; }
@@ -56,7 +57,13 @@ public class GenerateGitVersion : Task
 
         try
         {
-            var currentBranch = GetCurrentBranch(gitInfo);
+            var currentBranch = !string.IsNullOrWhiteSpace(GitVersionBranch)
+                ? GitVersionBranch
+                : GetCurrentBranch(gitInfo);
+            if (!string.IsNullOrWhiteSpace(GitVersionBranch))
+            {
+                Log.LogMessage(MessageImportance.High, $"Branch overridden via GitVersionBranch property: {GitVersionBranch}");
+            }
             if (string.IsNullOrWhiteSpace(GitVersionNumberBranches))
             {
                 Log.LogWarning("GitVersionNumberBranches is not set, versioning disabled? Skipping automatic Git versioning.");

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/GenerateVersionNumber.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/GenerateVersionNumber.targets
@@ -15,6 +15,7 @@
 			GitVersionNumberBranches="$(GitVersionNumberBranches)"
 			Version="$(Version)"
 			GitVersionNumberFallback="$(GitVersionNumberFallback)"
+			GitVersionBranch="$(GitVersionBranch)"
 		>
 			<Output TaskParameter="VersionOutput" PropertyName="Version"/>
 			<Output TaskParameter="LastCommitDateTimeOutput" PropertyName="LastCommitDateTime"/>


### PR DESCRIPTION
## Why

`GenerateGitVersion` always resolves the current branch via `git rev-parse --abbrev-ref HEAD` (with CI env-var fallbacks). There was no MSBuild-level escape hatch, making it impossible to:

- Test versioning logic for a different branch without switching branches
- Correct the branch name in non-standard CI pipelines (shallow clones, custom merge strategies, etc.)
- Override the branch when the git/CI detection returns an unexpected value

## What changed

Adds an optional `GitVersionBranch` MSBuild property. When set, the task skips branch detection entirely and uses the supplied value directly. When left unset, existing behavior is unchanged.

**`GenerateGitVersion.cs`** - new task input property:
```csharp
public string GitVersionBranch { get; set; }
```

Branch resolution in `Execute()` now respects the override:
```csharp
var currentBranch = !string.IsNullOrWhiteSpace(GitVersionBranch)
    ? GitVersionBranch
    : GetCurrentBranch(gitInfo);
```

**`GenerateVersionNumber.targets`** - wires the new property through the task invocation:
```xml
GitVersionBranch="$(GitVersionBranch)"
```

This is consistent with how `GitVersionNumberBranches` and `GitVersionNumberFallback` are already overridable.

## Usage

Pass the property from the command line or set it in a project/Directory.Build.props:

```
dotnet build -p:GitVersionBranch=develop
```

Closes #75