### PR TITLE
fix: run Git version generation for PdPackage projects (#89)

### DIFF
--- a/src/Dataverse/PDPackage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.PdPackage.targets
+++ b/src/Dataverse/PDPackage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.PdPackage.targets
@@ -14,23 +14,16 @@
     </PropertyGroup>
   </Target>
 
-  <!-- Runs before BeforeBuild and before GenerateNuspec; generates and applies the Git-based
-       version number so the .pdpkg.zip and .nupkg pick up the SDK's versioning strategy instead
-       of the static <Version> literal in the csproj.
+  <!-- Generates and applies the Git-based version number so the .pdpkg.zip and .nupkg use the
+       repository's versioning strategy instead of the static <Version> literal in the csproj.
 
-       GenerateNuspec is included in addition to BeforeBuild because a no-build pack (dotnet pack
-       with the NoBuild flag set) skips Build/BeforeBuild entirely: PdPackage's pack pipeline
-       (_IncludePdPackageZipInPack to _GeneratePdPackageAfterPublish, AfterTargets="Publish") does
-       not force Build to run first (unlike Solution's pack pipeline, which uses
-       DependsOnTargets="Build" directly). Without this second hook, a no-build pack would
-       silently produce a nupkg with the stale, project-evaluation-time version.
-
-       GenerateNuspec, not Pack, is the correct hook point: Pack's own DependsOnTargets already
-       includes GenerateNuspec, and the actual PackageVersion value is read inside GenerateNuspec's
-       target body (via the PackTask). A BeforeTargets="Pack" hook would run after GenerateNuspec
-       has already executed, too late to have any effect. Hooking GenerateNuspec directly does not
-       force Build: GenerateNuspecDependsOn only conditionally includes Build when NoBuild is not
-       true, so a no-build pack still correctly skips Build. -->
+       Hooked before both BeforeBuild and GenerateNuspec because a no-build pack (dotnet pack
+       with NoBuild set) skips Build/BeforeBuild entirely, and PdPackage's pack pipeline does not
+       force Build to run first (unlike Solution's, which depends on Build directly). GenerateNuspec
+       is the correct target to hook: it is what actually reads PackageVersion (via PackTask) and
+       it runs as one of Pack's own dependencies, so hooking Pack itself would run too late. Hooking
+       GenerateNuspec does not force Build to run: GenerateNuspecDependsOn only includes Build when
+       NoBuild is not set. -->
   <Target Name="_ApplyPdPackageVersionNumber" BeforeTargets="BeforeBuild;GenerateNuspec">
     <CallTarget Targets="GenerateVersionNumber" />
   </Target>

--- a/src/Dataverse/PDPackage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.PdPackage.targets
+++ b/src/Dataverse/PDPackage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.PdPackage.targets
@@ -14,10 +14,24 @@
     </PropertyGroup>
   </Target>
 
-  <!-- Runs before BeforeBuild; generates and applies the Git-based version number so the
-       .pdpkg.zip and .nupkg pick up the SDK's versioning strategy instead of the static
-       <Version> literal in the csproj. -->
-  <Target Name="_ApplyPdPackageVersionNumber" BeforeTargets="BeforeBuild">
+  <!-- Runs before BeforeBuild and before GenerateNuspec; generates and applies the Git-based
+       version number so the .pdpkg.zip and .nupkg pick up the SDK's versioning strategy instead
+       of the static <Version> literal in the csproj.
+
+       GenerateNuspec is included in addition to BeforeBuild because a no-build pack (dotnet pack
+       with the NoBuild flag set) skips Build/BeforeBuild entirely: PdPackage's pack pipeline
+       (_IncludePdPackageZipInPack to _GeneratePdPackageAfterPublish, AfterTargets="Publish") does
+       not force Build to run first (unlike Solution's pack pipeline, which uses
+       DependsOnTargets="Build" directly). Without this second hook, a no-build pack would
+       silently produce a nupkg with the stale, project-evaluation-time version.
+
+       GenerateNuspec, not Pack, is the correct hook point: Pack's own DependsOnTargets already
+       includes GenerateNuspec, and the actual PackageVersion value is read inside GenerateNuspec's
+       target body (via the PackTask). A BeforeTargets="Pack" hook would run after GenerateNuspec
+       has already executed, too late to have any effect. Hooking GenerateNuspec directly does not
+       force Build: GenerateNuspecDependsOn only conditionally includes Build when NoBuild is not
+       true, so a no-build pack still correctly skips Build. -->
+  <Target Name="_ApplyPdPackageVersionNumber" BeforeTargets="BeforeBuild;GenerateNuspec">
     <CallTarget Targets="GenerateVersionNumber" />
   </Target>
 

--- a/src/Dataverse/PDPackage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.PdPackage.targets
+++ b/src/Dataverse/PDPackage/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.PdPackage.targets
@@ -14,6 +14,13 @@
     </PropertyGroup>
   </Target>
 
+  <!-- Runs before BeforeBuild; generates and applies the Git-based version number so the
+       .pdpkg.zip and .nupkg pick up the SDK's versioning strategy instead of the static
+       <Version> literal in the csproj. -->
+  <Target Name="_ApplyPdPackageVersionNumber" BeforeTargets="BeforeBuild">
+    <CallTarget Targets="GenerateVersionNumber" />
+  </Target>
+
   <Target Name="_DetectPdProjectReferenceTypes"
           BeforeTargets="ResolveProjectReferences"
           Condition="'@(ProjectReference)'!=''">

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/GenerateVersionNumber.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/GenerateVersionNumber.targets
@@ -1,6 +1,16 @@
 <Project>
 	<Target Name="GenerateVersionNumber">
 		<Error Text="Version element in your project file is missing. You must declare a version number in order to specify major and minor numbers." Condition=" '$(Version)' == '' " />
+		<!-- Capture PackageVersion's state before Git version generation runs. The .NET SDK
+		     defaults PackageVersion from Version at project-evaluation time, so if they still
+		     match here, PackageVersion was never explicitly customized by the consumer and it's
+		     safe to overwrite it below. If a consumer set PackageVersion to something different
+		     from Version on purpose (e.g. to pin a package version independently), this leaves
+		     their explicit value alone instead of silently clobbering it. -->
+		<PropertyGroup>
+			<_GenerateVersionNumberPackageVersionWasImplicit Condition="'$(PackageVersion)' == '$(Version)'">true</_GenerateVersionNumberPackageVersionWasImplicit>
+			<_GenerateVersionNumberPackageVersionWasImplicit Condition="'$(_GenerateVersionNumberPackageVersionWasImplicit)' == ''">false</_GenerateVersionNumberPackageVersionWasImplicit>
+		</PropertyGroup>
 		<RetrieveProjectReferences CurrentProjectFullPath="$(MSBuildProjectFullPath)">
 			<Output TaskParameter="ReferencedProjects" ItemName="AllReferences"/>
 		</RetrieveProjectReferences>
@@ -25,8 +35,10 @@
 		</GenerateGitVersion>
 		<!-- PackageVersion defaults from $(Version) at project-evaluation time, before this target
 		     runs, so it does not pick up the Git-generated Version automatically. Reset it explicitly
-		     so `dotnet pack` produces a .nupkg with the Git-generated version. -->
-		<PropertyGroup>
+		     so `dotnet pack` produces a .nupkg with the Git-generated version - but only if it was
+		     implicit to begin with (see capture above), so an explicit consumer override of
+		     PackageVersion is preserved untouched. -->
+		<PropertyGroup Condition="'$(_GenerateVersionNumberPackageVersionWasImplicit)' == 'true'">
 			<PackageVersion>$(Version)</PackageVersion>
 		</PropertyGroup>
 		<Message Text="Git-generated version number: $(Version)" Importance="high" />

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/GenerateVersionNumber.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/GenerateVersionNumber.targets
@@ -23,6 +23,12 @@
 			<Output TaskParameter="SemVerOutput" PropertyName="SemVer"/>
 			<Output TaskParameter="LastCommitDateTimeOutput" PropertyName="LastCommitDateTime"/>
 		</GenerateGitVersion>
+		<!-- PackageVersion defaults from $(Version) at project-evaluation time, before this target
+		     runs, so it does not pick up the Git-generated Version automatically. Reset it explicitly
+		     so `dotnet pack` produces a .nupkg with the Git-generated version. -->
+		<PropertyGroup>
+			<PackageVersion>$(Version)</PackageVersion>
+		</PropertyGroup>
 		<Message Text="Git-generated version number: $(Version)" Importance="high" />
 		<Message Text="Last commit date and time: $(LastCommitDateTime)" Importance="high" />
 	</Target>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/GenerateVersionNumber.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/GenerateVersionNumber.targets
@@ -1,12 +1,9 @@
 <Project>
 	<Target Name="GenerateVersionNumber">
 		<Error Text="Version element in your project file is missing. You must declare a version number in order to specify major and minor numbers." Condition=" '$(Version)' == '' " />
-		<!-- Capture PackageVersion's state before Git version generation runs. The .NET SDK
-		     defaults PackageVersion from Version at project-evaluation time, so if they still
-		     match here, PackageVersion was never explicitly customized by the consumer and it's
-		     safe to overwrite it below. If a consumer set PackageVersion to something different
-		     from Version on purpose (e.g. to pin a package version independently), this leaves
-		     their explicit value alone instead of silently clobbering it. -->
+		<!-- The .NET SDK defaults PackageVersion from Version at project-evaluation time. Record
+		     whether that default is still in effect so PackageVersion can be safely regenerated
+		     below without overwriting a value the consumer set explicitly. -->
 		<PropertyGroup>
 			<_GenerateVersionNumberPackageVersionWasImplicit Condition="'$(PackageVersion)' == '$(Version)'">true</_GenerateVersionNumberPackageVersionWasImplicit>
 			<_GenerateVersionNumberPackageVersionWasImplicit Condition="'$(_GenerateVersionNumberPackageVersionWasImplicit)' == ''">false</_GenerateVersionNumberPackageVersionWasImplicit>
@@ -33,11 +30,9 @@
 			<Output TaskParameter="SemVerOutput" PropertyName="SemVer"/>
 			<Output TaskParameter="LastCommitDateTimeOutput" PropertyName="LastCommitDateTime"/>
 		</GenerateGitVersion>
-		<!-- PackageVersion defaults from $(Version) at project-evaluation time, before this target
-		     runs, so it does not pick up the Git-generated Version automatically. Reset it explicitly
-		     so `dotnet pack` produces a .nupkg with the Git-generated version - but only if it was
-		     implicit to begin with (see capture above), so an explicit consumer override of
-		     PackageVersion is preserved untouched. -->
+		<!-- Apply the Git-generated Version to PackageVersion so dotnet pack produces a .nupkg
+		     with the same version, unless PackageVersion was set explicitly by the consumer
+		     (see the capture above), in which case it is left untouched. -->
 		<PropertyGroup Condition="'$(_GenerateVersionNumberPackageVersionWasImplicit)' == 'true'">
 			<PackageVersion>$(Version)</PackageVersion>
 		</PropertyGroup>


### PR DESCRIPTION
## Summary

Fixes #89. `PdPackage.targets` never triggered Git-based version generation, unlike `Solution.targets` and `Plugin.targets`. Any `ProjectType=PDPackage` project silently shipped whatever static version string was in the csproj's `<Version>`, bypassing the SDK's branch-based versioning strategy described in `docs/Versioning.md`.

## Changes

- **`PdPackage.targets`**: added `_ApplyPdPackageVersionNumber` (`BeforeTargets="BeforeBuild"`) calling `GenerateVersionNumber`, mirroring the pattern already used by `Plugin.targets`/`WorkflowActivity.targets`. PdPackage has no manifest to stamp (unlike Solution, which hooks *after* `ProcessCdsProjectReferencesOutputs` to stamp `solution.xml`), so `BeforeBuild` is the correct, earliest-safe hook point for this project type.
- **`GenerateVersionNumber.targets`**: now also resets `$(PackageVersion)` after Git version generation. `PackageVersion` is evaluated from `$(Version)` at project-evaluation time — before any target runs — so a target-time reassignment of `Version` alone does not propagate to `PackageVersion`/the packed `.nupkg`. This was the "related footgun" called out in the issue, and this fix benefits all packable project types (Solution, PdPackage), not just PdPackage.

## Verification

Packed all SDK packages to a local NuGet feed and built a throwaway PdPackage-shaped consumer project against them, with `GitVersionNumberProductionBranches=main;master` set explicitly (the SDK normally supplies this default; a raw `Tasks`-package-only consumer, as used here, does not) and a real git commit on a `master` branch so the production-tier branch match in `GenerateGitVersion` actually triggers:

| | `Version` | `PackageVersion` |
|---|---|---|
| Baseline (no fix) | `1.0.0.1` (static, unchanged) | `1.0.0.1` (static, unchanged) |
| With fix (`-p:IsRunningInCI=true -p:GitVersionBranch=master`) | `1.0.2607.13001` (Git-generated, production tier per `docs/Versioning.md`) | `1.0.2607.13001` (Git-generated) |

`1.0.2607.13001` matches the documented production format `Major.Minor.YYMM.DDccc` (`Major.Minor` from the csproj `<Version>`, `2607` = July 2026, `13001` = 13th + 1st commit that day) — confirming both the fix and the "production" tier match, not the `0.0.20000.0` local-build fallback.

Full solution build (`dotnet build TALXIS.DevKit.Build.slnx --configuration Release`) succeeds with 0 errors.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## Additional verification: transitive versioning across `ProjectReference` chains

Since PdPackage now runs `GenerateGitVersion`, it inherits the same transitive-versioning behavior as other project types: `RetrieveProjectReferences` walks the full `ProjectReference` graph, and `GenerateGitVersion` picks the latest commit date/count across *all* resolved projects, not just the building one.

Scaffolded a real `Packages.Main` (PdPackage) → `Solutions.Test` (Solution) → `Scripts.UI` (ScriptLibrary) chain via `dotnet new pp-package`/`pp-solution`/`pp-script-library`, wired with real `ProjectReference`s, built against this fix's packages via a local NuGet feed:

- Baseline build: `Packages.Main` version `1.0.2607.13004`.
- Committed a change touching **only** `src/Scripts.UI/src/index.ts` (verified via `git show --stat`, no other files touched).
- Rebuilt `Packages.Main` **without changing it or `Solutions.Test`**: version became `1.0.2607.13005`.

Confirms a change several levels down a `ProjectReference` chain (ScriptLibrary, referenced by a Solution, referenced by a PdPackage) correctly bumps the top-level PdPackage's computed version, as documented in `docs/Versioning.md`'s "Monorepos" section.
