### PR TITLE
feat: two-tier versioning with GitVersionNumberProductionBranches and GitVersionNumberBranchPrefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Defaults can be set per project or per folder via `Directory.Build.props` file. 
 ```xml
 <Project>
    <PropertyGroup>
-      <GitVersionNumberBranches>master:1;main:1;develop:2;release/*:3</GitVersionNumberBranches>
+      <GitVersionNumberProductionBranches>main;master;hotfix/*;release/*;</GitVersionNumberProductionBranches>
+      <GitVersionNumberBranchPrefixes>develop:1;</GitVersionNumberBranchPrefixes>
    </PropertyGroup>
 </Project>
 ```

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -42,7 +42,7 @@ Our answer is a **date + same-day commit count**, which both increases over time
 
 The build number answers *"which build is newer?"*. It must **not** answer *"is this a breaking change?"* - that's a people release decision. So `Major.Minor` is **never** auto-derived from dates; it comes from the project (`<Version>` in the csproj) and optionally from a release-branch name or a Git tag.
 
-### Constraint 5 - It should reduce of deployment mistakes
+### Constraint 5 - It should reduce deployment mistakes
 
 People and agents routinely produce deployable artifacts during development and testing. The dangerous mistake is **deploying the wrong artifact into the wrong environment** e.g. a unreleased and untested local build landing in UAT/PROD.
 

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -268,11 +268,7 @@ There may be edge cases. If you find one, please [report it](https://github.com/
 
 ### CI builds from unlisted branches produce LocalBuildVersionNumber
 
-Any branch not listed in `GitVersionNumberProductionBranches` or `GitVersionNumberBranchPrefixes` produces `LocalBuildVersionNumber` (`0.0.20000.0`) even in CI. The build emits a warning identifying the branch.
-
-This is intentional. It forces teams to explicitly declare every branch that should produce a deployable artifact. Unlisted branch builds produce `0.0.20000.0`, which is higher than any develop CI build (`0.0.1YYMM.DDddd`, max `0.0.19912.DDddd`), so the unlisted build can be imported over develop — but once it lands on a devbox, develop CI can no longer update that devbox because develop's version is always lower.
-
-If you want CI builds from feature branches to be consistently importable over develop, add them to `GitVersionNumberBranchPrefixes` with a prefix lower than develop. Prefix 1 is already taken by the default `develop:1`, but teams do not have to use `develop` at all — they can reconfigure both properties freely.
+Any branch not listed in `GitVersionNumberProductionBranches` or `GitVersionNumberBranchPrefixes` produces `LocalBuildVersionNumber` (`0.0.20000.0`) even in CI, with a build warning. Add the branch to `GitVersionNumberBranchPrefixes` to give it a real build number.
 
 ### Removing a project reference results in a lower version number on the same day
 

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -1,82 +1,275 @@
 # Versioning
 
-Git-based version number generation is enabled by default. The SDK automatically derives version numbers from Git history so that every build on a tracked branch produces a unique, monotonically increasing version.
+Automatic Git-based version number generation is enabled by default. TALXIS SDK derives a version number from Git history so that every build on a tracked branch produces a unique, monotonically increasing version based on commits - with **zero configuration** for most teams.
 
-## Version number format
+Versioning is a hard problem: several constraints pull in different directions, and most "obvious" simplifications break one of them. Please read the rationale before changing the defaults - a change can introduce a class of problems.
+
+---
+
+## Problem statement
+
+We have to satisfy multiple constraints at the same time. Together they rule out simple schemes.
+
+### Constraint 1 - It must be a valid EXE/DLL assembly version
+
+To ensure compatibility across all operating systems and platforms, each of the four version fields (Major.Minor.Build.Revision) must be limited to a maximum value of 65535 (16-bit). While modern frameworks (like .NET) and environments (Linux, macOS) support versions as arbitrary strings or larger integers, the Windows Portable Executable (PE) file format intentionally maintains strict backward compatibility with its 16-bit resource structure. This decision ensures that binary metadata can be reliably read by all runtimes, deployment and build systems. ([why build numbers are limited to 65535](https://learn.microsoft.com/en-us/archive/blogs/msbuild/why-are-build-numbers-limited-to-65535)).
+
+It means:
+- You **cannot** put a full timestamp in one part (`20250615` overflows).
+- You **cannot** put a global, ever-growing commit count in one part (it eventually overflows, and it isn't even monotonic across branches).
+- You have very little room: each part must encode something meaningful in **at most 5 digits**.
+
+### Constraint 2 - It must also be expressible as SemVer
+
+The same artifact set spans .NET assemblies **and** packages that use [Semantic Versioning](https://semver.org/) (npm, NuGet, PCFs). We need a **lossless round-trip** between the two so a single source of truth drives both, and so a package registry never sees a "lower" version than the assembly it came from.
+
+SemVer's build-metadata suffix (`+...`) is the natural home for the 4th .NET part. That only works if the .NET version is structured so it maps cleanly: `A.B.C.D` ↔ `A.B.C+D`. A scheme that, say, packs unrelated data into Major or spreads one logical number across two parts cannot round-trip.
+
+One constraint which we were not able to satisfy is that PCF controls don't accept build-metadata suffix. Because of that we use a specific strategy for PCF controls.
+
+### Constraint 3 - The build number should be automatic, from Git history
+
+Developers should not hand-edit a build counter - it's friction, error-prone and it isn't reproducible. The build/revision portion has to be **derived from Git** and be **unique and monotonically increasing** over time, while still fitting Constraint 1.
+
+Our answer is a **date + same-day commit count**, which both increases over time and fits in 16 bits:
+
+- `Build` carries `YYMM` (year + month) - e.g. June 2025 → `2506`.
+- `Revision` carries `DD` + the same-day commit count - e.g. the 3rd commit on the 15th → `15003`.
+
+`YYMM` ≤ `9912` and `DDcc` (day + up to 999 commits) ≤ `31999` - both safely under 65535. Time only moves forward, so versions only go up.
+
+### Constraint 4 - Major/Minor must stay under manual control as a release decision
+
+The build number answers *"which build is newer?"*. It must **not** answer *"is this a breaking change?"* - that's a people release decision. So `Major.Minor` is **never** auto-derived from dates; it comes from the project (`<Version>` in the csproj) and optionally from a release-branch name or a Git tag.
+
+### Constraint 5 - It should reduce of deployment mistakes
+
+People and agents routinely produce deployable artifacts during development and testing. The dangerous mistake is **deploying the wrong artifact into the wrong environment** e.g. a unreleased and untested local build landing in UAT/PROD.
+
+In an ideal world, developers hold no privileged accounts and can only deploy to their own devbox. In reality most teams don't have that discipline and coding agents often run under identities with access to multiple environments (instructions drift risk).
+
+We try to lower the risk by adding a **version-ordering guardrail**: lower-trust origins produce lower version numbers, and **deployment tooling rejects deployment of an artifact whose version is lower than what's already installed**. A stray import is therefore *blocked loudly*.
+
+> **Important:** This is enforced by **our deployment tooling**, not by the Dataverse platform (anymore). Dataverse APIs no longer enforces same or higher version.
+
+> **This is a guardrail, not a security control.** It is trivially bypassable (anyone can set a version by hand) and is **no substitute for proper privileged identity management**.
+
+### Why these collide
+
+The build number (Constraints 1–3) tells you which artifact is *newer*. But "newer" is exactly the wrong signal for safety (Constraint 5): a local experiment built today is *newer in time* than last week's UAT release, yet must never be allowed to overwrite it. We cannot solve safety with the date-derived number alone, and we cannot solve "which build is newer" with Major/Minor alone. The design below resolves the tension by giving the two jobs to **two different parts of the version**.
+
+---
+
+## Version number strategy
+
+| Part of the version | Job | Controlled by |
+|---|---|---|
+| **`Major.Minor`** | Communicates breaking changes and decides *which class of environment* an artifact is allowed into | People (release decision) |
+| **`Build.Revision`** | Decides *which build is newer* within a tier | Git history (automatic) |
+
+### Format
 
 ```
-<Major>.<Minor>.<BranchPrefix><YY><MM>.<DD><CommitCount>
+<Major>.<Minor>.[<BranchPrefix>]<YY><MM>.<DD><CommitCount>
+└─ tier guard ─┘└────────── automatic ordering ──────────┘
 ```
 
 | Part | Source | Example |
 |------|--------|---------|
-| `Major` | First number from `<Version>` in your project file | `1` |
-| `Minor` | Second number from `<Version>` in your project file | `0` |
-| `BranchPrefix` | Optional digit (0–5) from branch rules in `GitVersionNumberBranches` | `2` (for develop) |
-| `YY` | Last two digits of the latest commit year | `26` |
-| `MM` | Month of the latest commit (zero-padded) | `05` |
+| `Major` | First number of `<Version>` in the project file (`0` for non-production) | `1` |
+| `Minor` | Second number of `<Version>` in the project file (`0` for non-production) | `0` |
+| `BranchPrefix` | **Optional** digit from the branch→prefix map `GitVersionNumberBranchPrefixes`; **absent by default for production** | `1` (develop) |
+| `YY` | Last two digits of the latest commit year | `25` |
+| `MM` | Month of the latest commit (zero-padded) | `06` |
 | `DD` | Day of the latest commit (zero-padded) | `15` |
-| `CommitCount` | Number of commits on that day, zero-padded to 3 digits | `003` |
+| `CommitCount` | Same-day commit count, zero-padded to 3 digits (counts all referenced projects, resolved recursively via `ProjectReference`) | `003` |
 
-**Example:** `Version=1.0`, branch `develop` (prefix `2`), latest commit on 2026-05-15 with 3 commits that day → **`1.0.22605.15003`**
+### Tiers
 
-The branch prefix allows higher-priority branches (e.g. production) to always have a higher version than lower-priority branches, preventing accidental overwrites when deploying. Maximum prefix value is `5` due to the [build number limitation](https://learn.microsoft.com/en-us/archive/blogs/msbuild/why-are-build-numbers-limited-to-65535) in Windows.
+| Tier | `Major.Minor` | `Build` | Default branches |
+|------|---------------|---------|------------------|
+| **Production** | real, from csproj `<Version>` | `YYMM` → `2506` (prefix optional) | `main`, `master`, `hotfix/*`, `release/*` |
+| **Non-production** | `0.0` | `<prefix>YYMM` → `12506` | `develop` (prefix `1`) + any you add |
+| **Local / untracked** | `0.0` | `20000` (reserved prefix 2) | anything unmatched, or any non-CI build |
 
-Commit counts include commits from all referenced projects (resolved recursively via `ProjectReference`).
+Because production is always `≥ 1.0.*` and non-production is always `0.0.*`, **any production artifact outranks any non-production artifact** - the guard cannot be crossed by accident. The build number still orders builds *within* a tier, but it can never lift a `0.0` artifact above a real release.
 
-## MSBuild properties
+The two properties are **orthogonal**: `GitVersionNumberProductionBranches` decides `Major.Minor` (real vs `0.0`), and `GitVersionNumberBranchPrefixes` optionally assigns a build prefix to **any** branch. Production branches are unprefixed by default (clean `YYMM`), but you may give them a prefix too if you need to order several production environments.
+
+---
+
+## Safety rules
+
+Two concrete rules fall directly out of Constraint 5.
+
+### Rule 1 - Local builds are always `0.0.20000.0`
+
+A build only gets a *production* number when it runs **in CI** from a production branch. **Outside CI, every build is `0.0.20000.0` regardless of branch** - so a local build on `master` can never produce `>1.0.x`, and can't therefore be imported over a production environment (via our tools).
+
+CI is auto-detected from the environment variables set by common runners. If your runner isn't auto-detected, set the `IsRunningInCI` MSBuild property to `true` (or `false` to force local behavior).
+
+This deliberately **does not** trust the branch name alone. Checking out `master` locally is normal; producing a `master`-grade artifact from an unreviewed working tree is not.
+
+### Rule 2 - Daily-integration CI is the lowest; local builds own prefix 2
+
+Developers must be able to import their **own local build over their devbox**, which is hydrated nightly by integration CI. If devbox builds outranked local builds, local development would be impractical. So daily-integration CI gets the **lowest** prefix (`1`), and **local builds are given the next band up - prefix `2` - which is reserved exclusively for them**.
+
+```
+0.0.1YYMM.*   daily integration CI (devbox hydration)   ≤ 0.0.19912.*   ← LOWEST
+0.0.2xxxx.*   local builds (reserved prefix 2)                          ← always just above daily CI
+```
+
+Today every local build is exactly `0.0.20000.0` - the floor of the prefix-2 band, and greater than any `1YYMM` (max `19912`). Reserving the **whole** prefix-2 band for local builds (rather than a single value) leaves room to make local builds incremental in the future (see [Future](#future-incremental-local-builds)) without disturbing any other tier. Higher environments therefore start at prefix `3`.
+
+---
+
+## The non-production prefix ladder
+
+Real projects have **many** non-production environments, and an artifact promoted up the chain must keep outranking the one below it. The optional prefix ranks environments *inside* the `0.0` tier - higher prefix = higher version = wins the guard:
+
+```
+prefix 1   daily integration CI (devbox hydration)   0.0.1YYMM.*   (10001–19912)  ← LOWEST
+prefix 2   local builds (RESERVED - do not assign)   0.0.2xxxx.*                  ← Rule 2
+prefix 3   feature devbox                             0.0.3YYMM.*   (30001–39912)
+prefix 4   SIT                                        0.0.4YYMM.*   (40001–49912)
+prefix 5   UAT                                        0.0.5YYMM.*   (50001–59912)
+```
+
+**Prefix `2` is reserved for local builds** and must not be assigned to a branch. `5YYMM` ≤ `59912` < 65535, so **the maximum usable prefix is `5`** - a direct consequence of Constraint 1. That leaves prefixes `3`–`5` for higher non-production environments. The default ships **only `develop:1`** (the one tier every devbox-hydrating team needs); the rest are a ready-made recipe (see [Workflow recipes](#workflow-recipes)) rather than clutter in the zero-config default.
+
+---
+
+## Major/Minor: where it comes from
+
+`Major.Minor` is the release decision, kept under people control (Constraint 4). It is deliberately a **separate, overridable input**, so teams can pick whatever is common for them - the tooling does not lock you into one source:
+
+- **In the project file** (default) - the first two parts of `<Version>` in the csproj.
+- **From the pipeline** - set or override `Version` (or the major/minor properties) from CI variables at build time.
+- **From a release branch name** - trunk-then-cut teams cut a `release/x` branch that carries its **own `Major.Minor`**; a common convention is to encode it in the branch name (e.g. `release/2.1`). The next release uses a higher `Major.Minor`. This is how one release line is distinguished from the next - by the guard, not the build number.
+- **From a Git tag** - tagging a release (e.g. `v2.1.0`) and taking `Major.Minor` from the tag is a widespread practice.
+
+Reading `Major.Minor` from the **branch name** or a **Git tag** are planned, opt-in features; today the value comes from `<Version>` (which a pipeline can set). The whole point of the design is that adding those sources later changes only *where the two numbers come from* - never the build/revision machinery or the safety guard.
+
+### Monorepos
+
+Versions are evaluated **per project**, and commit counts are resolved recursively through `ProjectReference`. Each package in a monorepo therefore gets its own independent version driven by the commits that actually affect it.
+
+---
+
+## Examples
+
+```
+CI on main,        2025-06-15, 3 commits   →  1.0.2506.15003     (production)
+CI on release/2.0, 2025-06-15              →  2.0.2506.15001     (production, next release line)
+CI on hotfix/x,    2025-06-15              →  1.0.2506.15001     (production, patches 1.0)
+CI on develop,     2025-06-15, 3 commits   →  0.0.12506.15003    (non-production, prefix 1, lowest)
+any local build (any branch)               →  0.0.20000.0        (always - Rule 1, reserved prefix 2)
+CI on feature/*  (with feature/*:3)        →  0.0.32506.15003    (non-production, prefix 3)
+```
+
+Ordering that matters:
+
+- Any production `≥ 1.0.*` **>** any non-production `0.0.*` → the tier guard.
+- Within non-production: daily CI `0.0.1YYMM` (≤ `19912`) **<** local `0.0.2xxxx` (reserved prefix 2) **<** feature `0.0.3YYMM` … **<** UAT `0.0.5YYMM`.
+
+---
+
+## Configuration
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `GitVersionNumber` | `true` (SDK) / _empty_ (Tasks) | Master switch. Set to `false` to disable Git-based versioning entirely — the project's `Version` property is used as-is. When using the Tasks package directly (without the SDK), this is not set by default. |
-| `GitVersionNumberBranches` | `main:1;master:1;develop:2;` (SDK only) | Semicolon-separated branch rules. Each entry is `<branch-name>` or `<branch-name>:<prefix>`. Wildcard patterns are supported (e.g. `feature/*:0`). Defaults are only applied when using the SDK package; the Tasks package alone does not populate this. |
-| `LocalBuildVersionNumber` | `0.0.20000.0` | Version used when not in CI or when the branch doesn't match any rule. Override only when needed — by default `0.0.20000.0` is used automatically for local builds. |
-| `IsRunningInCI` | _(auto-detect)_ | Override CI detection. Set to `true` or `false` to force the behaviour; omit to let the task auto-detect from common CI environment variables (`CI`, `TF_BUILD`, `GITHUB_ACTIONS`, `GITLAB_CI`, `JENKINS_URL`, `CIRCLECI`, `TEAMCITY_VERSION`). |
+| `GitVersionNumber` | `true` (SDK) / _empty_ (Tasks) | Master switch. Set to `false` to disable Git-based versioning entirely - the project's `Version` is used as-is. The Tasks package alone does not set this. |
+| `GitVersionNumberProductionBranches` | `main;master;hotfix/*;release/*;` | Branches that receive the **real `Major.Minor`** (when built in CI). Everything else is non-production (`0.0`). Wildcards supported. |
+| `GitVersionNumberBranchPrefixes` | `develop:1;` | Optional branch→prefix map (`<branch>:<prefix>`) that assigns a build prefix for ordering. Applies to **any** branch, production or not. Prefix `2` is reserved for local builds; usable values are `1` and `3`–`5`. Wildcards supported (e.g. `feature/*:3`). SDK-only default. |
+| `LocalBuildVersionNumber` | `0.0.20000.0` | Version for local / untracked / non-CI builds. The `0.0` marks it as never-deployable-to-a-real-environment (Rule 1); `20000` is the floor of the reserved prefix-2 band, just above daily-integration CI (Rule 2). |
+| `IsRunningInCI` | _(auto)_ | Leave empty to auto-detect CI from environment variables. Set to `true`/`false` to override detection. |
+| `SemVer` | _(output)_ | The SemVer projection of the generated version, `Major.Minor.Build+Revision` (see [SemVer round-trip](#semver--npm-round-trip)). |
 
-These properties can be set per project in your `.csproj` or shared via `Directory.Build.props`:
+Set these per project or share them via `Directory.Build.props`:
 
 ```xml
 <Project>
    <PropertyGroup>
-      <GitVersionNumberBranches>master:1;main:1;develop:2;release/*:3</GitVersionNumberBranches>
+      <GitVersionNumberProductionBranches>main;master;hotfix/*;release/*;</GitVersionNumberProductionBranches>
+      <GitVersionNumberBranchPrefixes>develop:1;</GitVersionNumberBranchPrefixes>
+      <LocalBuildVersionNumber>0.0.20000.0</LocalBuildVersionNumber>
    </PropertyGroup>
 </Project>
 ```
 
-### Opting out of Git versioning
+### Workflow recipes
 
-Set `GitVersionNumber` to `false` to disable automatic version generation:
+The defaults assume Git Flow, but nothing forces a particular flow. A few starting points:
+
+| Workflow | `GitVersionNumberProductionBranches` | `GitVersionNumberBranchPrefixes` |
+|----------|--------------------------------------|----------------------------------|
+| Simple trunk | `main;master;` | _(none)_ |
+| Git Flow **(default)** | `main;master;hotfix/*;release/*;` | `develop:1;` |
+| Trunk + release cuts (trunk = daily integration) | `release/*;hotfix/*;` | `main:1;master:1;` |
+| Full non-production ladder | `main;master;hotfix/*;release/*;` | `develop:1;feature/*:3;sit/*:4;uat/*:5;` |
+
+In the "trunk + release cuts" recipe, `main`/`master` are **not** production, so they build as non-production daily integration (`0.0`) with prefix `1` (lowest, devbox hydration); only the cut `release/*` branches are production with their own `Major.Minor`. Prefix `2` is skipped everywhere because it is reserved for local builds.
+
+### Opting out
 
 ```xml
 <GitVersionNumber>false</GitVersionNumber>
 ```
 
-When disabled, `GitVersionNumberBranches` is not populated with defaults and the `GenerateGitVersion` task uses the project's `Version` property as-is.
+When disabled, `GitVersionNumberBranchPrefixes` is not populated with defaults and the `GenerateGitVersion` task uses the project's `Version` as-is.
 
-### Local builds
+---
 
-When building locally, the task auto-detects that it is not in CI and uses `LocalBuildVersionNumber` instead of generating a commit-derived version. No extra configuration is needed.
+## SemVer / npm round-trip
 
-If your CI system is not auto-detected, set `IsRunningInCI` explicitly in your pipeline configuration:
+The mapping is lossless and contains **no branch logic** - it is a pure structural projection (Constraint 2):
 
-```xml
-<IsRunningInCI>true</IsRunningInCI>
 ```
+.NET  A.B.C.D    ↔    SemVer  A.B.C+D
+```
+
+```
+1.0.2506.15003    →  1.0.2506+15003    (a registry / npm sees 1.0.2506)
+0.0.12506.15003   →  0.0.12506+15003
+0.0.20000.0       →  0.0.20000+0
+```
+
+The `GenerateGitVersion` task exposes this via the `SemVer` MSBuild property, always formatted `{Major}.{Minor}.{Build}+{Revision}`.
+
+---
+
+## Future: incremental local builds
+
+Today, **every** local build is exactly `0.0.20000.0`. That guarantees safety (Rule 1) but has a known cost: because consecutive local builds produce the *same* number, importing a fresh local build over your previous one requires a force-update - the guardrail can't tell them apart.
+
+A natural future requirement is to make local builds **incremental** - derived from the build **time** and whether the working tree has **dirty (uncommitted) changes** - so each rebuild outranks the last and reimporting over your own devbox "just works". The design reserves room for exactly this:
+
+- Prefix `2` (the whole `0.0.2xxxx.*` band) is **reserved for local builds** and assigned to no environment.
+- That band is a large, collision-free space: build `20000`–`29912` × revision `0`–`65535`. A future implementation can map a timestamp (plus a dirty-tree marker) into it to produce a monotonically increasing local version.
+- Every value in the band still **outranks daily-integration CI** (any `1YYMM` ≤ `19912`) and stays **below every higher environment** (prefix `3`+), so the safety tiers are untouched.
+
+The invariant to preserve: incremental local builds must stay **inside the prefix-2 band** and keep `Major.Minor` at `0.0`, or they would break Rules 1 and 2. Carving out that band is the hard part, and it is already done - which is why `0.0.20000.0` is a load-bearing default, not an arbitrary placeholder.
+
+---
 
 ## PCFs
 
-Since PCFs [use semantic versioning](https://learn.microsoft.com/en-us/power-apps/developer/component-framework/manifest-schema-reference/control), and there are [some nuances](https://dianabirkelbach.wordpress.com/2020/12/23/all-about-pcf-versioning/) with changing the major and minor numbers. The maximum value for each part is *2,147,483,647* (32-bit integer). With PCFs it is impossible to push a lower version of PCF (even with `ForceUpdate=TRUE`). We currently assemble the PCF version as following from the outputs generated above (this applies also when not using the generate version):
+PCFs [use semantic versioning](https://learn.microsoft.com/en-us/power-apps/developer/component-framework/manifest-schema-reference/control), with [some nuances](https://dianabirkelbach.wordpress.com/2020/12/23/all-about-pcf-versioning/) around changing major/minor. Each part may be up to *2,147,483,647* (32-bit), and it is impossible to push a *lower* PCF version (even with `ForceUpdate=TRUE`). We therefore assemble the PCF version from the outputs above as (this applies even when Git versioning is disabled):
 
 ```
 0.0.<SECONDS_FROM_2020-01-01_TILL_LAST_COMMIT_OR_NOW>
 ```
 
+---
+
 ## Edge cases
 
-There may obviously be some edge cases. If you find any, please [report them](https://github.com/TALXIS/tools-devkit-build/issues) or submit a PR to fix it!
+There may be edge cases. If you find one, please [report it](https://github.com/TALXIS/tools-devkit-build/issues) or submit a PR.
 
 ### Removing a project reference results in a lower version number on the same day
-If you make a change to a solution with a referenced project on the same day, and then remove a project reference on the same day, the second build version is going to be lower and the solution will fail to import. This is most likely to happen in non-production branches and the known workaround is to make a commit and rebuild the affected solution the next day. This is to change in future.
+
+If you change a solution with a referenced project on a given day, then remove a project reference on the same day, the second build's commit count can be lower, producing a lower version that fails to import. This is most likely on non-production branches; the workaround is to make a commit and rebuild the next day. To be improved in future.
 
 ### Over 999 commits per day
-Each number of version is limited by [`ushort`](https://learn.microsoft.com/en-us/dotnet/api/system.uint16?view=net-9.0)'s maximum size. If you do more than 999 commits per day across all referenced projects, you will end up with an error. A workaround is to bump projects with too many commits in that day to a single commit the next day. Alternatively, you can consider using [squashing commits](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits). If you hit this, please reach out to us.
+
+Each version part is bounded by [`ushort`](https://learn.microsoft.com/en-us/dotnet/api/system.uint16) (65535). More than 999 commits in one day across all referenced projects overflows the revision. Workarounds: collapse to fewer commits the next day, or [squash on merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits). If you hit this, please reach out.

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -270,7 +270,7 @@ There may be edge cases. If you find one, please [report it](https://github.com/
 
 Any branch not listed in `GitVersionNumberProductionBranches` or `GitVersionNumberBranchPrefixes` produces `LocalBuildVersionNumber` (`0.0.20000.0`) even in CI. The build emits a warning identifying the branch.
 
-This is intentional. It forces teams to explicitly declare every branch that should produce a deployable artifact. Unlisted branch builds are treated the same as local builds: they are importable to an empty devbox but will be blocked if develop CI (`0.0.1YYMM.DDddd`) is already installed there, because `0.0.20000.0 > 0.0.1YYMM.DDddd`.
+This is intentional. It forces teams to explicitly declare every branch that should produce a deployable artifact. Unlisted branch builds produce `0.0.20000.0`, which is higher than any develop CI build (`0.0.1YYMM.DDddd`, max `0.0.19912.DDddd`), so the unlisted build can be imported over develop — but once it lands on a devbox, develop CI can no longer update that devbox because develop's version is always lower.
 
 If you want CI builds from feature branches to be consistently importable over develop, add them to `GitVersionNumberBranchPrefixes` with a prefix lower than develop. Prefix 1 is already taken by the default `develop:1`, but teams do not have to use `develop` at all — they can reconfigure both properties freely.
 

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -266,6 +266,14 @@ PCFs [use semantic versioning](https://learn.microsoft.com/en-us/power-apps/deve
 
 There may be edge cases. If you find one, please [report it](https://github.com/TALXIS/tools-devkit-build/issues) or submit a PR.
 
+### CI builds from unlisted branches produce LocalBuildVersionNumber
+
+Any branch not listed in `GitVersionNumberProductionBranches` or `GitVersionNumberBranchPrefixes` produces `LocalBuildVersionNumber` (`0.0.20000.0`) even in CI. The build emits a warning identifying the branch.
+
+This is intentional. It forces teams to explicitly declare every branch that should produce a deployable artifact. Unlisted branch builds are treated the same as local builds: they are importable to an empty devbox but will be blocked if develop CI (`0.0.1YYMM.DDddd`) is already installed there, because `0.0.20000.0 > 0.0.1YYMM.DDddd`.
+
+If you want CI builds from feature branches to be consistently importable over develop, add them to `GitVersionNumberBranchPrefixes` with a prefix lower than develop. Prefix 1 is already taken by the default `develop:1`, but teams do not have to use `develop` at all — they can reconfigure both properties freely.
+
 ### Removing a project reference results in a lower version number on the same day
 
 If you change a solution with a referenced project on a given day, then remove a project reference on the same day, the second build's commit count can be lower, producing a lower version that fails to import. This is most likely on non-production branches; the workaround is to make a commit and rebuild the next day. To be improved in future.

--- a/src/Dataverse/Pcf/README.md
+++ b/src/Dataverse/Pcf/README.md
@@ -24,7 +24,7 @@ The package imports `Microsoft.PowerApps.MSBuild.Pcf` targets as a NuGet depende
 
 The `_ApplyPcfVersionBeforeBuild` target runs before `BeforeBuild` and executes two steps in sequence:
 
-1. **GenerateVersionNumber** (from `Tasks`) -- reads the `Version` property, inspects the current Git branch against `GitVersionNumberBranches` rules, and produces a full four-part version number.
+1. **GenerateVersionNumber** (from `Tasks`) -- reads the `Version` property, inspects the current Git branch against `GitVersionNumberProductionBranches` and `GitVersionNumberBranchPrefixes` rules, and produces a full four-part version number.
 2. **ApplyPluginVersionNumber** -- writes the generated version to `AssemblyVersion`, `FileVersion`, `Version`, and `PackageVersion`.
 
 The Microsoft PCF targets version is controlled by `MicrosoftPowerAppsTargetsVersion` from `Directory.Build.props`.

--- a/src/Dataverse/Plugin/README.md
+++ b/src/Dataverse/Plugin/README.md
@@ -40,8 +40,8 @@ These targets are called by `TALXIS.DevKit.Build.Dataverse.Solution` when it dis
 |----------|---------|-------------|
 | `ProjectType` | `Plugin` | Marks the project as a plugin for reference discovery. |
 | `Version` | _(required)_ | Base version; major/minor are used for Git versioning. |
-| `GitVersionNumberBranches` | _(none)_ | Semicolon-separated branch rules (e.g. `master;hotfix;develop:1;pr:3;feature/*:2`). |
-| `GitVersionNumberFallback` | `0.0.20000.0` | Fallback version when Git versioning is not applied. |
+| `GitVersionNumberBranchPrefixes` | _(none)_ | Optional `<branch>:<prefix>` map for build ordering (e.g. `develop:1;feature/*:3`). Prefix `2` is reserved for local builds. |
+| `LocalBuildVersionNumber` | `0.0.20000.0` | Version used for local / non-CI builds. |
 | `PluginTargetFramework` | `$(TargetFramework)` or `net462` | Target framework used to locate the compiled plugin DLL. |
 | `PluginPublishFolderName` | `publish` | Publish folder name under `bin\<Configuration>\<TFM>\`. |
 | `PluginAssemblyId` | _(auto-generated)_ | Explicit GUID for the plugin assembly metadata; a new GUID is generated if empty. |

--- a/src/Dataverse/Tasks/README.md
+++ b/src/Dataverse/Tasks/README.md
@@ -27,7 +27,7 @@ The package ships a single `net10.0` task assembly and requires an MSBuild 18+ .
 
 ### Key targets
 
-- **GenerateVersionNumber** -- requires the `Version` property. Runs `GenerateGitVersion` using the major/minor from `Version`, the current Git branch, and `GitVersionNumberBranches` rules to produce a full four-part version number.
+- **GenerateVersionNumber** -- requires the `Version` property. Runs `GenerateGitVersion` using the major/minor from `Version`, the current Git branch, `GitVersionNumberProductionBranches`, and `GitVersionNumberBranchPrefixes` to produce a full four-part version number.
 - **ApplyVersionNumber** -- patches the generated version into solution metadata folders (`SolutionXml`, `PluginAssemblies`, `Workflows`, `Controls`, `SdkMessageProcessingSteps`).
 - **ApplyPcfVersionNumber** -- updates the version in `ControlManifest.xml` for PCF controls.
 - **PackDataverseSolution** -- invokes SolutionPackagerLib to produce a `.zip` from the working directory without shelling out to `pac.exe`.
@@ -61,7 +61,7 @@ Error codes emitted by validation tasks:
 |----------|---------|-------------|
 | `Version` | _(required)_ | Base version (`Major.Minor`); used by `GenerateGitVersion` to produce the full version. |
 
-See [Versioning](/docs/Versioning.md) for the full list of versioning properties (`GitVersionNumber`, `GitVersionNumberBranches`, `LocalBuildVersionNumber`, `IsRunningInCI`) and the version number format.
+See [Versioning](/docs/Versioning.md) for the full list of versioning properties (`GitVersionNumber`, `GitVersionNumberProductionBranches`, `GitVersionNumberBranchPrefixes`, `LocalBuildVersionNumber`, `IsRunningInCI`) and the version number format.
 
 ### Solution packager paths
 

--- a/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
+++ b/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
@@ -173,9 +173,11 @@ public class GenerateGitVersion : Task
         if (string.IsNullOrWhiteSpace(dotNetVersion))
             return dotNetVersion;
         var parts = dotNetVersion.Split('.');
-        if (parts.Length < 4)
-            return dotNetVersion;
-        return $"{parts[0]}.{parts[1]}.{parts[2]}+{parts[3]}";
+        var major    = parts.Length > 0 ? parts[0] : "0";
+        var minor    = parts.Length > 1 ? parts[1] : "0";
+        var patch    = parts.Length > 2 ? parts[2] : "0";
+        var revision = parts.Length > 3 ? parts[3] : "0";
+        return $"{major}.{minor}.{patch}+{revision}";
     }
 
     private (int, DateTime) GetNumberOfCommits(string projectPath)

--- a/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
+++ b/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
@@ -23,13 +23,16 @@ public class GenerateGitVersion : Task
     public string ProjectFileName { get; set; }
     [Required]
     public string Version { get; set; }
-    public string GitVersionNumberBranches { get; set; } // template "master;hotfix;develop:1;pr:3;other:0"
+    public string GitVersionNumberBranchPrefixes { get; set; } // e.g. "develop:1;feature/*:3;hotfix/*:4"
+    public string GitVersionNumberProductionBranches { get; set; } // e.g. "main;master;hotfix/*;release/*"
     public string LocalBuildVersionNumber { get; set; }
     public string IsRunningInCI { get; set; }
     public string GitVersionBranch { get; set; }
 
     [Output]
     public string VersionOutput { get; private set; }
+    [Output]
+    public string SemVerOutput { get; private set; }
     [Output]
     public string LastCommitDateTimeOutput { get; private set; }
 
@@ -44,6 +47,7 @@ public class GenerateGitVersion : Task
         {
             Log.LogMessage(MessageImportance.High, "Git repository not found; skipping automatic Git versioning.");
             VersionOutput = LocalBuildVersionNumber;
+            SemVerOutput = ToSemVer(LocalBuildVersionNumber);
             LastCommitDateTimeOutput = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
             return true;
         }
@@ -52,6 +56,7 @@ public class GenerateGitVersion : Task
         {
             Log.LogMessage(MessageImportance.High, "Not running in CI; using LocalBuildVersionNumber.");
             VersionOutput = LocalBuildVersionNumber;
+            SemVerOutput = ToSemVer(LocalBuildVersionNumber);
             LastCommitDateTimeOutput = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
             return true;
         }
@@ -68,93 +73,109 @@ public class GenerateGitVersion : Task
             {
                 Log.LogMessage(MessageImportance.High, $"Branch overridden via GitVersionBranch property: {GitVersionBranch}");
             }
-            if (string.IsNullOrWhiteSpace(GitVersionNumberBranches))
+            if (string.IsNullOrWhiteSpace(GitVersionNumberBranchPrefixes) && string.IsNullOrWhiteSpace(GitVersionNumberProductionBranches))
             {
-                Log.LogWarning("GitVersionNumberBranches is not set, versioning disabled? Skipping automatic Git versioning.");
+                Log.LogWarning("Neither GitVersionNumberBranchPrefixes nor GitVersionNumberProductionBranches is set; skipping automatic Git versioning.");
                 VersionOutput = Version;
+                SemVerOutput = ToSemVer(Version);
                 LastCommitDateTimeOutput = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
                 return true;
             }
-            _branches = GitVersionNumberBranches.Split(';').Select(BranchVersioning.Parse);
-            if (_branches == null || !_branches.Any())
-            {
-                Log.LogWarning($"No valid branches found in GitVersionNumberBranches '{GitVersionNumberBranches}'.");
-                VersionOutput = Version;
-                LastCommitDateTimeOutput = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
-                return true;
-            }
+            _branches = string.IsNullOrWhiteSpace(GitVersionNumberBranchPrefixes)
+                ? Enumerable.Empty<BranchVersioning>()
+                : GitVersionNumberBranchPrefixes.Split(';').Where(s => !string.IsNullOrWhiteSpace(s)).Select(BranchVersioning.Parse);
+
+            var productionBranches = string.IsNullOrWhiteSpace(GitVersionNumberProductionBranches)
+                ? Array.Empty<string>()
+                : GitVersionNumberProductionBranches.Split(';').Where(s => !string.IsNullOrWhiteSpace(s)).ToArray();
+
+            var isProduction = productionBranches.Any(p =>
+                string.Equals(p, currentBranch, StringComparison.OrdinalIgnoreCase) ||
+                (p.EndsWith("*") && currentBranch.StartsWith(p.TrimEnd('*'), StringComparison.OrdinalIgnoreCase)));
+
             var branch = _branches.FirstOrDefault(b =>
                 string.Equals(b.BranchName, currentBranch, StringComparison.OrdinalIgnoreCase) ||
-                // Basic wildcard support, e.g. feature/*
-                (b.BranchName.EndsWith("*") && currentBranch.StartsWith(b.BranchName.TrimEnd('*'), StringComparison.OrdinalIgnoreCase))
-            );
-            if (branch == null)
+                (b.BranchName.EndsWith("*") && currentBranch.StartsWith(b.BranchName.TrimEnd('*'), StringComparison.OrdinalIgnoreCase)));
+
+            if (!isProduction && branch == null)
             {
-                Log.LogWarning($"The current branch '{currentBranch}' is not enabled for automatic Git versioning.");
+                Log.LogWarning($"The current branch '{currentBranch}' is not in GitVersionNumberProductionBranches or GitVersionNumberBranchPrefixes.");
                 VersionOutput = LocalBuildVersionNumber;
+                SemVerOutput = ToSemVer(LocalBuildVersionNumber);
                 LastCommitDateTimeOutput = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
                 return true;
             }
-            else
+
+            Log.LogMessage($"The current branch '{currentBranch}' is enabled for automatic Git versioning (production={isProduction}).");
+
+            var projects = new List<string> { ProjectPath };
+            RetrieveAllProjectReferences(ProjectPath, projects);
+            Log.LogMessage(MessageImportance.High, $"Got number of projects: {projects.Count}");
+
+            var totalComitCount = 0;
+            var latestCommitDate = new DateTime(1900, 1, 1);
+
+            foreach (var project in projects)
             {
-                Log.LogMessage($"The current branch '{currentBranch}' is enabled for automatic Git versioning.");
-
-                var projects = new List<string>
+                Log.LogMessage(MessageImportance.High, $"Project: {project}");
+                var (commitCount, lastCommitDate) = GetNumberOfCommits(project);
+                Log.LogMessage(MessageImportance.High, $"{project}: Last commit: {lastCommitDate:yyyy-MM-dd}, count: {commitCount}");
+                if (latestCommitDate < lastCommitDate)
                 {
-                    ProjectPath
-                };
-                RetrieveAllProjectReferences(ProjectPath, projects);
-                Log.LogMessage(MessageImportance.High, $"Got number of projects: {projects.Count}");
-
-                var totalComitCount = 0;
-                var latestCommitDate = new DateTime(1900, 1, 1);
-
-                foreach (var project in projects)
-                {
-                    Log.LogMessage(MessageImportance.High, $"Project: {project}");
-                    var (commitCount, lastCommitDate) = GetNumberOfCommits(project);
-                    Log.LogMessage(MessageImportance.High, $"{project}: Last commit: {lastCommitDate:yyyy-MM-dd}, count: {commitCount}");
-                    if (latestCommitDate < lastCommitDate)
-                    {
-                        totalComitCount = commitCount;
-                        latestCommitDate = lastCommitDate;
-                    }
-                    else if (latestCommitDate == lastCommitDate)
-                    {
-                        totalComitCount += commitCount;
-                    }
+                    totalComitCount = commitCount;
+                    latestCommitDate = lastCommitDate;
                 }
-                Log.LogMessage(MessageImportance.High, $"Commit count for the month: {totalComitCount}");
-                if (totalComitCount > 999)
+                else if (latestCommitDate == lastCommitDate)
                 {
-                    throw new Exception($"Too many commits ({totalComitCount} > 999), cannot generate version number. Please reach out to the author.");
+                    totalComitCount += commitCount;
                 }
-
-                // Convert the latest commit date to build number
-                // DateTime lastCommitDateTime = DateTime.ParseExact(latestCommitDate, "yyyy-MM-dd HH:mm:ss K", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
-                var build = ushort.Parse(latestCommitDate.ToString("yyMM"));
-                if (branch.Prefix.HasValue)
-                {
-                    build = ushort.Parse($"{branch.Prefix}{latestCommitDate:yyMM}");
-                }
-
-                // Get the revision number as the last commit day and commit count for the month (reduce risk of deploying lower version after refactoring)
-                var revision = ushort.Parse($"{latestCommitDate:dd}{totalComitCount:000}");
-
-                // Combine the version parts into final version number
-                VersionOutput = $"{VersionMajor}.{VersionMinor}.{build}.{revision}";
-                LastCommitDateTimeOutput = latestCommitDate.ToString("yyyy-MM-ddTHH:mm:ssZ");
-
-                return true;
             }
+            Log.LogMessage(MessageImportance.High, $"Commit count for the day: {totalComitCount}");
+            if (totalComitCount > 999)
+            {
+                throw new Exception($"Too many commits ({totalComitCount} > 999), cannot generate version number. Please reach out to the author.");
+            }
+
+            // Build = [prefix]YYMM; prefix is optional. Prefix 2 is reserved for local builds.
+            var build = ushort.Parse(latestCommitDate.ToString("yyMM"));
+            if (branch?.Prefix.HasValue == true)
+            {
+                if (branch.Prefix.Value == 2)
+                    Log.LogWarning($"Branch prefix 2 is reserved for local builds; using it on branch '{currentBranch}' may cause version conflicts.");
+                build = ushort.Parse($"{branch.Prefix.Value}{latestCommitDate:yyMM}");
+            }
+
+            // Revision = DDddd (day + 3-digit same-day commit count)
+            var revision = ushort.Parse($"{latestCommitDate:dd}{totalComitCount:000}");
+
+            // Major.Minor: production branches use the csproj version; non-production uses 0.0
+            var major = isProduction ? VersionMajor : (ushort)0;
+            var minor = isProduction ? VersionMinor : (ushort)0;
+
+            VersionOutput = $"{major}.{minor}.{build}.{revision}";
+            SemVerOutput = $"{major}.{minor}.{build}+{revision}";
+            LastCommitDateTimeOutput = latestCommitDate.ToString("yyyy-MM-ddTHH:mm:ssZ");
+
+            return true;
         }
         catch (Exception ex)
         {
             Log.LogMessage(MessageImportance.High, $"Git versioning skipped: {ex.Message}");
             VersionOutput = LocalBuildVersionNumber;
+            SemVerOutput = ToSemVer(LocalBuildVersionNumber);
             LastCommitDateTimeOutput = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
             return true;
         }
+    }
+
+    private static string ToSemVer(string dotNetVersion)
+    {
+        if (string.IsNullOrWhiteSpace(dotNetVersion))
+            return dotNetVersion;
+        var parts = dotNetVersion.Split('.');
+        if (parts.Length < 4)
+            return dotNetVersion;
+        return $"{parts[0]}.{parts[1]}.{parts[2]}+{parts[3]}";
     }
 
     private (int, DateTime) GetNumberOfCommits(string projectPath)
@@ -392,7 +413,7 @@ public class GenerateGitVersion : Task
         {
             var parts = branchDefinition.Split(':');
             var branchName = parts[0].Trim();
-            int prefix = 0;
+            int? prefix = null;
             if (parts.Length > 1 && int.TryParse(parts[1].Trim(), out int parsedPrefix))
             {
                 if (parsedPrefix < 0 || parsedPrefix > 5)

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/GenerateVersionNumber.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/GenerateVersionNumber.targets
@@ -12,13 +12,15 @@
 			VersionMinor="$(Version.Split('.')[1])"
 			ProjectPath="$(ProjectDir)"
 			ProjectFileName="$(ProjectFileName)"
-			GitVersionNumberBranches="$(GitVersionNumberBranches)"
+			GitVersionNumberBranchPrefixes="$(GitVersionNumberBranchPrefixes)"
+			GitVersionNumberProductionBranches="$(GitVersionNumberProductionBranches)"
 			Version="$(Version)"
 			LocalBuildVersionNumber="$(LocalBuildVersionNumber)"
 			IsRunningInCI="$(IsRunningInCI)"
 			GitVersionBranch="$(GitVersionBranch)"
 		>
 			<Output TaskParameter="VersionOutput" PropertyName="Version"/>
+			<Output TaskParameter="SemVerOutput" PropertyName="SemVer"/>
 			<Output TaskParameter="LastCommitDateTimeOutput" PropertyName="LastCommitDateTime"/>
 		</GenerateGitVersion>
 		<Message Text="Git-generated version number: $(Version)" Importance="high" />

--- a/src/Dataverse/WorkflowActivity/README.md
+++ b/src/Dataverse/WorkflowActivity/README.md
@@ -40,8 +40,8 @@ These targets are called by `TALXIS.DevKit.Build.Dataverse.Solution` when it dis
 |----------|---------|-------------|
 | `ProjectType` | `WorkflowActivity` | Marks the project as a workflow activity for reference discovery. |
 | `Version` | _(required)_ | Base version; major/minor are used for Git versioning. |
-| `GitVersionNumberBranches` | _(none)_ | Semicolon-separated branch rules (e.g. `master;hotfix;develop:1;pr:3;feature/*:2`). |
-| `GitVersionNumberFallback` | `0.0.20000.0` | Fallback version when Git versioning is not applied. |
+| `GitVersionNumberBranchPrefixes` | _(none)_ | Optional `<branch>:<prefix>` map for build ordering (e.g. `develop:1;feature/*:3`). Prefix `2` is reserved for local builds. |
+| `LocalBuildVersionNumber` | `0.0.20000.0` | Version used for local / non-CI builds. |
 | `WorkflowActivityTargetFramework` | `$(TargetFramework)` or `net462` | Target framework used to locate the compiled workflow activity DLL. |
 | `WorkflowActivityPublishFolderName` | `publish` | Publish folder name under `bin\<Configuration>\<TFM>\`. |
 | `WorkflowActivityAssemblyId` | _(auto-generated)_ | Explicit GUID for the workflow activity assembly metadata; a new GUID is generated if empty. |

--- a/src/Sdk/README.md
+++ b/src/Sdk/README.md
@@ -39,7 +39,9 @@ The `TALXISDevKitDataversePackageName` property can be set explicitly to overrid
 | `TALXISDevKitDataversePackageVersion` | _(resolved from SDK install path)_ | Version used in the auto-generated package reference. Defaults to the installed SDK version, extracted from the NuGet cache path (`.../{id}/{version}/Sdk/Sdk.props`), so the referenced `TALXIS.DevKit.Build.Dataverse.*` package matches the SDK version. |
 | `TALXISDevKitDataversePackageName` | `$(Base).$(ProjectType)` | Explicit package name; overrides the base + ProjectType combination. |
 | `GitVersionNumber` | `true` | Enables Git-based version number generation. Set to `false` to opt out. See [Versioning](/docs/Versioning.md). |
-| `GitVersionNumberBranches` | `main:1;master:1;develop:2;` | Default branch rules for Git versioning. See [Versioning](/docs/Versioning.md). |
+| `GitVersionNumberProductionBranches` | `main;master;hotfix/*;release/*;` | Branches that receive the real `Major.Minor` from the csproj `<Version>`. Everything else gets `0.0`. See [Versioning](/docs/Versioning.md). |
+| `GitVersionNumberBranchPrefixes` | `develop:1;` | Optional `<branch>:<prefix>` map for ordering builds within the non-production `0.0` tier. Prefix `2` is reserved for local builds. See [Versioning](/docs/Versioning.md). |
+| `LocalBuildVersionNumber` | `0.0.20000.0` | Version used for all local / non-CI builds. See [Versioning](/docs/Versioning.md). |
 
 ## Related Packages
 

--- a/src/Sdk/Sdk/Sdk.targets
+++ b/src/Sdk/Sdk/Sdk.targets
@@ -6,9 +6,32 @@
   </PropertyGroup>
 
   <!-- Default branch rules for Git versioning. Evaluated after the project file
-       so that GitVersionNumber=false in the csproj correctly prevents population. -->
+       so that GitVersionNumber=false in the csproj correctly prevents population.
+
+       Two orthogonal properties drive the versioning strategy:
+
+       GitVersionNumberProductionBranches — decides Major.Minor.
+         Branches listed here get the real Major.Minor from the csproj <Version>.
+         Everything else gets 0.0, which our deployment tooling treats as
+         "non-production" and blocks from importing into real environments.
+
+       GitVersionNumberBranchPrefixes — optional build-number prefix per branch.
+         Format: <branch>:<prefix> where prefix is 1 or 3-5 (prefix 2 is reserved
+         for local builds). Higher prefix = higher version = wins the guard within
+         the 0.0 tier. Leave production branches unprefixed for a clean YYMM build
+         number, or assign a prefix to order multiple production environments.
+
+       Safety rules:
+         - Outside CI every build is LocalBuildVersionNumber (0.0.20000.0).
+           This is enforced by CI detection, not by branch name.
+         - develop:1 (daily integration CI) is the lowest non-production tier,
+           so developers can always import their own local build over their devbox.
+         - Prefix 2 (0.0.2xxxx.*) is reserved for local builds; do not assign it
+           to any branch.
+  -->
   <PropertyGroup>
-    <GitVersionNumberBranches Condition="'$(GitVersionNumberBranches)' == '' and '$(GitVersionNumber)' == 'true'">main:1;master:1;develop:2;</GitVersionNumberBranches>
+    <GitVersionNumberProductionBranches Condition="'$(GitVersionNumberProductionBranches)' == '' and '$(GitVersionNumber)' == 'true'">main;master;hotfix/*;release/*;</GitVersionNumberProductionBranches>
+    <GitVersionNumberBranchPrefixes Condition="'$(GitVersionNumberBranchPrefixes)' == '' and '$(GitVersionNumber)' == 'true'">develop:1;</GitVersionNumberBranchPrefixes>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TALXISDevKitDataversePackageName)' != ''">


### PR DESCRIPTION
Implements the versioning strategy documented in `docs/Versioning.md`. Builds on top of #87 (CI detection).

## Breaking change

`GitVersionNumberBranches` is **renamed** to `GitVersionNumberBranchPrefixes`. Any `Directory.Build.props` using the old name must be updated.

---

## What changed

### Two-tier Major.Minor model

The key design insight: Major.Minor now carries deployment-environment meaning, not just a release label.

| Branch type | Major.Minor | Build number |
|---|---|---|
| Production branch (`main`, `master`, `hotfix/*`, `release/*`) | From `<Version>` in csproj | `[prefix]YYMM` |
| Everything else (develop, feature, PR, local) | Always `0.0` | `[prefix]YYMM` or `YYMM` |

This means a production artifact (`1.0.2506.xxx`) is **always** numerically higher than any develop artifact (`0.0.12506.xxx`), so the deployment version guard naturally prevents importing a lower-trust artifact into a higher environment.

### Two orthogonal properties

| Property | Purpose |
|---|---|
| `GitVersionNumberProductionBranches` | Glob list of branches that get real Major.Minor from csproj. Default: `main;master;hotfix/*;release/*` |
| `GitVersionNumberBranchPrefixes` | Optional `branch:prefix` map ordering environments within a tier. Default: `develop:1` |

Production branches are **not** in `GitVersionNumberBranchPrefixes` by default — they produce a clean `YYMM` build number. Teams that run multiple production-like environments (e.g. staging vs prod) can add them.

### Prefix 2 reserved for local builds

The `0.0.2xxxx.*` band is reserved exclusively for local (non-CI) builds. Assigning prefix `2` to a branch emits a build warning. Usable branch prefixes: `1` and `3–5`.

Current local build = `0.0.20000.0` (floor of the prefix-2 band). Future incremental local builds (time+dirty tree) will stay in this band.

### SemVer output

New `[Output]` property `SemVerOutput` on `GenerateGitVersion` task, exposed as `SemVer` MSBuild property. Always set (including local fallback: `0.0.20000+0`). Format: `Major.Minor.Build+Revision`.

### BranchVersioning.Prefix is now truly nullable

Previously a branch with no `:N` suffix got `Prefix = 0`, prepending `0` to the build number (`02506`). Now `Prefix` is `null` when not specified → clean `YYMM`.

### SDK defaults updated

```xml
<GitVersionNumberProductionBranches>main;master;hotfix/*;release/*;</GitVersionNumberProductionBranches>
<GitVersionNumberBranchPrefixes>develop:1;</GitVersionNumberBranchPrefixes>
```

---

## Docs

`docs/Versioning.md` is fully rewritten with a rationale-first approach ("The hard problem" section explains the five colliding constraints and why naive solutions fail). Sections cover safety rules, prefix ladder, Major/Minor sources (csproj / pipeline / release branch / git tag), SemVer roundtrip, workflow recipes, and a future incremental-local-builds section.

Supersedes #77