### PR TITLE
Fix PCF version patch running before manifest exists on clean build

### DIFF
--- a/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
+++ b/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
@@ -23,8 +23,11 @@
     <Exec Command="npm install" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 
-  <!-- Generates and applies the PCF version number. -->
-  <Target Name="_ApplyPcfVersionBeforeBuild" BeforeTargets="BeforeBuild" DependsOnTargets="NpmInstall">
+  <!-- Anchored to AfterTargets="PcfBuild" (not BeforeBuild/AfterBuild) so it runs after
+       ControlManifest.xml actually exists. PcfBuild is the target both _PcfNpmRunBuild and
+       _PcfForceNpmRunBuild call internally to run the webpack build, so this covers both the
+       incremental and forced build paths with one anchor. -->
+  <Target Name="_ApplyPcfVersionAfterBuild" AfterTargets="PcfBuild">
     <CallTarget Targets="GenerateVersionNumber"/>
     <CallTarget Targets="ApplyPcfVersionNumber"/>
   </Target>

--- a/src/Dataverse/Tasks/Tasks/ApplyPcfVersionNumber.cs
+++ b/src/Dataverse/Tasks/Tasks/ApplyPcfVersionNumber.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -39,8 +40,12 @@ public class ApplyPcfVersionNumber : Task
             LastCommitDateTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
         }
 
-        var lastCommitDateTime = DateTime.Parse(LastCommitDateTime);
-        Log.LogMessage(MessageImportance.High, $"Last commit date and time: {lastCommitDateTime}");
+        if (!DateTime.TryParseExact(LastCommitDateTime, "yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out var lastCommitDateTime))
+        {
+            Log.LogError($"LastCommitDateTime '{LastCommitDateTime}' is not in the expected 'yyyy-MM-ddTHH:mm:ssZ' UTC format.");
+            return false;
+        }
+        Log.LogMessage(MessageImportance.High, $"Last commit date and time: {lastCommitDateTime:yyyy-MM-ddTHH:mm:ssZ}");
 
         var secondsSince2020 = (long)(lastCommitDateTime - new DateTime(2020, 1, 1)).TotalSeconds;
         Log.LogMessage(MessageImportance.High, $"Seconds since 2020-01-01T00:00:00Z: {secondsSince2020}");

--- a/src/Dataverse/Tasks/Tasks/ApplyPcfVersionNumber.cs
+++ b/src/Dataverse/Tasks/Tasks/ApplyPcfVersionNumber.cs
@@ -20,32 +20,41 @@ public class ApplyPcfVersionNumber : Task
 
     public override bool Execute()
     {
-        if (PcfOutputPath != null && Directory.Exists(PcfOutputPath.ItemSpec))
+        if (PcfOutputPath == null || !Directory.Exists(PcfOutputPath.ItemSpec))
         {
-            var customControls = Directory.EnumerateFiles(PcfOutputPath.ItemSpec, "ControlManifest.xml", SearchOption.AllDirectories);
-
-            if(string.IsNullOrEmpty(LastCommitDateTime))
-            {
-                Log.LogWarning("LastCommitDateTime is not set, using current date and time.");
-                LastCommitDateTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
-            }
-
-            var lastCommitDateTime = DateTime.Parse(LastCommitDateTime);
-            Log.LogMessage(MessageImportance.High, $"Last commit date and time: {lastCommitDateTime}");
-            
-            var secondsSince2020 = (long)(lastCommitDateTime - new DateTime(2020, 1, 1)).TotalSeconds;
-            Log.LogMessage(MessageImportance.High, $"Seconds since 2020-01-01T00:00:00Z: {secondsSince2020}");
-
-            // var versionNumbers = Version.Split('.');
-            var pcfVersion = $"0.0.{secondsSince2020}";
-            Log.LogMessage(MessageImportance.High, $" > Using {pcfVersion} for PCF version number in manifest");
-
-            foreach (var manifest in customControls)
-            {
-                Log.LogMessage(MessageImportance.High, $"Processing {manifest}");
-                UpdateVersionInControlManifestXmlFile(manifest, pcfVersion);
-            }
+            Log.LogError($"PCF output directory not found at '{PcfOutputPath?.ItemSpec}'. Expected ControlManifest.xml to already exist by the time version patching runs.");
+            return false;
         }
+
+        var customControls = Directory.EnumerateFiles(PcfOutputPath.ItemSpec, "ControlManifest.xml", SearchOption.AllDirectories).ToList();
+        if (customControls.Count == 0)
+        {
+            Log.LogError($"No ControlManifest.xml found under '{PcfOutputPath.ItemSpec}'. Expected the PCF build to have produced one by the time version patching runs.");
+            return false;
+        }
+
+        if(string.IsNullOrEmpty(LastCommitDateTime))
+        {
+            Log.LogWarning("LastCommitDateTime is not set, using current date and time.");
+            LastCommitDateTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
+        }
+
+        var lastCommitDateTime = DateTime.Parse(LastCommitDateTime);
+        Log.LogMessage(MessageImportance.High, $"Last commit date and time: {lastCommitDateTime}");
+
+        var secondsSince2020 = (long)(lastCommitDateTime - new DateTime(2020, 1, 1)).TotalSeconds;
+        Log.LogMessage(MessageImportance.High, $"Seconds since 2020-01-01T00:00:00Z: {secondsSince2020}");
+
+        // var versionNumbers = Version.Split('.');
+        var pcfVersion = $"0.0.{secondsSince2020}";
+        Log.LogMessage(MessageImportance.High, $" > Using {pcfVersion} for PCF version number in manifest");
+
+        foreach (var manifest in customControls)
+        {
+            Log.LogMessage(MessageImportance.High, $"Processing {manifest}");
+            UpdateVersionInControlManifestXmlFile(manifest, pcfVersion);
+        }
+
         return true;
     }
 

--- a/src/Dataverse/Tasks/Tasks/ApplyVersionNumber.cs
+++ b/src/Dataverse/Tasks/Tasks/ApplyVersionNumber.cs
@@ -29,6 +29,12 @@ public class ApplyVersionNumber : Task
 
     public override bool Execute()
     {
+        if (SolutionXml == null || !File.Exists(SolutionXml.ItemSpec))
+        {
+            Log.LogError($"Solution.xml not found at '{SolutionXml?.ItemSpec}'. Expected it to already exist by the time version patching runs.");
+            return false;
+        }
+
         UpdateVersionInSolutionXmlFile(SolutionXml.ItemSpec, Version);
         var pluginAssemblyFolders = GetPluginAssemblyFolders().ToList();
         foreach (var pluginAssembliesFolder in pluginAssemblyFolders)


### PR DESCRIPTION
## Problem

`_ApplyPcfVersionBeforeBuild` was anchored to `BeforeTargets="BeforeBuild"`, while Microsoft's PCF webpack build (which creates `ControlManifest.xml`) is anchored to `AfterTargets="AfterBuild"`. These are two independent generic MSBuild lifecycle hooks with no guaranteed ordering relative to each other — they only happened to fall on opposite sides of `CoreCompile`.

On a **clean** build, the version-patch target ran first, tried to edit `ControlManifest.xml`, found it didn't exist yet (webpack hadn't run), and silently no-opped. The webpack build then ran afterward and wrote the manifest fresh from source with whatever version was hand-typed in `ControlManifest.Input.xml`, untouched.

It appears to "work" on a second local build only because the webpack target's `Inputs`/`Outputs` cause it to skip when nothing changed, leaving the *previous* run's manifest on disk for the (still mis-timed) patch to edit. Every clean CI build — which always starts from a fresh checkout — ships the unpatched version.

## Fix

- Re-anchor the patch target to `AfterTargets="PcfBuild"` — the inner target that both the incremental (`_PcfNpmRunBuild`) and forced (`_PcfForceNpmRunBuild`, `PcfAlwaysNpmRunBuild=true`) webpack paths call internally via `CallTarget`. A single anchor point covers both paths. This mirrors the pattern already used by the Solution project type (`_ApplySolutionVersionAfterProcessCds`, anchored to a real producer target instead of a generic marker).
- Renamed `_ApplyPcfVersionBeforeBuild` to `_ApplyPcfVersionAfterBuild` to reflect the new anchor.
- Made version application fail loudly instead of silently no-oping when its target file is missing, for both Pcf (`ApplyPcfVersionNumber.cs`) and Solution (`ApplyVersionNumber.cs`), so future timing/packaging regressions surface immediately with a clear message instead of shipping an unpatched version silently.

## Verification

Empirically reproduced and fixed using a real PCF fixture, packing "before" and "after" versions of the SDK/Tasks/Pcf packages side by side:

- **Before fix**: clean build results in `ControlManifest.xml` showing the stale hand-typed version. Bug reproduced.
- **After fix**: clean build results in `ControlManifest.xml` showing the correct Git-derived version on the **first** clean build (no second build needed).
- **No regression**: a subsequent incremental build still updates the version correctly.
- **Forced path**: clean build with `-p:PcfAlwaysNpmRunBuild=true` also applies the version correctly, confirming the single `AfterTargets="PcfBuild"` anchor covers both the incremental and forced webpack paths.

Closes #91.
