### PR TITLE
feat: add CI detection with local build version fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Defaults can be set per project or per folder via `Directory.Build.props` file. 
 <Project>
    <PropertyGroup>
       <GitVersionNumberBranches>master:1;main:1;develop:2;release/*:3</GitVersionNumberBranches>
-      <GitVersionNumberFallback>0.0.12345.0</GitVersionNumberFallback>
+      <LocalBuildVersionNumber>0.0.12345.0</LocalBuildVersionNumber>
    </PropertyGroup>
 </Project>
 ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Defaults can be set per project or per folder via `Directory.Build.props` file. 
 <Project>
    <PropertyGroup>
       <GitVersionNumberBranches>master:1;main:1;develop:2;release/*:3</GitVersionNumberBranches>
-      <LocalBuildVersionNumber>0.0.12345.0</LocalBuildVersionNumber>
    </PropertyGroup>
 </Project>
 ```

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -30,7 +30,7 @@ Commit counts include commits from all referenced projects (resolved recursively
 |----------|---------|-------------|
 | `GitVersionNumber` | `true` (SDK) / _empty_ (Tasks) | Master switch. Set to `false` to disable Git-based versioning entirely — the project's `Version` property is used as-is. When using the Tasks package directly (without the SDK), this is not set by default. |
 | `GitVersionNumberBranches` | `main:1;master:1;develop:2;` (SDK only) | Semicolon-separated branch rules. Each entry is `<branch-name>` or `<branch-name>:<prefix>`. Wildcard patterns are supported (e.g. `feature/*:0`). Defaults are only applied when using the SDK package; the Tasks package alone does not populate this. |
-| `LocalBuildVersionNumber` | `0.0.20000.0` | Version used when the build is not running in CI, or when the current branch does not match any rule in `GitVersionNumberBranches`. |
+| `LocalBuildVersionNumber` | `0.0.20000.0` | Version used when not in CI or when the branch doesn't match any rule. Override only when needed — by default `0.0.20000.0` is used automatically for local builds. |
 | `IsRunningInCI` | _(auto-detect)_ | Override CI detection. Set to `true` or `false` to force the behaviour; omit to let the task auto-detect from common CI environment variables (`CI`, `TF_BUILD`, `GITHUB_ACTIONS`, `GITLAB_CI`, `JENKINS_URL`, `CIRCLECI`, `TEAMCITY_VERSION`). |
 
 These properties can be set per project in your `.csproj` or shared via `Directory.Build.props`:
@@ -39,7 +39,6 @@ These properties can be set per project in your `.csproj` or shared via `Directo
 <Project>
    <PropertyGroup>
       <GitVersionNumberBranches>master:1;main:1;develop:2;release/*:3</GitVersionNumberBranches>
-      <LocalBuildVersionNumber>0.0.12345.0</LocalBuildVersionNumber>
    </PropertyGroup>
 </Project>
 ```
@@ -70,12 +69,6 @@ If you want to force git versioning locally for testing, you can set `IsRunningI
 
 ```shell
 dotnet build -p:IsRunningInCI=true
-```
-
-To pin a predictable local version regardless of CI detection, you can set `LocalBuildVersionNumber`:
-
-```xml
-<LocalBuildVersionNumber>0.0.12345.0</LocalBuildVersionNumber>
 ```
 
 Or clear the branch rules to force the fallback even in CI:

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -30,7 +30,8 @@ Commit counts include commits from all referenced projects (resolved recursively
 |----------|---------|-------------|
 | `GitVersionNumber` | `true` (SDK) / _empty_ (Tasks) | Master switch. Set to `false` to disable Git-based versioning entirely — the project's `Version` property is used as-is. When using the Tasks package directly (without the SDK), this is not set by default. |
 | `GitVersionNumberBranches` | `main:1;master:1;develop:2;` (SDK only) | Semicolon-separated branch rules. Each entry is `<branch-name>` or `<branch-name>:<prefix>`. Wildcard patterns are supported (e.g. `feature/*:0`). Defaults are only applied when using the SDK package; the Tasks package alone does not populate this. |
-| `GitVersionNumberFallback` | `0.0.20000.0` | Version used when the current branch does not match any rule in `GitVersionNumberBranches`. |
+| `LocalBuildVersionNumber` | `0.0.20000.0` | Version used when the build is not running in CI, or when the current branch does not match any rule in `GitVersionNumberBranches`. |
+| `IsRunningInCI` | _(auto-detect)_ | Override CI detection. Set to `true` or `false` to force the behaviour; omit to let the task auto-detect from common CI environment variables (`CI`, `TF_BUILD`, `GITHUB_ACTIONS`, `GITLAB_CI`, `JENKINS_URL`, `CIRCLECI`, `TEAMCITY_VERSION`). |
 
 These properties can be set per project in your `.csproj` or shared via `Directory.Build.props`:
 
@@ -38,7 +39,7 @@ These properties can be set per project in your `.csproj` or shared via `Directo
 <Project>
    <PropertyGroup>
       <GitVersionNumberBranches>master:1;main:1;develop:2;release/*:3</GitVersionNumberBranches>
-      <GitVersionNumberFallback>0.0.12345.0</GitVersionNumberFallback>
+      <LocalBuildVersionNumber>0.0.12345.0</LocalBuildVersionNumber>
    </PropertyGroup>
 </Project>
 ```
@@ -53,15 +54,35 @@ Set `GitVersionNumber` to `false` to disable automatic version generation:
 
 When disabled, `GitVersionNumberBranches` is not populated with defaults and the `GenerateGitVersion` task uses the project's `Version` property as-is.
 
-### Local builds on tracked branches
+### Local builds
 
-When building locally on `develop` or `master`, Git versioning produces a commit-derived version number (same as CI). If you prefer a predictable local version, you can override the branch rules at build time:
+When building locally, the task auto-detects that it is not in CI and uses `LocalBuildVersionNumber` instead of generating a commit-derived version. No extra configuration is needed.
+
+If you need to override this detection (e.g., your CI system is not recognised), set `IsRunningInCI` explicitly:
+
+```xml
+<IsRunningInCI>true</IsRunningInCI>
+```
+
+### Local builds on tracked branches (manual override)
+
+If you want to force git versioning locally for testing, you can set `IsRunningInCI=true` at the command line:
+
+```shell
+dotnet build -p:IsRunningInCI=true
+```
+
+To pin a predictable local version regardless of CI detection, you can set `LocalBuildVersionNumber`:
+
+```xml
+<LocalBuildVersionNumber>0.0.12345.0</LocalBuildVersionNumber>
+```
+
+Or clear the branch rules to force the fallback even in CI:
 
 ```shell
 dotnet build -p:GitVersionNumberBranches=""
 ```
-
-This clears the branch rules for that build, causing the task to fall back to `GitVersionNumberFallback`.
 
 ## PCFs
 

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -57,24 +57,10 @@ When disabled, `GitVersionNumberBranches` is not populated with defaults and the
 
 When building locally, the task auto-detects that it is not in CI and uses `LocalBuildVersionNumber` instead of generating a commit-derived version. No extra configuration is needed.
 
-If you need to override this detection (e.g., your CI system is not recognised), set `IsRunningInCI` explicitly:
+If your CI system is not auto-detected, set `IsRunningInCI` explicitly in your pipeline configuration:
 
 ```xml
 <IsRunningInCI>true</IsRunningInCI>
-```
-
-### Local builds on tracked branches (manual override)
-
-If you want to force git versioning locally for testing, you can set `IsRunningInCI=true` at the command line:
-
-```shell
-dotnet build -p:IsRunningInCI=true
-```
-
-Or clear the branch rules to force the fallback even in CI:
-
-```shell
-dotnet build -p:GitVersionNumberBranches=""
 ```
 
 ## PCFs

--- a/src/Dataverse/Tasks/README.md
+++ b/src/Dataverse/Tasks/README.md
@@ -61,7 +61,7 @@ Error codes emitted by validation tasks:
 |----------|---------|-------------|
 | `Version` | _(required)_ | Base version (`Major.Minor`); used by `GenerateGitVersion` to produce the full version. |
 
-See [Versioning](/docs/Versioning.md) for the full list of versioning properties (`GitVersionNumber`, `GitVersionNumberBranches`, `GitVersionNumberFallback`) and the version number format.
+See [Versioning](/docs/Versioning.md) for the full list of versioning properties (`GitVersionNumber`, `GitVersionNumberBranches`, `LocalBuildVersionNumber`, `IsRunningInCI`) and the version number format.
 
 ### Solution packager paths
 

--- a/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
+++ b/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
@@ -39,9 +39,8 @@ public class GenerateGitVersion : Task
     {
         Log.LogMessage(MessageImportance.High, "Preparing to generate version number...");
 
-        if (LocalBuildVersionNumber == null)
+        if (string.IsNullOrEmpty(LocalBuildVersionNumber))
         {
-            Log.LogWarning("LocalBuildVersionNumber is null, setting to default.");
             LocalBuildVersionNumber = "0.0.20000.0";
         }
 

--- a/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
+++ b/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
@@ -24,7 +24,8 @@ public class GenerateGitVersion : Task
     [Required]
     public string Version { get; set; }
     public string GitVersionNumberBranches { get; set; } // template "master;hotfix;develop:1;pr:3;other:0"
-    public string GitVersionNumberFallback { get; set; }
+    public string LocalBuildVersionNumber { get; set; }
+    public string IsRunningInCI { get; set; }
     public string GitVersionBranch { get; set; }
 
     [Output]
@@ -38,17 +39,25 @@ public class GenerateGitVersion : Task
     {
         Log.LogMessage(MessageImportance.High, "Preparing to generate version number...");
 
-        if (GitVersionNumberFallback == null)
+        if (LocalBuildVersionNumber == null)
         {
-            Log.LogWarning("GitVersionNumberFallback is null, setting to default.");
-            GitVersionNumberFallback = "0.0.20000.0";
+            Log.LogWarning("LocalBuildVersionNumber is null, setting to default.");
+            LocalBuildVersionNumber = "0.0.20000.0";
         }
 
         // Ensure repository is connected to Git before running commands
         if (!TryFindGitRoot(ProjectPath, out var gitRoot))
         {
             Log.LogMessage(MessageImportance.High, "Git repository not found; skipping automatic Git versioning.");
-            VersionOutput = GitVersionNumberFallback;
+            VersionOutput = LocalBuildVersionNumber;
+            return true;
+        }
+
+        if (!DetectIsRunningInCI())
+        {
+            Log.LogMessage(MessageImportance.High, "Not running in CI; using LocalBuildVersionNumber.");
+            VersionOutput = LocalBuildVersionNumber;
+            LastCommitDateTimeOutput = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
             return true;
         }
 
@@ -87,7 +96,7 @@ public class GenerateGitVersion : Task
             if (branch == null)
             {
                 Log.LogWarning($"The current branch '{currentBranch}' is not enabled for automatic Git versioning.");
-                VersionOutput = GitVersionNumberFallback;
+                VersionOutput = LocalBuildVersionNumber;
                 LastCommitDateTimeOutput = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
                 return true;
             }
@@ -147,7 +156,7 @@ public class GenerateGitVersion : Task
         catch (Exception ex)
         {
             Log.LogMessage(MessageImportance.High, $"Git versioning skipped: {ex.Message}");
-            VersionOutput = GitVersionNumberFallback;
+            VersionOutput = LocalBuildVersionNumber;
             LastCommitDateTimeOutput = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
             return true;
         }
@@ -308,6 +317,39 @@ public class GenerateGitVersion : Task
             directory = directory.Parent;
         }
         gitRoot = null;
+        return false;
+    }
+    private bool DetectIsRunningInCI()
+    {
+        if (!string.IsNullOrEmpty(IsRunningInCI))
+        {
+            var result = string.Equals(IsRunningInCI, "true", StringComparison.OrdinalIgnoreCase);
+            Log.LogMessage(MessageImportance.High, $"IsRunningInCI overridden to: {result}");
+            return result;
+        }
+
+        var ciVars = new[]
+        {
+            "CI",             // Generic (GitHub Actions, GitLab, Travis, CircleCI, etc.)
+            "TF_BUILD",       // Azure DevOps
+            "GITHUB_ACTIONS", // GitHub Actions
+            "GITLAB_CI",      // GitLab CI
+            "JENKINS_URL",    // Jenkins
+            "CIRCLECI",       // CircleCI
+            "TEAMCITY_VERSION" // TeamCity
+        };
+
+        foreach (var varName in ciVars)
+        {
+            var value = Environment.GetEnvironmentVariable(varName);
+            if (!string.IsNullOrEmpty(value))
+            {
+                Log.LogMessage(MessageImportance.High, $"CI environment detected via {varName}={value}");
+                return true;
+            }
+        }
+
+        Log.LogMessage(MessageImportance.High, "No CI environment detected; treating as local build.");
         return false;
     }
     private void RetrieveAllProjectReferences(string projectPath, List<string> projects)

--- a/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
+++ b/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
@@ -39,11 +39,6 @@ public class GenerateGitVersion : Task
     {
         Log.LogMessage(MessageImportance.High, "Preparing to generate version number...");
 
-        if (string.IsNullOrEmpty(LocalBuildVersionNumber))
-        {
-            LocalBuildVersionNumber = "0.0.20000.0";
-        }
-
         // Ensure repository is connected to Git before running commands
         if (!TryFindGitRoot(ProjectPath, out var gitRoot))
         {

--- a/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
+++ b/src/Dataverse/Tasks/Tasks/GenerateGitVersion.cs
@@ -44,6 +44,7 @@ public class GenerateGitVersion : Task
         {
             Log.LogMessage(MessageImportance.High, "Git repository not found; skipping automatic Git versioning.");
             VersionOutput = LocalBuildVersionNumber;
+            LastCommitDateTimeOutput = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
             return true;
         }
 
@@ -317,28 +318,46 @@ public class GenerateGitVersion : Task
     {
         if (!string.IsNullOrEmpty(IsRunningInCI))
         {
-            var result = string.Equals(IsRunningInCI, "true", StringComparison.OrdinalIgnoreCase);
-            Log.LogMessage(MessageImportance.High, $"IsRunningInCI overridden to: {result}");
-            return result;
+            if (bool.TryParse(IsRunningInCI, out var overrideValue))
+            {
+                Log.LogMessage(MessageImportance.High, $"IsRunningInCI overridden to: {overrideValue}");
+                return overrideValue;
+            }
+            Log.LogWarning($"IsRunningInCI value '{IsRunningInCI}' is not a valid boolean; falling back to auto-detection.");
         }
 
-        var ciVars = new[]
+        // Boolean-style vars: only treat explicit "true" as CI
+        var booleanCiVars = new[]
         {
             "CI",             // Generic (GitHub Actions, GitLab, Travis, CircleCI, etc.)
             "TF_BUILD",       // Azure DevOps
             "GITHUB_ACTIONS", // GitHub Actions
             "GITLAB_CI",      // GitLab CI
-            "JENKINS_URL",    // Jenkins
             "CIRCLECI",       // CircleCI
+        };
+
+        foreach (var varName in booleanCiVars)
+        {
+            var value = Environment.GetEnvironmentVariable(varName);
+            if (bool.TryParse(value, out var boolValue) && boolValue)
+            {
+                Log.LogMessage(MessageImportance.High, $"CI environment detected via {varName}");
+                return true;
+            }
+        }
+
+        // Non-boolean vars: any non-empty value indicates CI
+        var presenceCiVars = new[]
+        {
+            "JENKINS_URL",     // Jenkins
             "TEAMCITY_VERSION" // TeamCity
         };
 
-        foreach (var varName in ciVars)
+        foreach (var varName in presenceCiVars)
         {
-            var value = Environment.GetEnvironmentVariable(varName);
-            if (!string.IsNullOrEmpty(value))
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(varName)))
             {
-                Log.LogMessage(MessageImportance.High, $"CI environment detected via {varName}={value}");
+                Log.LogMessage(MessageImportance.High, $"CI environment detected via {varName}");
                 return true;
             }
         }

--- a/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.props
+++ b/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.props
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <LocalBuildVersionNumber Condition="'$(LocalBuildVersionNumber)' == ''">0.0.20000.0</LocalBuildVersionNumber>
+  </PropertyGroup>
 </Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/GenerateVersionNumber.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/GenerateVersionNumber.targets
@@ -14,7 +14,8 @@
 			ProjectFileName="$(ProjectFileName)"
 			GitVersionNumberBranches="$(GitVersionNumberBranches)"
 			Version="$(Version)"
-			GitVersionNumberFallback="$(GitVersionNumberFallback)"
+			LocalBuildVersionNumber="$(LocalBuildVersionNumber)"
+			IsRunningInCI="$(IsRunningInCI)"
 			GitVersionBranch="$(GitVersionBranch)"
 		>
 			<Output TaskParameter="VersionOutput" PropertyName="Version"/>


### PR DESCRIPTION
## Summary

When `GenerateGitVersion` runs outside of CI (local developer build), it now detects this automatically and skips git-based versioning, returning a predictable `LocalBuildVersionNumber` instead.

Closes #54 — local builds on `develop`/`master` no longer produce git-derived versions; `LocalBuildVersionNumber` (`0.0.20000.0` by default) is always used when not in CI.

## Changes

### `GenerateGitVersion.cs`
- **Renamed** `GitVersionNumberFallback` → `LocalBuildVersionNumber` (name better reflects its purpose)
- **Added** `IsRunningInCI` string property — leave empty for auto-detection, or set explicitly to `"true"`/`"false"` to override
- **Added** `DetectIsRunningInCI()` helper that checks common CI environment variables:
  - `CI` (GitHub Actions, GitLab, Travis, CircleCI, …)
  - `TF_BUILD` (Azure DevOps)
  - `GITHUB_ACTIONS`
  - `GITLAB_CI`
  - `JENKINS_URL`
  - `CIRCLECI`
  - `TEAMCITY_VERSION`
- **Early-exit** in `Execute()`: if not in CI → log message + return `LocalBuildVersionNumber` immediately, skipping all git commands

### `TALXIS.DevKit.Build.Dataverse.Tasks.props`
- Default value for `LocalBuildVersionNumber` set here (`0.0.20000.0`) using the standard `Condition` pattern, consistent with other property defaults

### `GenerateVersionNumber.targets`
- Updated task invocation: `GitVersionNumberFallback` → `LocalBuildVersionNumber`, added `IsRunningInCI`

### Docs
- Updated `docs/Versioning.md`, `README.md`, `src/Dataverse/Tasks/README.md` with new property names and CI detection documentation

## Behaviour

| Scenario | Version used |
|----------|-------------|
| Local build (no CI env vars) | `LocalBuildVersionNumber` (default `0.0.20000.0`) |
| CI build, branch matched | Git-derived version |
| CI build, branch not matched | `LocalBuildVersionNumber` |
| CI not auto-detected, set `<IsRunningInCI>true</IsRunningInCI>` in pipeline | Git-derived version |

## Breaking change

`GitVersionNumberFallback` is renamed to `LocalBuildVersionNumber`. Update any project files or `Directory.Build.props` that set this property.