### PR TITLE
feat: default PD package zip name to csproj file name

### DIFF
--- a/src/Dataverse/PDPackage/README.md
+++ b/src/Dataverse/PDPackage/README.md
@@ -63,6 +63,7 @@ All `ProjectReference` items default to `ReferenceOutputAssembly=false` via `Ite
 | Property | Default | Description |
 |----------|---------|-------------|
 | `PdPackageMsBuildVersion` | `1.50.1` | Version of `Microsoft.PowerApps.MSBuild.PDPackage` imported by the package. |
+| `PdPackageTargetFileName` | `$(MSBuildProjectName).pdpkg.zip` | Name of the produced `.pdpkg.zip`. Defaults to the `.csproj` file name (instead of Microsoft's `$(PackageId)`). Set it explicitly to override. |
 | `GeneratePdPackageOnBuild` | `true` | Runs `GeneratePdPackage` after publish. |
 | `GeneratePackageOnPublish` | `true` | Triggers NuGet pack after `dotnet publish` to produce a `.nupkg` containing the `.pdpkg.zip`. |
 

--- a/src/Dataverse/PDPackage/README.md
+++ b/src/Dataverse/PDPackage/README.md
@@ -63,7 +63,7 @@ All `ProjectReference` items default to `ReferenceOutputAssembly=false` via `Ite
 | Property | Default | Description |
 |----------|---------|-------------|
 | `PdPackageMsBuildVersion` | `1.50.1` | Version of `Microsoft.PowerApps.MSBuild.PDPackage` imported by the package. |
-| `PdPackageTargetFileName` | `$(MSBuildProjectName).pdpkg.zip` | Name of the produced `.pdpkg.zip`. Defaults to the `.csproj` file name (instead of Microsoft's `$(PackageId)`). Set it explicitly to override. |
+| `PdPackageTargetFileName` | `$(PackageId).pdpkg.zip` | Name of the produced `.pdpkg.zip`.`$(PackageId)` falls back PackageId → AssemblyName → `.csproj` name. |
 | `GeneratePdPackageOnBuild` | `true` | Runs `GeneratePdPackage` after publish. |
 | `GeneratePackageOnPublish` | `true` | Triggers NuGet pack after `dotnet publish` to produce a `.nupkg` containing the `.pdpkg.zip`. |
 

--- a/src/Dataverse/PDPackage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.PdPackage.targets
+++ b/src/Dataverse/PDPackage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.PdPackage.targets
@@ -10,7 +10,7 @@
           BeforeTargets="ComputePdPackageOutput"
           Condition="'$(PdPackageTargetFileName)' == ''">
     <PropertyGroup>
-      <PdPackageTargetFileName>$(MSBuildProjectName).pdpkg.zip</PdPackageTargetFileName>
+      <PdPackageTargetFileName>$(PackageId)$(PdPackageTargetExt)</PdPackageTargetFileName>
     </PropertyGroup>
   </Target>
 

--- a/src/Dataverse/PDPackage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.PdPackage.targets
+++ b/src/Dataverse/PDPackage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.PdPackage.targets
@@ -6,6 +6,14 @@
     <GeneratePdPackageOnBuild Condition="'$(GeneratePdPackageOnBuild)'==''">true</GeneratePdPackageOnBuild>
   </PropertyGroup>
 
+  <Target Name="_OverridePdPackageZipName"
+          BeforeTargets="ComputePdPackageOutput"
+          Condition="'$(PdPackageTargetFileName)' == ''">
+    <PropertyGroup>
+      <PdPackageTargetFileName>$(MSBuildProjectName).pdpkg.zip</PdPackageTargetFileName>
+    </PropertyGroup>
+  </Target>
+
   <!-- Assembly merge: folds dependency DLLs into the package assembly after build.
        Uses the shared AssemblyMergeDependencies target from Tasks package.
        PdPackage excludes fewer assemblies than Plugin/WFA — Newtonsoft.Json is merged


### PR DESCRIPTION
Rebased version of PR #74 by @zekelinAlex on current master.

Original PR: #74

Defaults `PdPackageTargetFileName` to `$(PackageId)$(PdPackageTargetExt)` when not explicitly set, so the generated .pdpkg.zip has a meaningful name instead of the default from Microsoft.PowerApps.MSBuild.PDPackage.