### PR TITLE
Fix: disable default item globbing for ProjectType=Pcf (#92)

### DIFF
--- a/docs/BuildProcess.md
+++ b/docs/BuildProcess.md
@@ -218,6 +218,8 @@ Main hooks:
 
 This package also fixes the output layout by setting `AppendTargetFrameworkToOutputPath=false` and `OutputPath=$(ProjectDirectory)\out\controls`.
 
+Because `ProjectType=Pcf` is built on `Microsoft.NET.Sdk`, it also sets `EnableDefaultItems=false` and no-ops the `CreateManifestResourceNames`/`CoreCompile` targets. PCF output is produced by webpack/`pcf-scripts`, not MSBuild's C#/resx compile pipeline, and the project's own `<None Include="$(MSBuildProjectDirectory)\**"/>` glob already covers every file (including `.resx` localization files). Without this, the SDK's default item globbing would independently pick up the same `.resx` files as `EmbeddedResource`, colliding with the manual glob and failing with `MSB3577`. Consumers can still set `EnableDefaultItems=true` in their own project to opt back in.
+
 ### ScriptLibrary
 
 `TALXIS.DevKit.Build.Dataverse.ScriptLibrary` depends only on the shared Tasks package.

--- a/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.props
+++ b/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.props
@@ -8,6 +8,14 @@
     <PowerAppsTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\PowerApps</PowerAppsTargetsPath>
     <CopyBuildOutputToPublishDirectory>false</CopyBuildOutputToPublishDirectory>
     <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
+    <!-- PCF projects are JS/TS controls, not conventional SDK-style compiled projects. The
+         .NET SDK's default item globbing (EmbeddedResource/Compile auto-includes) would
+         collide with the project-wide <None Include="**"/> glob below (see
+         TALXIS.DevKit.Build.Dataverse.Pcf.targets), causing MSB3577 for any control that ships
+         .resx localization files. Disabling default items removes that collision; it provides
+         no value here since PCF output is produced by webpack/pcf-scripts, not MSBuild's C#
+         compile pipeline. Consumers can still opt back in via EnableDefaultItems=true. -->
+    <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
   <Import Project="$(PowerAppsTargetsPath)\Microsoft.PowerApps.VisualStudio.Pcf.props" Condition="Exists('$(PowerAppsTargetsPath)\Microsoft.PowerApps.VisualStudio.Pcf.props')" />

--- a/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
+++ b/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
@@ -19,6 +19,14 @@
 
   <Import Project="$(PowerAppsTargetsPath)\Microsoft.PowerApps.VisualStudio.Pcf.targets" Condition="Exists('$(PowerAppsTargetsPath)\Microsoft.PowerApps.VisualStudio.Pcf.targets')" />
 
+  <!-- Defense-in-depth for EnableDefaultItems=false above: even if a consumer re-enables default
+       items or manually adds a .resx as EmbeddedResource, PCF output is produced by
+       webpack/pcf-scripts, not MSBuild's C#/resx pipeline, so no-op the targets that would
+       otherwise compile it (mirrors Microsoft.PowerApps.MSBuild.Pcf.targets). Declared after the
+       import above so these overrides win. -->
+  <Target Name="CreateManifestResourceNames" />
+  <Target Name="CoreCompile" />
+
   <Target Name="NpmInstall" BeforeTargets="BeforeBuild">
     <Exec Command="npm install" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>


### PR DESCRIPTION
## Summary

Fixes #92. `ProjectType=Pcf` is built on `Microsoft.NET.Sdk`, which defaults `EnableDefaultItems=true`. This causes the SDK to auto-glob `.resx` files into `EmbeddedResource` items, colliding with the Pcf target's own manual `<None Include="$(MSBuildProjectDirectory)\**"/>` glob and failing with `MSB3577: Two output file names resolved to the same output path: obj/Release/.resources` for any PCF control that ships `.resx` localization files (e.g. `translations.1029.resx`, `translations.1033.resx`) — a common pattern for localized controls.

## Fix

Mirrors the defensive approach used by Microsoft's own [`Microsoft.PowerApps.MSBuild.Pcf`](https://www.nuget.org/packages/Microsoft.PowerApps.MSBuild.Pcf) package (verified by inspecting its `.targets`/`.props` directly), which avoids this by not being SDK-style and by no-oping the resource/compile pipeline:

- `TALXIS.DevKit.Build.Dataverse.Pcf.props` — sets `EnableDefaultItems=false`
- `TALXIS.DevKit.Build.Dataverse.Pcf.targets` — no-ops `CreateManifestResourceNames`/`CoreCompile` as defense-in-depth, in case a consumer re-enables default items or manually adds `.resx` as `EmbeddedResource`
- `docs/BuildProcess.md` — documents the new behavior in the Pcf section

## Scope

Limited to `Pcf` only. I checked every other `ProjectType` for the same problem:

| ProjectType | Affected? |
|---|---|
| Plugin, WorkflowActivity | No — genuine compiled C# assemblies, need default items |
| **Solution** | No — and must **not** be touched: it actively relies on `EnableDefaultItems=true` via `<EmbeddedResource Update="...WebResources\localization\*.resx">` for its own localization feature |
| PDPackage | No — no broad glob, no compile reliance |
| ScriptLibrary, GenPage, CodeApp | No reproducible break — same JS/TS architecture as Pcf but no directory-wide glob colliding with default items |

## Verification

- `dotnet build TALXIS.DevKit.Build.slnx` succeeds
- Packed the pre-fix code and built a scratch PCF project with two `.resx` files (matching the `FileExplorer` repro from the issue) — **reproduced the exact `MSB3577` failure**
- Rebuilt against the fixed package — **build succeeds**, 0 errors
- Confirmed `.resx` files still ship correctly via the project's existing `None` glob (nothing lost, just no longer double-processed)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
