### PR TITLE
Fix PDPackage ILRepack on Linux without Mono

### DIFF
--- a/src/Dataverse/PDPackage/msbuild/build/TALXIS.DevKit.Build.Dataverse.PdPackage.props
+++ b/src/Dataverse/PDPackage/msbuild/build/TALXIS.DevKit.Build.Dataverse.PdPackage.props
@@ -13,11 +13,11 @@
   <Import Project="$(_PdPackageMsBuildProps)" Condition="Exists('$(_PdPackageMsBuildProps)')" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.*" PrivateAssets="All" />
     <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="[2.0.44.2]" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.*" PrivateAssets="All" />
     <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>
 

--- a/src/Dataverse/PDPackage/msbuild/build/TALXIS.DevKit.Build.Dataverse.PdPackage.props
+++ b/src/Dataverse/PDPackage/msbuild/build/TALXIS.DevKit.Build.Dataverse.PdPackage.props
@@ -13,6 +13,7 @@
   <Import Project="$(_PdPackageMsBuildProps)" Condition="Exists('$(_PdPackageMsBuildProps)')" />
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.*" PrivateAssets="All" />
     <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="[2.0.44.2]" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/AssemblyMerge.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/AssemblyMerge.targets
@@ -19,6 +19,10 @@
       <_AssemblyMergeUnmergedPrimaryFromObj>$(IntermediateOutputPath)$(AssemblyName).dll</_AssemblyMergeUnmergedPrimaryFromObj>
       <!-- _AssemblyMergeOutputPath: final merged assembly written to the output directory. -->
       <_AssemblyMergeOutputPath>$(OutDir)$(AssemblyName).dll</_AssemblyMergeOutputPath>
+      <_AssemblyMergeTargetFrameworkReferenceAssemblyPath Condition="'$(TargetFrameworkRootPath)' != ''">$([System.IO.Path]::Combine('$(TargetFrameworkRootPath)', '$(TargetFrameworkIdentifier)', '$(TargetFrameworkVersion)'))</_AssemblyMergeTargetFrameworkReferenceAssemblyPath>
+      <_AssemblyMergeLibraryPath>$([System.IO.Path]::GetFullPath('$(OutDir)'))</_AssemblyMergeLibraryPath>
+      <_AssemblyMergeLibraryPath Condition="'$(FrameworkPathOverride)' != '' And Exists('$(FrameworkPathOverride)')">$(_AssemblyMergeLibraryPath);$([System.IO.Path]::GetFullPath('$(FrameworkPathOverride)'))</_AssemblyMergeLibraryPath>
+      <_AssemblyMergeLibraryPath Condition="'$(_AssemblyMergeTargetFrameworkReferenceAssemblyPath)' != '' And Exists('$(_AssemblyMergeTargetFrameworkReferenceAssemblyPath)')">$(_AssemblyMergeLibraryPath);$([System.IO.Path]::GetFullPath('$(_AssemblyMergeTargetFrameworkReferenceAssemblyPath)'))</_AssemblyMergeLibraryPath>
     </PropertyGroup>
     <ItemGroup>
       <!-- _AssemblyMergeAllOutputDlls: all DLLs in the output directory. -->
@@ -44,15 +48,14 @@
 
     <!-- Internalize=false: keep public type names so Dataverse reflection
          still finds IPlugin / CodeActivity types. -->
-    <!-- LibraryPath needs the absolute path to OutDir so Mono.Cecil's
-         resolver finds referenced assemblies regardless of CWD. -->
+    <!-- LibraryPath needs absolute paths so Mono.Cecil resolves output and reference assemblies regardless of CWD. -->
     <ILRepack Condition=" '@(_AssemblyMergeDependenciesToFold)' != '' "
               Parallel="true"
               Internalize="false"
               InputAssemblies="$(_AssemblyMergeUnmergedPrimaryFromObj);@(_AssemblyMergeDependenciesToFold)"
               OutputFile="$(_AssemblyMergeOutputPath)"
               KeyFile="$(AssemblyOriginatorKeyFile)"
-              LibraryPath="$([System.IO.Path]::GetFullPath('$(OutDir)'))" />
+              LibraryPath="$(_AssemblyMergeLibraryPath)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
## Root cause
PDPackage projects target net472 and reference `System.ComponentModel.Composition`. ILRepack merges OutDir DLLs, but on Linux without Mono the .NET Framework facade is not in the GAC/OutDir, so ILRepack could not resolve it from folded XrmTooling PackageDeployment dependencies.

## Changes
- Added `Microsoft.NETFramework.ReferenceAssemblies` with `PrivateAssets=All` to the PDPackage props so net472 reference assemblies are restored for consumers.
- Extended the shared AssemblyMerge ILRepack `LibraryPath` to include OutDir plus available .NET Framework reference assembly paths (`FrameworkPathOverride` and the restored `TargetFrameworkRootPath` path), preserving Plugin/WorkflowActivity behavior.

## Verification
- Packed local SDK/Tasks/PDPackage packages with `dotnet pack TALXIS.DevKit.Build.slnx --configuration Release -p:PackageVersion=0.0.1-pdlinux.1 -p:Version=0.0.1-pdlinux.1 -o artifacts/local-nupkg`.
- In `ghcr.io/talxis/tools-agentbox/image:latest`, confirmed `mono=`/no `mono` on PATH, scaffolded a `pp-package` plus `pp-solution`/`pp-entity`, consumed the locally packed packages from `/pkg`, restored `Microsoft.NETFramework.ReferenceAssemblies.net472`, and ran `dotnet build src/Packages.Main/Packages.Main.csproj --no-restore`.
- Result: `Build succeeded`, `0 Error(s)`, no `Failed to resolve assembly`; ILRepack merge completed successfully.