### PR TITLE
refactor: remove vestigial ILRepack assembly merge from PdPackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Project dependency folders are analyzed for Git changes to be reflected in gener
 | [TALXIS.DevKit.Build.Dataverse.Pcf](src/Dataverse/Pcf/README.md) | MSBuild integration for PCF controls. Wraps `Microsoft.PowerApps.MSBuild.Pcf` with Git-based versioning. |
 | [TALXIS.DevKit.Build.Dataverse.WorkflowActivity](src/Dataverse/WorkflowActivity/README.md) | MSBuild integration for custom workflow activity assemblies with auto-versioning and Solution project integration. |
 | [TALXIS.DevKit.Build.Dataverse.ScriptLibrary](src/Dataverse/ScriptLibrary/README.md) | Builds TypeScript/JS web resource projects (`npm install` + `npm run build`) and integrates them into Solution builds. |
-| [TALXIS.DevKit.Build.Dataverse.PdPackage](src/Dataverse/PDPackage/README.md) | Package Deployer integration with ILRepack assembly merging and CMT metadata merge/zip support. |
+| [TALXIS.DevKit.Build.Dataverse.PdPackage](src/Dataverse/PDPackage/README.md) | Package Deployer integration with CMT metadata merge/zip support. |
 
 ## Getting Started
 > [!TIP]  

--- a/src/Dataverse/PDPackage/README.md
+++ b/src/Dataverse/PDPackage/README.md
@@ -1,6 +1,6 @@
 # TALXIS.DevKit.Build.Dataverse.PdPackage
 
-MSBuild integration for Power Platform Package Deployer (PD) packages. Wraps `Microsoft.PowerApps.MSBuild.PDPackage`, adds ILRepack-based assembly merging for the deployment package DLL, and provides Configuration Migration Tool (CMT) package discovery, metadata merging, and zipping.
+MSBuild integration for Power Platform Package Deployer (PD) packages. Wraps `Microsoft.PowerApps.MSBuild.PDPackage` and provides Configuration Migration Tool (CMT) package discovery, metadata merging, and zipping.
 
 ## Installation
 
@@ -46,10 +46,6 @@ The generated entries appear in the **same order as the references are declared 
 
 If you ship a hand-written `PkgAssets/ImportConfig.xml` with explicit `<configsolutionfile>` entries, auto-generation is skipped entirely and your file is used as-is.
 
-### Assembly merge
-
-`AssemblyMergeDependencies` (runs after `Build` via `_AssemblyMergePackageDependenciesAfterBuild`) merges dependency DLLs into the main output assembly using the shared ILRepack engine from `TALXIS.DevKit.Build.Dataverse.Tasks`. PdPackage defaults to a different exclude list than Plugin/WorkflowActivity — `Newtonsoft.Json` is **not** excluded because the package-deployer runtime doesn't provide it. Can be disabled with `<AssemblyMergeSkip>true</AssemblyMergeSkip>`.
-
 ### CMT package discovery
 
 `DiscoverCmtPackages` scans for folders containing `[Content_Types].xml` with sibling `data.xml` and `data_schema.xml`. Supports include/exclude filtering via `IncludedCmtPackages`/`ExcludedCmtPackages`.
@@ -76,13 +72,6 @@ If you ship a hand-written `PkgAssets/ImportConfig.xml` with explicit `<configso
 | `PdPackageTargetFileName` | `$(PackageId).pdpkg.zip` | Name of the produced `.pdpkg.zip`.`$(PackageId)` falls back PackageId → AssemblyName → `.csproj` name. |
 | `GeneratePdPackageOnBuild` | `true` | Runs `GeneratePdPackage` after publish. |
 | `GeneratePackageOnPublish` | `true` | Triggers NuGet pack after `dotnet publish` to produce a `.nupkg` containing the `.pdpkg.zip`. |
-
-### Assembly merge
-
-| Property | Default | Description |
-|----------|---------|-------------|
-| `AssemblyMergeSkip` | _(unset)_ | When `true`, skips the post-build `AssemblyMergeDependencies` ILRepack step. |
-| `AssemblyMergeExcludes` | `mscorlib;netstandard;Microsoft.Xrm.Sdk;Microsoft.Crm.Sdk.Proxy` | Semicolon-separated assembly filenames (without `.dll`) to exclude from merging. Note: PdPackage does **not** exclude `Newtonsoft.Json` by default (unlike Plugin/WorkflowActivity) because the package-deployer runtime doesn't provide it. Prefix patterns `Microsoft.Xrm.Sdk.*` and `System.*` are always excluded. |
 
 ### Validation
 
@@ -115,7 +104,7 @@ If you ship a hand-written `PkgAssets/ImportConfig.xml` with explicit `<configso
 
 ## Related Packages
 
-- **Depends on**: `Microsoft.PowerApps.MSBuild.PDPackage`, `ILRepack.Lib.MSBuild.Task`, `TALXIS.DevKit.Build.Dataverse.Tasks`
+- **Depends on**: `Microsoft.PowerApps.MSBuild.PDPackage`, `TALXIS.DevKit.Build.Dataverse.Tasks`
 - **Typically references**: `TALXIS.DevKit.Build.Dataverse.Solution` projects
 
 

--- a/src/Dataverse/PDPackage/TALXIS.DevKit.Build.Dataverse.PdPackage.nuspec
+++ b/src/Dataverse/PDPackage/TALXIS.DevKit.Build.Dataverse.PdPackage.nuspec
@@ -17,7 +17,6 @@
     <repository type="git" url="https://github.com/TALXIS/tools-devkit-build" branch="master" />
     <dependencies>
       <dependency id="Microsoft.PowerApps.MSBuild.PDPackage" version="$MicrosoftPowerAppsTargetsVersion$" />
-      <dependency id="ILRepack.Lib.MSBuild.Task" version="[2.0.44.2]" />
       <dependency id="TALXIS.DevKit.Build.Dataverse.Tasks" version="$Version$" />
     </dependencies>
   </metadata>

--- a/src/Dataverse/PDPackage/msbuild/build/TALXIS.DevKit.Build.Dataverse.PdPackage.props
+++ b/src/Dataverse/PDPackage/msbuild/build/TALXIS.DevKit.Build.Dataverse.PdPackage.props
@@ -12,10 +12,6 @@
 
   <Import Project="$(_PdPackageMsBuildProps)" Condition="Exists('$(_PdPackageMsBuildProps)')" />
 
-  <ItemGroup>
-    <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="[2.0.44.2]" PrivateAssets="All" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.*" PrivateAssets="All" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/Dataverse/PDPackage/msbuild/tasks/AssemblyMergeDisableAutoMerge.targets
+++ b/src/Dataverse/PDPackage/msbuild/tasks/AssemblyMergeDisableAutoMerge.targets
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- No-op. PdPackage.targets sets $(ILRepackTargetsFile) to this file
-     to suppress ILRepack.Lib.MSBuild.Task's own AfterTargets="Build" target. -->
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-</Project>

--- a/src/Dataverse/PDPackage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.PdPackage.targets
+++ b/src/Dataverse/PDPackage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.PdPackage.targets
@@ -14,21 +14,6 @@
     </PropertyGroup>
   </Target>
 
-  <!-- Assembly merge: folds dependency DLLs into the package assembly after build.
-       Uses the shared AssemblyMergeDependencies target from Tasks package.
-       PdPackage excludes fewer assemblies than Plugin/WFA — Newtonsoft.Json is merged
-       because the package-deployer runtime doesn't provide it.
-       Opt out: <AssemblyMergeSkip>true</AssemblyMergeSkip>. -->
-  <PropertyGroup>
-    <AssemblyMergeExcludes Condition="'$(AssemblyMergeExcludes)' == ''">mscorlib;netstandard;Microsoft.Xrm.Sdk;Microsoft.Crm.Sdk.Proxy</AssemblyMergeExcludes>
-    <ILRepackTargetsFile>$(MSBuildThisFileDirectory)AssemblyMergeDisableAutoMerge.targets</ILRepackTargetsFile>
-  </PropertyGroup>
-
-  <Target Name="_AssemblyMergePackageDependenciesAfterBuild"
-          AfterTargets="Build"
-          Condition="'$(AssemblyMergeSkip)' != 'true'"
-          DependsOnTargets="AssemblyMergeDependencies" />
-
   <Target Name="_DetectPdProjectReferenceTypes"
           BeforeTargets="ResolveProjectReferences"
           Condition="'@(ProjectReference)'!=''">


### PR DESCRIPTION
Removes the ILRepack assembly merge step from `TALXIS.DevKit.Build.Dataverse.PdPackage`. The merge is vestigial: dependency DLLs are already placed next to the package assembly inside the generated `.pdpkg.zip`, so merging them into a single DLL no longer serves any purpose.