### PR TITLE
feat: change default GitVersionNumber branch prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Defaults can be set per project or per folder via `Directory.Build.props` file. 
 ```xml
 <Project>
    <PropertyGroup>
-      <GitVersionNumberBranches>master:1;main:1;develop:2;release/*:3</GitVersionNumberBranches>
-      <GitVersionNumberFallback>0.0.12345.0</GitVersionNumberFallback>
+      <GitVersionNumberBranches>master:5;main:5;develop:4;</GitVersionNumberBranches>
+      <GitVersionNumberFallback>0.0.20000.0</GitVersionNumberFallback>
    </PropertyGroup>
 </Project>
 ```

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -12,13 +12,13 @@ Git-based version number generation is enabled by default. The SDK automatically
 |------|--------|---------|
 | `Major` | First number from `<Version>` in your project file | `1` |
 | `Minor` | Second number from `<Version>` in your project file | `0` |
-| `BranchPrefix` | Optional digit (0–5) from branch rules in `GitVersionNumberBranches` | `2` (for develop) |
+| `BranchPrefix` | Optional digit (0–5) from branch rules in `GitVersionNumberBranches` | `4` (for develop) |
 | `YY` | Last two digits of the latest commit year | `26` |
 | `MM` | Month of the latest commit (zero-padded) | `05` |
 | `DD` | Day of the latest commit (zero-padded) | `15` |
 | `CommitCount` | Number of commits on that day, zero-padded to 3 digits | `003` |
 
-**Example:** `Version=1.0`, branch `develop` (prefix `2`), latest commit on 2026-05-15 with 3 commits that day → **`1.0.22605.15003`**
+**Example:** `Version=1.0`, branch `develop` (prefix `4`), latest commit on 2026-05-15 with 3 commits that day → **`1.0.42605.15003`**
 
 The branch prefix allows higher-priority branches (e.g. production) to always have a higher version than lower-priority branches, preventing accidental overwrites when deploying. Maximum prefix value is `5` due to the [build number limitation](https://learn.microsoft.com/en-us/archive/blogs/msbuild/why-are-build-numbers-limited-to-65535) in Windows.
 
@@ -29,7 +29,7 @@ Commit counts include commits from all referenced projects (resolved recursively
 | Property | Default | Description |
 |----------|---------|-------------|
 | `GitVersionNumber` | `true` (SDK) / _empty_ (Tasks) | Master switch. Set to `false` to disable Git-based versioning entirely — the project's `Version` property is used as-is. When using the Tasks package directly (without the SDK), this is not set by default. |
-| `GitVersionNumberBranches` | `main:1;master:1;develop:2;` (SDK only) | Semicolon-separated branch rules. Each entry is `<branch-name>` or `<branch-name>:<prefix>`. Wildcard patterns are supported (e.g. `feature/*:0`). Defaults are only applied when using the SDK package; the Tasks package alone does not populate this. |
+| `GitVersionNumberBranches` | `main:5;master:5;develop:4;` (SDK only) | Semicolon-separated branch rules. Each entry is `<branch-name>` or `<branch-name>:<prefix>`. Wildcard patterns are supported (e.g. `feature/*:0`). Defaults are only applied when using the SDK package; the Tasks package alone does not populate this. |
 | `GitVersionNumberFallback` | `0.0.20000.0` | Version used when the current branch does not match any rule in `GitVersionNumberBranches`. |
 
 These properties can be set per project in your `.csproj` or shared via `Directory.Build.props`:
@@ -37,8 +37,8 @@ These properties can be set per project in your `.csproj` or shared via `Directo
 ```xml
 <Project>
    <PropertyGroup>
-      <GitVersionNumberBranches>master:1;main:1;develop:2;release/*:3</GitVersionNumberBranches>
-      <GitVersionNumberFallback>0.0.12345.0</GitVersionNumberFallback>
+      <GitVersionNumberBranches>master:5;main:5;develop:4;</GitVersionNumberBranches>
+      <GitVersionNumberFallback>0.0.20000.0</GitVersionNumberFallback>
    </PropertyGroup>
 </Project>
 ```

--- a/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
+++ b/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
@@ -23,7 +23,7 @@ public class GenerateGitVersion : Task
     public string ProjectFileName { get; set; }
     [Required]
     public string Version { get; set; }
-    public string GitVersionNumberBranches { get; set; } // template "master;hotfix;develop:1;pr:3;other:0"
+    public string GitVersionNumberBranches { get; set; } 
     public string GitVersionNumberFallback { get; set; }
 
     [Output]

--- a/src/Sdk/Sdk/Sdk.targets
+++ b/src/Sdk/Sdk/Sdk.targets
@@ -8,7 +8,7 @@
   <!-- Default branch rules for Git versioning. Evaluated after the project file
        so that GitVersionNumber=false in the csproj correctly prevents population. -->
   <PropertyGroup>
-    <GitVersionNumberBranches Condition="'$(GitVersionNumberBranches)' == '' and '$(GitVersionNumber)' == 'true'">main:1;master:1;develop:2;</GitVersionNumberBranches>
+    <GitVersionNumberBranches Condition="'$(GitVersionNumberBranches)' == '' and '$(GitVersionNumber)' == 'true'">main:5;master:5;develop:4;</GitVersionNumberBranches>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TALXISDevKitDataversePackageName)' != ''">


### PR DESCRIPTION
Changes the default git-versioning branch prefixes from 1/1/2 to 5/5/4 (master/main/develop) so production branches always outrank lower ones. 