### PR TITLE
Add Rush-aware Node restore/build support for PCF, ScriptLibrary, and CodeApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Generates version numbers based on Git commit history, applying these versions a
 #### Build Number From Dependencies
 Project dependency folders are analyzed for Git changes to be reflected in generated version numbers. See [here](/docs/Versioning.md) for more details.
 
+#### Node Dependency Restore
+Pcf/ScriptLibrary/CodeApp projects auto-detect and run the right Node package manager (npm, pnpm, Yarn, Bun, or Rush) instead of a hardcoded `npm install`. See [here](/docs/NodeDependencies.md) for more details.
+
 ## Packages
 
 | Package | Description |
@@ -45,10 +48,10 @@ Project dependency folders are analyzed for Git changes to be reflected in gener
 | [TALXIS.DevKit.Build.Dataverse.Plugin](src/Dataverse/Plugin/README.md) | MSBuild integration for Dataverse plugin assemblies with auto-versioning and metadata exposure for Solution projects. |
 | [TALXIS.DevKit.Build.Dataverse.Pcf](src/Dataverse/Pcf/README.md) | MSBuild integration for PCF controls. Wraps `Microsoft.PowerApps.MSBuild.Pcf` with Git-based versioning. |
 | [TALXIS.DevKit.Build.Dataverse.WorkflowActivity](src/Dataverse/WorkflowActivity/README.md) | MSBuild integration for custom workflow activity assemblies with auto-versioning and Solution project integration. |
-| [TALXIS.DevKit.Build.Dataverse.ScriptLibrary](src/Dataverse/ScriptLibrary/README.md) | Builds TypeScript/JS web resource projects (`npm install` + `npm run build`) and integrates them into Solution builds. |
+| [TALXIS.DevKit.Build.Dataverse.ScriptLibrary](src/Dataverse/ScriptLibrary/README.md) | Builds TypeScript/JS web resource projects (auto-detected Node package manager restore + `npm run build`) and integrates them into Solution builds. |
 | [TALXIS.DevKit.Build.Dataverse.PdPackage](src/Dataverse/PDPackage/README.md) | Package Deployer integration with CMT metadata merge/zip support. |
 
-See [docs/BuildProcess.md](docs/BuildProcess.md) for how these packages are layered and what each one wires into the build, and [docs/Versioning.md](docs/Versioning.md) for the version-numbering strategy.
+See [docs/BuildProcess.md](docs/BuildProcess.md) for how these packages are layered and what each one wires into the build, [docs/Versioning.md](docs/Versioning.md) for the version-numbering strategy, and [docs/NodeDependencies.md](docs/NodeDependencies.md) for how Node dependency restore is auto-detected.
 
 ## Getting Started
 > [!TIP]  

--- a/docs/BuildProcess.md
+++ b/docs/BuildProcess.md
@@ -211,7 +211,7 @@ Main hooks:
 
 - imports `Microsoft.PowerApps.VisualStudio.Pcf.props` / `.targets`
 - `_PcfNodeRestore` runs `AfterTargets="CollectPackageReferences"` (not `BeforeTargets="BeforeBuild"` - this is what makes a bare `dotnet restore` at the repo/solution root hydrate Node deps too, see [NodeDependencies.md](NodeDependencies.md#verb-parity)) and calls the shared `NodeRestore` target - replaces the previous hardcoded `NpmInstall`/`npm install` target
-- `PcfBuild` is overridden (Rush-resolved projects only) to delegate the actual build to Rush's own `build` command instead of Microsoft's own `npm run build` `<Exec>`, forwarding `--buildMode`/`--outDir`/`--buildSource` as Rush custom command-line parameters - see [NodeDependencies.md](NodeDependencies.md#pcf-specific-forwarding---buildmode---outdir---buildsource)
+- `PcfBuild` is overridden (Rush-resolved projects only) to delegate the actual build to Rush's own `build` command instead of Microsoft's own `npm run build` `<Exec>`, forwarding the build mode as a `--build-mode` Rush custom command-line parameter (reusing Microsoft's own `$(PcfBuildMode)` Debug/Release mapping) - see [NodeDependencies.md](NodeDependencies.md#pcf-specific-forwarding-the-build-mode-as---build-mode)
 - `_ApplyPcfVersionAfterBuild` runs `AfterTargets="PcfBuild"` (after `ControlManifest.xml` actually exists) and applies Git-based versioning
 - `_EnsurePcfStubAssembly` runs before `Publish` / `GetCopyToPublishDirectoryItems` and creates a stub DLL if needed
 - `PcfCopyToPublish` runs `AfterTargets="Publish"` and copies PCF output into `out\controls\publish`

--- a/docs/BuildProcess.md
+++ b/docs/BuildProcess.md
@@ -210,8 +210,8 @@ Like the Plugin package, it replaces ILRepack's default auto-hook with a no-op t
 Main hooks:
 
 - imports `Microsoft.PowerApps.VisualStudio.Pcf.props` / `.targets`
-- `NpmInstall` runs `BeforeTargets="BeforeBuild"`
-- `_ApplyPcfVersionBeforeBuild` runs `BeforeTargets="BeforeBuild"` and depends on `NpmInstall`
+- `_PcfNodeRestore` runs `BeforeTargets="BeforeBuild"` and calls the shared `NodeRestore` target (see [NodeDependencies.md](NodeDependencies.md)) - replaces the previous hardcoded `NpmInstall`/`npm install` target
+- `_ApplyPcfVersionAfterBuild` runs `AfterTargets="PcfBuild"` (after `ControlManifest.xml` actually exists) and applies Git-based versioning
 - `_EnsurePcfStubAssembly` runs before `Publish` / `GetCopyToPublishDirectoryItems` and creates a stub DLL if needed
 - `PcfCopyToPublish` runs `AfterTargets="Publish"` and copies PCF output into `out\controls\publish`
 - sets `IsPackable=false` and hooks `$(BeforePack)` with `_ErrorOnPcfPack`, which raises a hard error before any nuspec/nupkg work starts
@@ -226,13 +226,13 @@ Because `ProjectType=Pcf` is built on `Microsoft.NET.Sdk`, it also sets `EnableD
 
 Main hooks:
 
-- `CheckScriptLibraryPrereqs`
-- `BuildTypeScript` (`BeforeTargets="Build"`)
+- `CheckScriptLibraryPrereqs` (Node.js presence only - package manager presence is left to `NodeRestore`)
+- `BuildTypeScript` (`BeforeTargets="Build"`, calls the shared `NodeRestore` target then `npm run build`)
 - `CopyScriptLibraryMainToOutput` (`AfterTargets="Build"`)
 - `GetScriptLibraryOutputs`
 - `GetSuppressedScriptLibraryReferences`
 
-The package expects TypeScript sources under `$(TypeScriptDir)` (default `TS`), runs `npm install` and `npm run build`, copies the selected main JS file to `$(TargetDir)`, and lets Solution builds query which referenced script libraries are `CompileOnly` and therefore should not be deployed as separate web resources. Standalone `npm` packaging of a ScriptLibrary is planned but not yet implemented, so it does not currently set `IsPackable=false`.
+The package expects TypeScript sources under `$(TypeScriptDir)` (default `TS`), hydrates dependencies via the shared `NodeRestore` target (see [NodeDependencies.md](NodeDependencies.md) - replaces the previous hardcoded `npm install`), runs `npm run build`, copies the selected main JS file to `$(TargetDir)`, and lets Solution builds query which referenced script libraries are `CompileOnly` and therefore should not be deployed as separate web resources. Standalone `npm` packaging of a ScriptLibrary is planned but not yet implemented, so it does not currently set `IsPackable=false`.
 
 ### CodeApp
 
@@ -240,13 +240,13 @@ The package expects TypeScript sources under `$(TypeScriptDir)` (default `TS`), 
 
 Main hooks:
 
-- `CheckCodeAppPrereqs`
-- `BuildCodeApp` (`BeforeTargets="Build"`)
+- `CheckCodeAppPrereqs` (Node.js presence only - package manager presence is left to `NodeRestore`)
+- `BuildCodeApp` (`BeforeTargets="Build"`, calls the shared `NodeRestore` target then `npm run build`)
 - `CopyCodeAppDist` (`AfterTargets="Build"`)
 - `GetCodeAppOutputs`
 - `CopyCodeAppDistPublish` (`AfterTargets="Publish"`)
 
-The package runs `npm install` and `npm run build`, expects output under `dist/`, copies it into `$(OutputPath)$(AppName)/` and `$(PublishDir)$(AppName)/`, and exposes the `dist` folder plus `power.config.json` to Solution packaging. CodeApp projects are not standalone components, so the package sets `IsPackable=false` and hooks `$(BeforePack)` with `_ErrorOnCodeAppPack`, which raises a hard error before any nuspec/nupkg work starts.
+The package hydrates dependencies via the shared `NodeRestore` target (see [NodeDependencies.md](NodeDependencies.md) - replaces the previous hardcoded `npm install`), runs `npm run build`, expects output under `dist/`, copies it into `$(OutputPath)$(AppName)/` and `$(PublishDir)$(AppName)/`, and exposes the `dist` folder plus `power.config.json` to Solution packaging. CodeApp projects are not standalone components, so the package sets `IsPackable=false` and hooks `$(BeforePack)` with `_ErrorOnCodeAppPack`, which raises a hard error before any nuspec/nupkg work starts.
 
 ### GenPage
 

--- a/docs/BuildProcess.md
+++ b/docs/BuildProcess.md
@@ -1,6 +1,6 @@
 # Build process
 
-This document describes how the TALXIS build packages are layered, how their MSBuild files are distributed through NuGet, and what each project-type package actually wires into a consumer build. For the version-numbering rules themselves, see [Versioning.md](./Versioning.md).
+This document describes how the TALXIS build packages are layered, how their MSBuild files are distributed through NuGet, and what each project-type package actually wires into a consumer build. For the version-numbering rules themselves, see [Versioning.md](./Versioning.md). For how Node dependency hydration and build delegation work (auto-detection, Rush, CI-frozen installs, the design principles behind the mechanism), see [NodeDependencies.md](./NodeDependencies.md#design-principles).
 
 ## Overview
 
@@ -210,7 +210,8 @@ Like the Plugin package, it replaces ILRepack's default auto-hook with a no-op t
 Main hooks:
 
 - imports `Microsoft.PowerApps.VisualStudio.Pcf.props` / `.targets`
-- `_PcfNodeRestore` runs `BeforeTargets="BeforeBuild"` and calls the shared `NodeRestore` target (see [NodeDependencies.md](NodeDependencies.md)) - replaces the previous hardcoded `NpmInstall`/`npm install` target
+- `_PcfNodeRestore` runs `AfterTargets="CollectPackageReferences"` (not `BeforeTargets="BeforeBuild"` - this is what makes a bare `dotnet restore` at the repo/solution root hydrate Node deps too, see [NodeDependencies.md](NodeDependencies.md#verb-parity)) and calls the shared `NodeRestore` target - replaces the previous hardcoded `NpmInstall`/`npm install` target
+- `PcfBuild` is overridden (Rush-resolved projects only) to delegate the actual build to Rush's own `build` command instead of Microsoft's own `npm run build` `<Exec>`, forwarding `--buildMode`/`--outDir`/`--buildSource` as Rush custom command-line parameters - see [NodeDependencies.md](NodeDependencies.md#pcf-specific-forwarding---buildmode---outdir---buildsource)
 - `_ApplyPcfVersionAfterBuild` runs `AfterTargets="PcfBuild"` (after `ControlManifest.xml` actually exists) and applies Git-based versioning
 - `_EnsurePcfStubAssembly` runs before `Publish` / `GetCopyToPublishDirectoryItems` and creates a stub DLL if needed
 - `PcfCopyToPublish` runs `AfterTargets="Publish"` and copies PCF output into `out\controls\publish`
@@ -226,13 +227,14 @@ Because `ProjectType=Pcf` is built on `Microsoft.NET.Sdk`, it also sets `EnableD
 
 Main hooks:
 
-- `CheckScriptLibraryPrereqs` (Node.js presence only - package manager presence is left to `NodeRestore`)
-- `BuildTypeScript` (`BeforeTargets="Build"`, calls the shared `NodeRestore` target then `npm run build`)
+- `_ScriptLibraryNodeRestore` (`AfterTargets="CollectPackageReferences"`, calls the shared `NodeRestore` target - fires on solution/repo-root `dotnet restore` too, see [NodeDependencies.md](NodeDependencies.md#verb-parity))
+- `BuildTypeScript` (`BeforeTargets="Build"` - delegates to Rush's own `build` command when Rush is resolved, otherwise `npm run build` directly, unchanged)
+- `CleanScriptLibrary` (`AfterTargets="Clean"`, removes the TypeScript output folder only - never `node_modules`)
 - `CopyScriptLibraryMainToOutput` (`AfterTargets="Build"`)
 - `GetScriptLibraryOutputs`
 - `GetSuppressedScriptLibraryReferences`
 
-The package expects TypeScript sources under `$(TypeScriptDir)` (default `TS`), hydrates dependencies via the shared `NodeRestore` target (see [NodeDependencies.md](NodeDependencies.md) - replaces the previous hardcoded `npm install`), runs `npm run build`, copies the selected main JS file to `$(TargetDir)`, and lets Solution builds query which referenced script libraries are `CompileOnly` and therefore should not be deployed as separate web resources. Standalone `npm` packaging of a ScriptLibrary is planned but not yet implemented, so it does not currently set `IsPackable=false`.
+The package expects TypeScript sources under `$(TypeScriptDir)` (default `TS`), hydrates dependencies via the shared `NodeRestore` target (see [NodeDependencies.md](NodeDependencies.md) - replaces the previous hardcoded `npm install`), builds via Rush delegation or `npm run build` (see [NodeDependencies.md](NodeDependencies.md#build-delegation-to-rush)), copies the selected main JS file to `$(TargetDir)`, and lets Solution builds query which referenced script libraries are `CompileOnly` and therefore should not be deployed as separate web resources. Standalone `npm` packaging of a ScriptLibrary is planned but not yet implemented, so it does not currently set `IsPackable=false`.
 
 ### CodeApp
 
@@ -241,12 +243,14 @@ The package expects TypeScript sources under `$(TypeScriptDir)` (default `TS`), 
 Main hooks:
 
 - `CheckCodeAppPrereqs` (Node.js presence only - package manager presence is left to `NodeRestore`)
-- `BuildCodeApp` (`BeforeTargets="Build"`, calls the shared `NodeRestore` target then `npm run build`)
+- `_CodeAppNodeRestore` (`AfterTargets="CollectPackageReferences"`, calls the shared `NodeRestore` target - fires on solution/repo-root `dotnet restore` too, see [NodeDependencies.md](NodeDependencies.md#verb-parity))
+- `BuildCodeApp` (`BeforeTargets="Build"` - delegates to Rush's own `build` command when Rush is resolved, otherwise `npm run build` directly, unchanged)
+- `CleanCodeApp` (`AfterTargets="Clean"`, removes `dist` only - never `node_modules`)
 - `CopyCodeAppDist` (`AfterTargets="Build"`)
 - `GetCodeAppOutputs`
 - `CopyCodeAppDistPublish` (`AfterTargets="Publish"`)
 
-The package hydrates dependencies via the shared `NodeRestore` target (see [NodeDependencies.md](NodeDependencies.md) - replaces the previous hardcoded `npm install`), runs `npm run build`, expects output under `dist/`, copies it into `$(OutputPath)$(AppName)/` and `$(PublishDir)$(AppName)/`, and exposes the `dist` folder plus `power.config.json` to Solution packaging. CodeApp projects are not standalone components, so the package sets `IsPackable=false` and hooks `$(BeforePack)` with `_ErrorOnCodeAppPack`, which raises a hard error before any nuspec/nupkg work starts.
+The package hydrates dependencies via the shared `NodeRestore` target (see [NodeDependencies.md](NodeDependencies.md) - replaces the previous hardcoded `npm install`), builds via Rush delegation or `npm run build` (see [NodeDependencies.md](NodeDependencies.md#build-delegation-to-rush)), expects output under `dist/`, copies it into `$(OutputPath)$(AppName)/` and `$(PublishDir)$(AppName)/`, and exposes the `dist` folder plus `power.config.json` to Solution packaging. CodeApp projects are not standalone components, so the package sets `IsPackable=false` and hooks `$(BeforePack)` with `_ErrorOnCodeAppPack`, which raises a hard error before any nuspec/nupkg work starts.
 
 ### GenPage
 

--- a/docs/NodeDependencies.md
+++ b/docs/NodeDependencies.md
@@ -18,6 +18,146 @@ This replaces the previous behavior of unconditionally running `npm install`, wh
 - **Always ran, every build** - no once-per-workspace guarantee for monorepos with multiple PCF/ScriptLibrary/CodeApp
   projects sharing one `node_modules`.
 
+## Design principles
+
+This mechanism exists to let developers of polyglot (.NET + Node) monorepos use one consistent verb set -
+`dotnet restore` / `build` / `clean` / `publish` - without needing to know or care which project uses which
+underlying Node tool:
+
+- **The `dotnet` CLI is the only interaction surface.** CI/CD pipelines in consumer repos never run a wrapper
+  script and never need to "run `rush`/`npm` first, then run `dotnet`" - `dotnet restore`/`build`/`clean`/
+  `publish` alone must produce the right outcome, whether a project is pure .NET, pure Node, or both.
+- **Incremental and full-repo adoption use the same mechanism, not separate code paths.** A single `.csproj`
+  dropped into an otherwise-plain folder (own local `package.json`, no repo-wide orchestrator) and every project
+  in a repo sharing one Rush/pnpm/npm workspace both fall out of the same marker walk-up
+  (`GetDirectoryNameOfFileAbove`) - the incremental case simply resolves the workspace root to the project's own
+  directory because no marker is found above it.
+- **Rush is the out-of-box-supported orchestrator, not the only one.** Nothing Rush-specific is hardcoded into
+  the shared detection/dispatch path; the two escape hatches (`NodePackageManager=<name>` for a tool already in
+  the command table, `NodeRestoreCommand=<any command>` for anything else) are the intended extension surface for
+  a tool this SDK doesn't ship day-one support for - no plugin/adapter abstraction is introduced.
+- **Hand repo-level exclusivity arbitration to the tool that already owns it - don't reinvent it.** Rush already
+  has its own whole-repo, fail-fast lock for `update`/`install`/`build`. Rather than building a new generic lock
+  file to serialize MSBuild's parallel solution builds, `NodeRestore` retries the Rush invocation with a bounded,
+  exponential backoff when it hits Rush's own "already running" condition - narrow, tool-specific resilience for
+  one confirmed failure mode, not a general-purpose mechanism imposed on every tool.
+- **MSBuild stays the top-level orchestrator.** It decides *when*/*whether* each project builds at all and in
+  what order (via project references, `.slnx` build graph, `-m` parallelism). Rush is only ever the primitive
+  that the *Node-specific* portion of that work is delegated to (installing dependencies, and - for Rush
+  specifically - running the actual Node build step too, to get its content-hash incremental skip and build
+  cache) - never the other way around.
+
+## Verb parity
+
+| Verb | Node behavior |
+|---|---|
+| `dotnet restore` (project **or solution/repo-root**) | Hydrates Node deps via `NodeRestore`, hooked on `AfterTargets="CollectPackageReferences"` - the one per-project target NuGet's solution-level restore reliably invokes for every project, unlike `AfterTargets="Restore"` which only fires for single-project restore. This is what makes a bare `dotnet restore` at the repo root hydrate Node dependencies for every project, not just NuGet ones. |
+| `dotnet build` | Hydrates (implicit restore) + builds. For non-Rush tools, `npm run build` runs directly, unchanged. For Rush-resolved projects (`Pcf`/`ScriptLibrary`/`CodeApp`), the build step itself delegates to Rush's own `build` command instead, so Rush's content-hash incremental skip and build cache apply - see "Build delegation to Rush" below. |
+| `dotnet clean` | Removes this project's own JS build-output folder only (`dist` for CodeApp, ScriptLibrary's TypeScript output folder). Never touches `node_modules` or any shared workspace state - "clean" and "prune installed deps" are different operations, and removing `node_modules` is a far more expensive, disruptive step than a normal `dotnet clean` should trigger silently. `Pcf` has no new Clean target from this SDK - Microsoft's own `PcfClean` (`npm run clean`) already owns PCF's `out/controls` cleanup. |
+| `dotnet publish` | Copies JS build output into the publish directory (existing, unaffected by any of the above). |
+
+`dotnet build --no-restore` still triggers `NodeRestore` - `CollectPackageReferences` is a build-time target, not
+gated by NuGet's `--no-restore` flag. This is deliberate, not a bug: worst case it's a cheap no-op via the
+existing incremental gate (non-Rush) or Rush's own state hash (Rush); it never silently skips Node hydration just
+because NuGet's own restore step was skipped.
+
+## Build delegation to Rush
+
+When the resolved tool for a `Pcf`/`ScriptLibrary`/`CodeApp` project is Rush, the *build* step (not just
+dependency hydration) is delegated to Rush's own `install-run-rush.js build`, instead of calling `npm run build`
+directly - this is what actually lets Rush's per-project content-hash incremental skip and build cache apply to
+the Node build step. A direct `npm run build` every time has zero incrementality of its own.
+
+The exact command is chosen by MSBuild's own solution-vs-project signal (`$(SolutionPath)`), not a single fixed
+choice, because a fixed choice creates one of two different regressions:
+
+- **Standalone build** (`dotnet build a.csproj`, `$(SolutionPath)` unset/`*Undefined*`): uses **scoped**
+  `install-run-rush.js build --to .` - builds only this project plus its transitive Rush-graph upstream
+  dependencies. This keeps "build the one project I'm working on after a fresh clone" fast on a large Rush repo -
+  it does not build the whole registered graph.
+- **Solution-scope build** (`dotnet build repo.slnx`, potentially N Rush-registered projects building in
+  parallel via `-m`): uses plain **unscoped** `install-run-rush.js build` - whichever project's target reaches
+  this branch first builds the entire registered graph via Rush's own internal parallelism; every other
+  project's own call to the same command hits Rush's default incremental skip and returns as a fast no-op.
+  Avoids serializing N real Node builds behind Rush's one exclusive whole-repo lock, which a per-project-scoped
+  call would otherwise do (`rush build` acquires the exact same whole-repo lock as `rush update`/`install`).
+
+A project directory under a Rush marker but not actually listed in `rush.json`'s `projects` array (legitimate
+incremental adoption - not every project needs to join Rush's graph on day one) is detected proactively before
+either restore or build routes through Rush, and falls back to this project's own direct `npm install`/
+`npm run build` with a visible warning instead.
+
+### PCF-specific: forwarding `--build-mode`/`--out-dir`/`--build-source`
+
+Microsoft's own `PcfBuild` `<Exec>` (in `Microsoft.PowerApps.MSBuild.Pcf.targets`) passes three CLI flags to
+`pcf-scripts build`: `--buildMode $(PcfBuildMode)`, `--outDir "$(PcfOutputPath)"`, `--buildSource $(BuildSource)`.
+Rush's `command-line.json` JSON schema requires custom parameter `longName`s to be lower-case, dash-delimited
+(`^-(-[a-z0-9]+)+$`) - it rejects camelCase names like `--buildMode` outright. `pcf-scripts` parses its CLI
+via `yargs`, which enables camel-case-expansion by default, so a kebab-case `--build-mode` on the command
+line is automatically also exposed as `argv.buildMode` - confirmed empirically. So the parameters below are
+declared and invoked in kebab-case, even though `pcf-scripts`' own flags are camelCase.
+Rush's generic `build` command has no built-in mechanism to forward arbitrary CLI arguments through to each
+project's own script - so this package's Rush-branch override of `PcfBuild` forwards them via Rush's own
+documented **custom commands and parameters** feature instead
+(`common/config/rush/command-line.json`, the same mechanism Rush's own docs demonstrate with a `--ship`/
+production-build example), rather than a Debug-only Configuration gate (which would permanently exclude
+production builds from Rush delegation) or transient file patching (an unwanted build-time side effect).
+
+**This requires a one-time addition to your repo's `common/config/rush/command-line.json`** - add the following
+to its `parameters` array (each `associatedCommands` must include both `"build"` and `"rebuild"`):
+
+```json
+{ "parameterKind": "string", "longName": "--build-mode", "description": "PCF build mode", "associatedCommands": ["build", "rebuild"], "argumentName": "BUILD_MODE" },
+{ "parameterKind": "string", "longName": "--out-dir", "description": "PCF build output directory", "associatedCommands": ["build", "rebuild"], "argumentName": "OUT_DIR" },
+{ "parameterKind": "string", "longName": "--build-source", "description": "PCF build source tag", "associatedCommands": ["build", "rebuild"], "argumentName": "BUILD_SOURCE" }
+```
+
+If a Rush-registered PCF project's `command-line.json` doesn't declare these yet, **the build fails immediately**
+with an error naming the missing parameter(s) and this exact snippet - it does not silently fall back to
+Microsoft's un-cached, un-delegated `<Exec>`. This is deliberate: once a project is Rush-registered, it has
+unambiguously opted into Rush build delegation, so a missing declaration is a fixable configuration gap, not a
+legitimate "not opted in yet" state (contrast with the `rush.json` registration check above, which *does* fall
+back gracefully, since a project simply not yet added to `rush.json` at all is indistinguishable from valid
+incremental adoption).
+
+Rush's build cache already incorporates the command-line parameters used into its cache key, so a `--build-mode
+development` (Debug) and `--build-mode production` (Release) build of the same project get distinct, correct
+cache entries automatically - no extra work needed here.
+
+**Second, independently-required one-time change: your PCF project's `package.json` `"build"` script must
+translate the forwarded kebab-case flags back to the camelCase flags `pcf-scripts` actually needs.** This was
+found empirically (a real acceptance retest against a production PCF control): passing `--build-mode`/`--out-dir`
+straight through to `pcf-scripts build` - the only spelling Rush's own schema allows - produces a broken,
+oversized production bundle (`[pcf-1045] bundle exceeds the maximum size allowed`) and skips
+`ControlManifest.xml` generation entirely, even though the camelCase and kebab-case spellings resolve to a
+byte-identical internal `pcf-scripts` config (confirmed via debug instrumentation - the divergence happens
+somewhere inside webpack/babel/terser, not any code path `pcf-scripts` itself owns, and is out of this SDK's
+reach to fix upstream). Replace the default `"build"` script:
+
+```json
+"build": "pcf-scripts build"
+```
+
+with:
+
+```json
+"build": "node -e \"const a=process.argv.slice(1);const g=k=>{const i=a.indexOf('--'+k);return i===-1?undefined:a[i+1];};const bm=g('build-mode');const od=g('out-dir');const bs=g('build-source');const cp=require('child_process');const args=['build'];if(bm)args.push('--buildMode',bm);if(od)args.push('--outDir',od);if(bs)args.push('--buildSource',bs);const r=cp.spawnSync('pcf-scripts',args,{stdio:'inherit',shell:true});process.exit(r.status===null?1:r.status);\" --"
+```
+
+This is a plain, consumer-owned `package.json` edit - not a file this SDK ships or patches on your behalf; `node`
+is already a hard requirement for any `pcf-scripts` project, so no new toolchain dependency is introduced. Like
+the `command-line.json` declaration above, a Rush-registered PCF project whose `"build"` script still looks like
+the unmodified default (no `buildMode`/`outDir` references found) **fails the build immediately** with this exact
+snippet, rather than silently reproducing the broken-bundle failure.
+
+**For the build *cache* itself to activate** (as opposed to just delegation, which works either way via Rush's
+default incremental "output preservation" skip), each PCF project also needs its own `rush-project.json`
+declaring `projectOutputFolderNames` (typically `["out"]`) - this is a separate, recommended-but-not-required
+consumer prerequisite; a project missing it still builds correctly through the forwarded parameters, just
+without the archived-cache performance benefit.
+
+`Pcf` projects have no new Clean target from this SDK, and this override does not affect `PcfClean`.
+
 ## How detection works
 
 Purely via MSBuild's built-in `GetDirectoryNameOfFileAbove`, walking up from the project directory (or

--- a/docs/NodeDependencies.md
+++ b/docs/NodeDependencies.md
@@ -1,0 +1,132 @@
+# Node dependency restore
+
+`Pcf`, `ScriptLibrary`, and `CodeApp` projects need `node_modules` hydrated before their JavaScript/TypeScript
+build step runs. The SDK does this automatically via a shared `NodeRestore` MSBuild target - it detects the
+right package manager for the project (npm, pnpm, Yarn, Bun, or Rush) from the same marker files those tools
+themselves already use, and runs the correct install command for the situation (local dev vs. CI, mutable vs.
+frozen/reproducible).
+
+This replaces the previous behavior of unconditionally running `npm install`, which had three problems:
+
+- **No opt-out** - broke any repo where dependencies are hydrated by a different tool, or by an orchestrator
+  like Rush that must never be bypassed (running `pnpm install` directly in a Rush repo corrupts Rush's own
+  state).
+- **Mutated the lockfile mid-build** - `npm install` reconciles `package-lock.json` to `package.json` and can
+  rewrite it (format migration, re-resolved ranges). This breaks any CI cache keyed on the lockfile's hash (the
+  key changes between cache restore and cache save, so it can never hit again) and makes installs
+  non-reproducible.
+- **Always ran, every build** - no once-per-workspace guarantee for monorepos with multiple PCF/ScriptLibrary/CodeApp
+  projects sharing one `node_modules`.
+
+## How detection works
+
+Purely via MSBuild's built-in `GetDirectoryNameOfFileAbove`, walking up from the project directory (or
+`$(TypeScriptDir)` for ScriptLibrary) looking for the first marker in this order:
+
+| Precedence | Marker | Resolved tool |
+|---|---|---|
+| 1 | `rush.json` | `rush` |
+| 2 | `pnpm-lock.yaml` | `pnpm` |
+| 3 | `yarn.lock` | `yarn` (Classic or Berry, detected via `.yarnrc.yml`) |
+| 4 | `bun.lockb` | `bun` |
+| 5 | `package-lock.json` | `npm` |
+| _(none found)_ | - | `npm`, run in the project directory itself (today's default behavior for a bare project) |
+
+No bundled Node script, external npm dependency, or extra process is needed - these five filenames have been
+stable across all of these tools for years, and the small number of install command variants below don't need
+a library to track.
+
+## Configuration
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `NodePackageManager` | _(auto)_ | Leave empty to auto-detect via the table above. Set explicitly to `npm`, `pnpm`, `yarn`, `bun`, or `rush` to skip detection and force a tool (the workspace root is still resolved the same way). Set to `None` to skip Node restore entirely - use this when dependencies are hydrated by something external to the build (a separate CI step, a different orchestrator, etc.). |
+| `NodeRestoreCommand` | _(empty)_ | Escape hatch: if set, this exact command line is run instead of anything auto-detected or resolved from `NodePackageManager` - for any tool this SDK doesn't know about, or any custom install invocation. Runs every build (no incremental caching, since an arbitrary command's staleness can't be inferred). |
+| `NodeRestoreProjectDirectory` | `$(MSBuildProjectDirectory)` | Directory containing `package.json` that detection starts walking up from. ScriptLibrary sets this to `$(TypeScriptDir)` before calling `NodeRestore`; Pcf/CodeApp use the default. |
+| `IsRunningInCI` | _(auto)_ | Reused as-is from [Versioning.md](Versioning.md) - leave empty to auto-detect CI from environment variables, or set `true`/`false` to override. Selects the frozen/reproducible install variant below. |
+
+## Frozen (CI-safe) installs
+
+When `IsRunningInCI` resolves to `true` **and** a lockfile exists at the resolved workspace root, `NodeRestore`
+uses the frozen/reproducible install variant instead of the mutable one:
+
+| Tool | Local / mutable | CI / frozen |
+|---|---|---|
+| `rush` | `install-run-rush.js update` | `install-run-rush.js install` |
+| `pnpm` | `pnpm install` | `pnpm install --frozen-lockfile` |
+| `yarn` (Classic) | `yarn install` | `yarn install --frozen-lockfile` |
+| `yarn` (Berry) | `yarn install` | `yarn install --immutable` |
+| `bun` | `bun install` | `bun install --frozen-lockfile` |
+| `npm` | `npm install` | `npm ci` |
+
+Both conditions matter: `npm ci` (and the other frozen variants) hard-fail when there is no lockfile, so CI
+without a committed lockfile intentionally still falls back to the mutable variant with a build warning,
+rather than breaking a build that previously worked. Locally, the frozen variant is never used - `npm ci` in
+particular deletes `node_modules` and reinstalls from scratch on every invocation, and fails outright on the
+transient `package.json`/lockfile mismatch that's normal mid-edit during local development.
+
+This is a **behavior change for CI builds** compared to the SDK's previous unconditional `npm install`: CI
+builds with a committed lockfile now get a frozen, non-mutating install. This directly fixes the lockfile
+cache-invalidation and reproducibility problems described above.
+
+Rush is always treated as "has a lockfile" for this purpose - `install-run-rush.js`'s own `install` vs.
+`update` verbs already enforce the same frozen-vs-mutable distinction internally.
+
+## Rush specifics
+
+Rush is not a package manager - it's an installer-owning orchestrator that wraps npm/pnpm/Yarn internally and
+must never be bypassed. `NodeRestore` always invokes it via the version-pinned bootstrap script
+(`<rush.json directory>/common/scripts/install-run-rush.js`), never a global `rush` binary, so the exact Rush
+version pinned in `rush.json` is always what runs.
+
+Rush is invoked **unconditionally on every build** rather than being gated by a stamp file: Rush is already
+self-idempotent (it compares a state hash against `common/temp/last-install.flag` and exits almost immediately
+if nothing changed) and already self-serializing across concurrent invocations (its own
+`common/temp/rush#<pid>.lock`). A second, custom incrementality mechanism layered on top would duplicate one
+Rush already owns and would be a likely source of subtly-wrong "already restored" bugs.
+
+## Once-per-workspace execution (non-Rush tools)
+
+For npm/pnpm/Yarn/Bun, `NodeRestore` runs at the detected workspace root and is gated by an MSBuild
+Inputs/Outputs check (lockfile → a `.node-restore-stamp` file under that root's `node_modules`), so the second,
+third, ... project in the same build that shares a workspace root sees the install as already up-to-date and
+skips it - the same "once per workspace, not once per project" guarantee `dotnet restore` gives per solution.
+
+Known limitation: concurrent multi-proc MSBuild builds (`dotnet build -m`) of independent projects sharing one
+workspace root can still race to invoke install simultaneously for these tools, since none of npm/pnpm/Yarn/Bun
+ship a cross-process lock of their own (Rush does not have this problem - see above).
+
+## No global side effects
+
+`NodeRestore` never installs anything globally on the developer's machine: no `npm install -g`, no
+`corepack enable`, no silently bootstrapping a missing tool. If the resolved tool isn't on `PATH`, the install
+command itself fails with a normal "command not found"-style error - the same philosophy as `dotnet restore`
+erroring on a missing SDK/tool rather than trying to fix the environment.
+
+Rush's own `install-run-rush.js` downloads the `rush.json`-pinned Rush release into Rush's own per-user cache
+(not a global npm package, not added to `PATH`). This is Rush's own pre-existing, documented mechanism -
+identical to what already happens the moment a developer manually runs `rush update` in that repo today. It is
+not a new side effect introduced by this SDK.
+
+## Interop with Microsoft's PCF build SDK (`Pcf` package only)
+
+`TALXIS.DevKit.Build.Dataverse.Pcf` depends on Microsoft's official `Microsoft.PowerApps.MSBuild.Pcf` NuGet
+package, which ships its own, independent, unconditional `npm install` hook
+(`_PcfAutoNpmInstall`/`RestoreNPM`, controlled by the `PcfEnableAutoNpmInstall` MSBuild property - defaults to
+`true` in Microsoft's targets). Left alone, that hook would run a second, plain `npm install` on every PCF
+build regardless of anything `NodeRestore` does - no package-manager detection, no CI/lockfile awareness.
+
+This package defaults `PcfEnableAutoNpmInstall` to `false` (in `TALXIS.DevKit.Build.Dataverse.Pcf.props`, which
+NuGet imports before the consumer's project body and before Microsoft's own default check runs), since
+`NodeRestore` already covers the same job with the detection/CI/frozen logic above. If you specifically want
+Microsoft's original unconditional `npm install` behavior back instead, set
+`<PcfEnableAutoNpmInstall>true</PcfEnableAutoNpmInstall>` in your own project - that value is set early enough
+to still win over both defaults.
+
+## Breaking change
+
+The previous `NpmInstall` target (Pcf) and inline `npm install` steps (ScriptLibrary, CodeApp) are replaced
+outright by the shared `NodeRestore` target - there is no back-compat alias for the old `NpmInstall` name. If
+you had a workaround hooking `BeforeTargets`/`AfterTargets="NpmInstall"` (for example, redefining it as a
+no-op to opt out, as described in [#90](https://github.com/TALXIS/tools-devkit-build/issues/90)), replace it
+with `NodePackageManager=None` instead, and remove the old workaround target entirely.

--- a/docs/NodeDependencies.md
+++ b/docs/NodeDependencies.md
@@ -87,73 +87,63 @@ incremental adoption - not every project needs to join Rush's graph on day one) 
 either restore or build routes through Rush, and falls back to this project's own direct `npm install`/
 `npm run build` with a visible warning instead.
 
-### PCF-specific: forwarding `--build-mode`/`--out-dir`/`--build-source`
+### PCF-specific: forwarding the build mode as `--build-mode`
 
-Microsoft's own `PcfBuild` `<Exec>` (in `Microsoft.PowerApps.MSBuild.Pcf.targets`) passes three CLI flags to
-`pcf-scripts build`: `--buildMode $(PcfBuildMode)`, `--outDir "$(PcfOutputPath)"`, `--buildSource $(BuildSource)`.
-Rush's `command-line.json` JSON schema requires custom parameter `longName`s to be lower-case, dash-delimited
-(`^-(-[a-z0-9]+)+$`) - it rejects camelCase names like `--buildMode` outright. `pcf-scripts` parses its CLI
-via `yargs`, which enables camel-case-expansion by default, so a kebab-case `--build-mode` on the command
-line is automatically also exposed as `argv.buildMode` - confirmed empirically. So the parameters below are
-declared and invoked in kebab-case, even though `pcf-scripts`' own flags are camelCase.
+One consistent convention drives every project type in this SDK, PCF included: run `dotnet build` for an
+unminified, source-mapped build, or `dotnet build --configuration Release` for a minified production build -
+the developer never has to think about it or pass any Node-specific flag themselves. This mirrors the exact
+Debug/Release convention Microsoft's own `Microsoft.PowerApps.MSBuild.Pcf.props` already established for
+`$(PcfBuildMode)`, so PCF's Rush-delegated path reuses `$(PcfBuildMode)` directly rather than introducing a
+second, parallel mapping.
+
 Rush's generic `build` command has no built-in mechanism to forward arbitrary CLI arguments through to each
-project's own script - so this package's Rush-branch override of `PcfBuild` forwards them via Rush's own
-documented **custom commands and parameters** feature instead
-(`common/config/rush/command-line.json`, the same mechanism Rush's own docs demonstrate with a `--ship`/
-production-build example), rather than a Debug-only Configuration gate (which would permanently exclude
-production builds from Rush delegation) or transient file patching (an unwanted build-time side effect).
+project's own script, so this package's Rush-branch override of `PcfBuild` forwards the mode via Rush's own
+documented **custom commands and parameters** feature (`common/config/rush/command-line.json`) - the same
+mechanism used for every project type's mode flag (see "Build delegation to Rush" above), just with the
+flag spelled `--build-mode` (matching `pcf-scripts`' own `--buildMode`, camel-case-expanded by `yargs`) instead
+of the generic `--mode`.
 
 **This requires a one-time addition to your repo's `common/config/rush/command-line.json`** - add the following
-to its `parameters` array (each `associatedCommands` must include both `"build"` and `"rebuild"`):
+to its `parameters` array (`associatedCommands` must include both `"build"` and `"rebuild"`):
 
 ```json
-{ "parameterKind": "string", "longName": "--build-mode", "description": "PCF build mode", "associatedCommands": ["build", "rebuild"], "argumentName": "BUILD_MODE" },
-{ "parameterKind": "string", "longName": "--out-dir", "description": "PCF build output directory", "associatedCommands": ["build", "rebuild"], "argumentName": "OUT_DIR" },
-{ "parameterKind": "string", "longName": "--build-source", "description": "PCF build source tag", "associatedCommands": ["build", "rebuild"], "argumentName": "BUILD_SOURCE" }
+{
+  "parameterKind": "choice",
+  "longName": "--build-mode",
+  "description": "PCF build mode",
+  "associatedCommands": ["build", "rebuild"],
+  "alternatives": [
+    { "name": "production", "description": "Minified production bundle" },
+    { "name": "development", "description": "Source-mapped development bundle" }
+  ],
+  "defaultValue": "development"
+}
 ```
 
-If a Rush-registered PCF project's `command-line.json` doesn't declare these yet, **the build fails immediately**
-with an error naming the missing parameter(s) and this exact snippet - it does not silently fall back to
-Microsoft's un-cached, un-delegated `<Exec>`. This is deliberate: once a project is Rush-registered, it has
-unambiguously opted into Rush build delegation, so a missing declaration is a fixable configuration gap, not a
-legitimate "not opted in yet" state (contrast with the `rush.json` registration check above, which *does* fall
-back gracefully, since a project simply not yet added to `rush.json` at all is indistinguishable from valid
-incremental adoption).
+If a Rush-registered PCF project's `command-line.json` doesn't declare this yet, **the build fails immediately**
+with an error naming the missing parameter - it does not silently fall back to Microsoft's un-cached,
+un-delegated `<Exec>`. This is deliberate: once a project is Rush-registered, it has unambiguously opted into
+Rush build delegation, so a missing declaration is a fixable configuration gap, not a legitimate "not opted in
+yet" state (contrast with the `rush.json` registration check above, which *does* fall back gracefully, since a
+project simply not yet added to `rush.json` at all is indistinguishable from valid incremental adoption).
 
-Rush's build cache already incorporates the command-line parameters used into its cache key, so a `--build-mode
-development` (Debug) and `--build-mode production` (Release) build of the same project get distinct, correct
-cache entries automatically - no extra work needed here.
+Rush's own build cache already incorporates the command-line parameters used into its cache key (a `choice`
+parameter with `defaultValue` is always appended, even on a plain `rush build`), so `--build-mode development`
+(Debug) and `--build-mode production` (Release) builds of the same project get distinct, correct cache entries
+automatically - no extra work needed here.
 
-**Second, independently-required one-time change: your PCF project's `package.json` `"build"` script must
-translate the forwarded kebab-case flags back to the camelCase flags `pcf-scripts` actually needs.** This was
-found empirically (a real acceptance retest against a production PCF control): passing `--build-mode`/`--out-dir`
-straight through to `pcf-scripts build` - the only spelling Rush's own schema allows - produces a broken,
-oversized production bundle (`[pcf-1045] bundle exceeds the maximum size allowed`) and skips
-`ControlManifest.xml` generation entirely, even though the camelCase and kebab-case spellings resolve to a
-byte-identical internal `pcf-scripts` config (confirmed via debug instrumentation - the divergence happens
-somewhere inside webpack/babel/terser, not any code path `pcf-scripts` itself owns, and is out of this SDK's
-reach to fix upstream). Replace the default `"build"` script:
-
-```json
-"build": "pcf-scripts build"
-```
-
-with:
-
-```json
-"build": "node -e \"const a=process.argv.slice(1);const g=k=>{const i=a.indexOf('--'+k);return i===-1?undefined:a[i+1];};const bm=g('build-mode');const od=g('out-dir');const bs=g('build-source');const cp=require('child_process');const args=['build'];if(bm)args.push('--buildMode',bm);if(od)args.push('--outDir',od);if(bs)args.push('--buildSource',bs);const r=cp.spawnSync('pcf-scripts',args,{stdio:'inherit',shell:true});process.exit(r.status===null?1:r.status);\" --"
-```
-
-This is a plain, consumer-owned `package.json` edit - not a file this SDK ships or patches on your behalf; `node`
-is already a hard requirement for any `pcf-scripts` project, so no new toolchain dependency is introduced. Like
-the `command-line.json` declaration above, a Rush-registered PCF project whose `"build"` script still looks like
-the unmodified default (no `buildMode`/`outDir` references found) **fails the build immediately** with this exact
-snippet, rather than silently reproducing the broken-bundle failure.
+No `package.json` "build" script translation is needed, and `--out-dir`/`--build-source` are not forwarded at
+all: `pcf-scripts`' own default output directory already matches this SDK's `$(PcfOutputPath)` default, and
+`--build-source` only affects telemetry. Rush invokes each project's script directly (no `npm run --`
+indirection, so no `--` argument terminator is ever involved) and constructs the command line as plain,
+space-separated tokens - `pcf-scripts build --build-mode production` - which `yargs`' default camel-case
+expansion reliably parses into `argv.buildMode`, exactly as if the flag had been spelled `--buildMode` in the
+first place.
 
 **For the build *cache* itself to activate** (as opposed to just delegation, which works either way via Rush's
 default incremental "output preservation" skip), each PCF project also needs its own `rush-project.json`
 declaring `projectOutputFolderNames` (typically `["out"]`) - this is a separate, recommended-but-not-required
-consumer prerequisite; a project missing it still builds correctly through the forwarded parameters, just
+consumer prerequisite; a project missing it still builds correctly through the forwarded parameter, just
 without the archived-cache performance benefit.
 
 `Pcf` projects have no new Clean target from this SDK, and this override does not affect `PcfClean`.

--- a/src/Dataverse/CodeApp/README.md
+++ b/src/Dataverse/CodeApp/README.md
@@ -1,6 +1,6 @@
 # TALXIS.DevKit.Build.Dataverse.CodeApp
 
-MSBuild integration for Power Apps code-first canvas app projects. Automates the `npm install` / `npm run build` lifecycle, copies the compiled `dist/` output into the correct location, and exposes metadata targets that allow Solution projects to discover, generate `.meta.xml`, and package canvas apps into the solution `.zip`.
+MSBuild integration for Power Apps code-first canvas app projects. Automates Node dependency restore (auto-detected package manager - npm, pnpm, Yarn, Bun, or Rush; see [NodeDependencies.md](../../../docs/NodeDependencies.md)) followed by `npm run build`, copies the compiled `dist/` output into the correct location, and exposes metadata targets that allow Solution projects to discover, generate `.meta.xml`, and package canvas apps into the solution `.zip`.
 
 ## Installation
 
@@ -30,8 +30,8 @@ Or use the SDK approach:
 
 ### Build-time targets
 
-1. **CheckCodeAppPrereqs** -- validates that `package.json` exists and that `node` / `npm` are available in PATH. Runs only when `RunNodeBuild` is `true` (auto-detected from the presence of `package.json`).
-2. **BuildCodeApp** (runs before `Build`, depends on `CheckCodeAppPrereqs`) -- executes `npm install` followed by `npm run build` in the project root directory.
+1. **CheckCodeAppPrereqs** -- validates that `package.json` exists and that `node` is available in PATH (package manager presence is checked by `NodeRestore` itself, since it depends on what's detected). Runs only when `RunNodeBuild` is `true` (auto-detected from the presence of `package.json`).
+2. **BuildCodeApp** (runs before `Build`, depends on `CheckCodeAppPrereqs`) -- calls the shared `NodeRestore` target (auto-detected package manager) followed by `npm run build` in the project root directory.
 3. **CopyCodeAppDist** (runs after `Build`) -- copies the `dist/` folder to `$(OutputPath)$(AppName)\`. Fails the build if `dist/` is missing or if `AppName` is not set.
 4. **CopyCodeAppDistPublish** (runs after `Publish`) -- same as above, but copies to `$(PublishDir)` instead.
 
@@ -47,7 +47,7 @@ These targets are called by `TALXIS.DevKit.Build.Dataverse.Solution` when it dis
 When a Solution project has a `ProjectReference` to a CodeApp project, the following happens automatically during solution build:
 
 1. **ProbeCodeApps** discovers the CodeApp reference by calling `GetProjectType`.
-2. **BuildCodeApps** calls `GetCodeAppOutputs`, which triggers the full CodeApp build (npm install + build).
+2. **BuildCodeApps** calls `GetCodeAppOutputs`, which triggers the full CodeApp build (Node dependency restore + build).
 3. **PrepareCodeAppsSources** generates `.meta.xml` via `GenerateCodeAppMetaXml`, adds a `RootComponent` entry (Type 300) to `Solution.xml`, and ensures the `CanvasApps` node exists in `Customizations.xml`.
 4. **CopyCodeAppsToMetadata** copies the CodeApp dist output into the solution metadata `CanvasApps/` folder before PAC packages the solution.
 

--- a/src/Dataverse/CodeApp/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.CodeApp.targets
+++ b/src/Dataverse/CodeApp/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.CodeApp.targets
@@ -43,7 +43,7 @@
     DependsOnTargets="CheckCodeAppPrereqs;_NodeRestoreResolve;_CodeAppSetNodeBuildArgs;_NodeRestoreDelegateBuildToRush;_NodeRestoreBuildDirect"
     BeforeTargets="Build"
     Condition="'$(RunNodeBuild)'=='true'">
-    <Message Text="Running npm run build in $(MSBuildProjectDirectory)" Importance="High" />
+    <Message Text="Node build for CodeApp in $(MSBuildProjectDirectory) completed (or was already up to date)." Importance="High" />
   </Target>
 
   <!-- Removes this project's own JS build-output folder ("dist") on "dotnet clean". Plain

--- a/src/Dataverse/CodeApp/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.CodeApp.targets
+++ b/src/Dataverse/CodeApp/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.CodeApp.targets
@@ -9,18 +9,19 @@
   <Target Name="CheckCodeAppPrereqs"
     Condition="'$(RunNodeBuild)'=='true'">
     <Error Condition="!Exists('$(MSBuildProjectDirectory)/package.json')" Text="CodeApp package.json not found in $(MSBuildProjectDirectory)" />
+    <!-- Only Node.js itself is a hard prerequisite here - which package manager binary is
+         actually required depends on what NodeRestore below detects (npm/pnpm/yarn/bun/rush),
+         so that check is left to NodeRestore's own Exec failing clearly if the resolved tool
+         isn't on PATH, rather than hardcoding a single tool's presence here. -->
     <Exec Command="node --version" IgnoreExitCode="true" />
     <Error Condition="'$(MSBuildLastTaskResult)'!='True'" Text="Node.js not found in PATH. Install Node.js to build CodeApp." />
-    <Exec Command="npm --version" IgnoreExitCode="true" />
-    <Error Condition="'$(MSBuildLastTaskResult)'!='True'" Text="npm not found in PATH. Install Node.js (includes npm) to build CodeApp." />
   </Target>
 
   <Target Name="BuildCodeApp"
     DependsOnTargets="CheckCodeAppPrereqs"
     BeforeTargets="Build"
     Condition="'$(RunNodeBuild)'=='true'">
-    <Message Text="Running npm install in $(MSBuildProjectDirectory)" Importance="High" />
-    <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Command="npm install" />
+    <CallTarget Targets="NodeRestore" />
     <Message Text="Running npm run build in $(MSBuildProjectDirectory)" Importance="High" />
     <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Command="npm run build" />
   </Target>

--- a/src/Dataverse/CodeApp/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.CodeApp.targets
+++ b/src/Dataverse/CodeApp/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.CodeApp.targets
@@ -17,13 +17,66 @@
     <Error Condition="'$(MSBuildLastTaskResult)'!='True'" Text="Node.js not found in PATH. Install Node.js to build CodeApp." />
   </Target>
 
+  <!-- Node dependency hydration, anchored to AfterTargets="CollectPackageReferences" (not
+       BeforeTargets="Build"/inlined into BuildCodeApp below) so it also fires during a bare
+       "dotnet restore" at the repo/solution root, not just when this project's own Build target
+       actually runs - CollectPackageReferences is the only per-project target NuGet's
+       solution-level restore reliably invokes for every project (empirically verified, see
+       NodeRestore.targets), which is what makes "dotnet restore" at the repo root hydrate Node
+       deps too, the same way it already hydrates NuGet ones. -->
+  <Target Name="_CodeAppNodeRestore" AfterTargets="CollectPackageReferences" Condition="'$(RunNodeBuild)'=='true'">
+    <CallTarget Targets="NodeRestore" />
+  </Target>
+
   <Target Name="BuildCodeApp"
-    DependsOnTargets="CheckCodeAppPrereqs"
+    DependsOnTargets="CheckCodeAppPrereqs;_NodeRestoreResolve"
     BeforeTargets="Build"
     Condition="'$(RunNodeBuild)'=='true'">
-    <CallTarget Targets="NodeRestore" />
     <Message Text="Running npm run build in $(MSBuildProjectDirectory)" Importance="High" />
-    <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Command="npm run build" />
+
+    <!-- When Rush is resolved for this project (and it is registered in rush.json - folded into
+         _NodeRestoreResolvedTool by _NodeRestoreResolve's own proactive registration check, see
+         NodeRestore.targets), delegate the build itself to Rush too, not just dependency
+         hydration, so Rush's own content-hash incremental skip + build cache actually apply
+         (Finding #7) - a direct "npm run build" every time has zero incrementality of its own.
+         Scoped vs unscoped chosen by $(SolutionPath), identical reasoning to Pcf's PcfBuild
+         override (see TALXIS.DevKit.Build.Dataverse.Pcf.targets): a standalone build stays fast
+         (only this project's own Rush-graph subset), a solution-scope build avoids serializing N
+         projects behind Rush's one exclusive whole-repo lock. -->
+    <PropertyGroup Condition="'$(_NodeRestoreResolvedTool)' == 'rush'">
+      <_CodeAppIsSolutionScope Condition="'$(SolutionPath)' != '' and '$(SolutionPath)' != '*Undefined*'">true</_CodeAppIsSolutionScope>
+      <_CodeAppRushBuildCommand Condition="'$(_CodeAppIsSolutionScope)' != 'true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" build --to .</_CodeAppRushBuildCommand>
+      <_CodeAppRushBuildCommand Condition="'$(_CodeAppIsSolutionScope)' == 'true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" build</_CodeAppRushBuildCommand>
+      <_NodeRestoreRetryCommand>$(_CodeAppRushBuildCommand)</_NodeRestoreRetryCommand>
+      <_NodeRestoreRetryWorkingDirectory>$(MSBuildProjectDirectory)</_NodeRestoreRetryWorkingDirectory>
+    </PropertyGroup>
+    <!-- MSBuild self-invocation, not CallTarget: this same shared target already ran once during
+         this project's restore-hydration phase (_NodeRestoreRunRush, in NodeRestore.targets)
+         earlier in this same "dotnet build" - MSBuild only executes a given target name once per
+         project build regardless of CallTarget call count, so a second CallTarget here would
+         silently no-op instead of running the build command. Invoking via the MSBuild task with
+         an explicit Properties list forces a fresh, distinct execution. -->
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="_NodeRestoreExecWithRetry"
+             Properties="_NodeRestoreRetryCommand=$(_NodeRestoreRetryCommand);_NodeRestoreRetryWorkingDirectory=$(_NodeRestoreRetryWorkingDirectory)"
+             Condition="'$(_NodeRestoreResolvedTool)' == 'rush'" />
+
+    <!-- Non-Rush tools (pnpm/yarn/npm/bun/no orchestrator): unchanged direct invocation - none of
+         those ship an equivalent workspace-wide build cache to delegate to in scope here;
+         over-solving for them repeats the over-engineering already rejected earlier in this
+         design. -->
+    <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Command="npm run build" Condition="'$(_NodeRestoreResolvedTool)' != 'rush'" />
+  </Target>
+
+  <!-- Removes this project's own JS build-output folder ("dist") on "dotnet clean" (Finding #4 -
+       a real gap before this: dotnet clean left stale JS bundles behind silently). Plain
+       RemoveDir, no process invocation - Clean needs no Node toolchain present at all here.
+       Deliberately never touches node_modules or any shared Rush/pnpm workspace state: npm-land
+       treats "clean" and "prune deps" as different operations, and node_modules removal is a far
+       more expensive, disruptive step that must not be a silent side effect of every
+       "dotnet clean". -->
+  <Target Name="CleanCodeApp" AfterTargets="Clean" Condition="'$(RunNodeBuild)'=='true'">
+    <RemoveDir Directories="$(MSBuildProjectDirectory)/dist" Condition="Exists('$(MSBuildProjectDirectory)/dist')" />
   </Target>
 
   <Target Name="CopyCodeAppDist"

--- a/src/Dataverse/CodeApp/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.CodeApp.targets
+++ b/src/Dataverse/CodeApp/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.CodeApp.targets
@@ -21,55 +21,32 @@
        BeforeTargets="Build"/inlined into BuildCodeApp below) so it also fires during a bare
        "dotnet restore" at the repo/solution root, not just when this project's own Build target
        actually runs - CollectPackageReferences is the only per-project target NuGet's
-       solution-level restore reliably invokes for every project (empirically verified, see
-       NodeRestore.targets), which is what makes "dotnet restore" at the repo root hydrate Node
-       deps too, the same way it already hydrates NuGet ones. -->
+       solution-level restore reliably invokes for every project, which is what makes "dotnet
+       restore" at the repo root hydrate Node deps too, the same way it already hydrates NuGet
+       ones. -->
   <Target Name="_CodeAppNodeRestore" AfterTargets="CollectPackageReferences" Condition="'$(RunNodeBuild)'=='true'">
     <CallTarget Targets="NodeRestore" />
   </Target>
 
+  <!-- Supplies this project's arguments to the shared NodeBuild targets via DependsOnTargets, not
+       CallTarget - properties set in a target reached through CallTarget are not visible inside
+       the called target, only ones reached through the DependsOnTargets chain are. -->
+  <Target Name="_CodeAppSetNodeBuildArgs">
+    <PropertyGroup>
+      <_NodeBuildProjectDirectory>$(MSBuildProjectDirectory)</_NodeBuildProjectDirectory>
+      <_NodeBuildExtraArgs></_NodeBuildExtraArgs>
+      <_NodeBuildRequiredRushParams></_NodeBuildRequiredRushParams>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="BuildCodeApp"
-    DependsOnTargets="CheckCodeAppPrereqs;_NodeRestoreResolve"
+    DependsOnTargets="CheckCodeAppPrereqs;_NodeRestoreResolve;_CodeAppSetNodeBuildArgs;_NodeRestoreDelegateBuildToRush;_NodeRestoreBuildDirect"
     BeforeTargets="Build"
     Condition="'$(RunNodeBuild)'=='true'">
     <Message Text="Running npm run build in $(MSBuildProjectDirectory)" Importance="High" />
-
-    <!-- When Rush is resolved for this project (and it is registered in rush.json - folded into
-         _NodeRestoreResolvedTool by _NodeRestoreResolve's own proactive registration check, see
-         NodeRestore.targets), delegate the build itself to Rush too, not just dependency
-         hydration, so Rush's own content-hash incremental skip + build cache actually apply
-         (Finding #7) - a direct "npm run build" every time has zero incrementality of its own.
-         Scoped vs unscoped chosen by $(SolutionPath), identical reasoning to Pcf's PcfBuild
-         override (see TALXIS.DevKit.Build.Dataverse.Pcf.targets): a standalone build stays fast
-         (only this project's own Rush-graph subset), a solution-scope build avoids serializing N
-         projects behind Rush's one exclusive whole-repo lock. -->
-    <PropertyGroup Condition="'$(_NodeRestoreResolvedTool)' == 'rush'">
-      <_CodeAppIsSolutionScope Condition="'$(SolutionPath)' != '' and '$(SolutionPath)' != '*Undefined*'">true</_CodeAppIsSolutionScope>
-      <_CodeAppRushBuildCommand Condition="'$(_CodeAppIsSolutionScope)' != 'true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" build --to .</_CodeAppRushBuildCommand>
-      <_CodeAppRushBuildCommand Condition="'$(_CodeAppIsSolutionScope)' == 'true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" build</_CodeAppRushBuildCommand>
-      <_NodeRestoreRetryCommand>$(_CodeAppRushBuildCommand)</_NodeRestoreRetryCommand>
-      <_NodeRestoreRetryWorkingDirectory>$(MSBuildProjectDirectory)</_NodeRestoreRetryWorkingDirectory>
-    </PropertyGroup>
-    <!-- MSBuild self-invocation, not CallTarget: this same shared target already ran once during
-         this project's restore-hydration phase (_NodeRestoreRunRush, in NodeRestore.targets)
-         earlier in this same "dotnet build" - MSBuild only executes a given target name once per
-         project build regardless of CallTarget call count, so a second CallTarget here would
-         silently no-op instead of running the build command. Invoking via the MSBuild task with
-         an explicit Properties list forces a fresh, distinct execution. -->
-    <MSBuild Projects="$(MSBuildProjectFullPath)"
-             Targets="_NodeRestoreExecWithRetry"
-             Properties="_NodeRestoreRetryCommand=$(_NodeRestoreRetryCommand);_NodeRestoreRetryWorkingDirectory=$(_NodeRestoreRetryWorkingDirectory)"
-             Condition="'$(_NodeRestoreResolvedTool)' == 'rush'" />
-
-    <!-- Non-Rush tools (pnpm/yarn/npm/bun/no orchestrator): unchanged direct invocation - none of
-         those ship an equivalent workspace-wide build cache to delegate to in scope here;
-         over-solving for them repeats the over-engineering already rejected earlier in this
-         design. -->
-    <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Command="npm run build" Condition="'$(_NodeRestoreResolvedTool)' != 'rush'" />
   </Target>
 
-  <!-- Removes this project's own JS build-output folder ("dist") on "dotnet clean" (Finding #4 -
-       a real gap before this: dotnet clean left stale JS bundles behind silently). Plain
+  <!-- Removes this project's own JS build-output folder ("dist") on "dotnet clean". Plain
        RemoveDir, no process invocation - Clean needs no Node toolchain present at all here.
        Deliberately never touches node_modules or any shared Rush/pnpm workspace state: npm-land
        treats "clean" and "prune deps" as different operations, and node_modules removal is a far

--- a/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.props
+++ b/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.props
@@ -16,6 +16,16 @@
          no value here since PCF output is produced by webpack/pcf-scripts, not MSBuild's C#
          compile pipeline. Consumers can still opt back in via EnableDefaultItems=true. -->
     <EnableDefaultItems>false</EnableDefaultItems>
+    <!-- Microsoft.PowerApps.MSBuild.Pcf (a dependency of this package) ships its own independent,
+         unconditional "npm install" hook (_PcfAutoNpmInstall/RestoreNPM, BeforeTargets="BeforeBuild"),
+         defaulted on via its own "Condition="'$(PcfEnableAutoNpmInstall)' == ''">true" in its .targets file.
+         It has no package-manager detection, no CI/lockfile awareness, and no useful override besides this
+         flag - our NodeRestore target (see TALXIS.DevKit.Build.Dataverse.Pcf.targets) supersedes it. Default
+         it off here so consumers get exactly one Node restore per build, not two. This file is NuGet's
+         auto-imported "build/" props, which import before the consumer's own project body and before
+         Microsoft's package targets evaluate their own default - so a consumer who explicitly sets
+         PcfEnableAutoNpmInstall=true in their own project keeps Microsoft's original behavior instead. -->
+    <PcfEnableAutoNpmInstall Condition="'$(PcfEnableAutoNpmInstall)' == ''">false</PcfEnableAutoNpmInstall>
   </PropertyGroup>
 
   <Import Project="$(PowerAppsTargetsPath)\Microsoft.PowerApps.VisualStudio.Pcf.props" Condition="Exists('$(PowerAppsTargetsPath)\Microsoft.PowerApps.VisualStudio.Pcf.props')" />

--- a/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
+++ b/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
@@ -30,8 +30,18 @@
   <!-- Node dependency hydration, see NodeRestore.targets (shared, from the Tasks package) for
        the detection/command logic. Breaking rename from the previous hardcoded "NpmInstall"
        target - anyone hooking BeforeTargets/AfterTargets on the old name must switch to
-       "_PcfNodeRestore"/depend on the shared "NodeRestore" target directly. -->
-  <Target Name="_PcfNodeRestore" BeforeTargets="BeforeBuild">
+       "_PcfNodeRestore"/depend on the shared "NodeRestore" target directly.
+       Anchored to AfterTargets="CollectPackageReferences", not BeforeTargets="BeforeBuild": NuGet's
+       solution-level restore (a bare "dotnet restore" at the repo/solution root, as opposed to a
+       single project) never runs a project's Build-side targets at all - it only runs the
+       narrower internal targets it needs to collect PackageReference items, of which
+       CollectPackageReferences is the one that reliably fires per-project for every project in a
+       solution-scope restore (empirically verified: BeforeBuild/Build never fire during solution
+       restore; CollectPackageReferences fires for every project, at both project and solution
+       scope, and also on a fresh, never-restored clone's first "dotnet build" with no explicit
+       restore first). This is what makes plain "dotnet restore" at the repo root hydrate Node
+       deps for every project, not just ones that happen to get their Build target invoked. -->
+  <Target Name="_PcfNodeRestore" AfterTargets="CollectPackageReferences">
     <CallTarget Targets="NodeRestore" />
   </Target>
 
@@ -42,6 +52,138 @@
   <Target Name="_ApplyPcfVersionAfterBuild" AfterTargets="PcfBuild">
     <CallTarget Targets="GenerateVersionNumber"/>
     <CallTarget Targets="ApplyPcfVersionNumber"/>
+  </Target>
+
+  <!-- Rush build delegation: a full redefinition of Microsoft.PowerApps.MSBuild.Pcf's own
+       "PcfBuild" target, not an AfterTargets/BeforeTargets hook - MSBuild resolves duplicate
+       target names by "last one imported wins", and this package's own .targets file is
+       empirically confirmed (via a real "dotnet restore" against locally packed nupkgs, inspecting
+       the generated .nuget.g.targets import order) to import AFTER
+       Microsoft.PowerApps.MSBuild.Pcf's, so this redefinition fully replaces Microsoft's Exec
+       body rather than running alongside/racing it. Both of Microsoft's own "_PcfNpmRunBuild"
+       (incremental) and "_PcfForceNpmRunBuild" (PcfRebuild) call "PcfBuild" by name via
+       CallTarget, so overriding it here covers both build paths with one definition - the same
+       target Microsoft itself uses as the single npm-invoking choke point.
+
+       Only takes effect once NodeRestore has resolved Rush AND this project is registered in
+       rush.json - both folded into "_NodeRestoreResolvedTool" by _NodeRestoreResolve's own
+       proactive registration check (see NodeRestore.targets), so a single Condition here covers
+       "not Rush", "Rush but not yet added to rush.json" (legitimate incremental adoption), and
+       "Rush and registered" uniformly. Anything not covered keeps Microsoft's original, untouched
+       "npm run build" invocation - unaffected by this file entirely, since the whole point of
+       "last import wins" is that our redefinition is all-or-nothing per project, so the Condition
+       itself must gate the entire body, not just parts of it. -->
+  <Target Name="PcfBuild"
+          DependsOnTargets="_NodeRestoreResolve"
+          Condition="'$(_NodeRestoreResolvedTool)' == 'rush'">
+
+    <!-- Hard requirement, not a graceful fallback (contrast with the rush.json registration check
+         above, which does fall back gracefully): once a Pcf project is Rush-registered, it has
+         unambiguously opted into Rush build delegation, so a command-line.json missing the
+         buildMode/outDir/buildSource custom parameters this SDK needs is a genuine, fixable
+         Rush configuration gap - not a legitimate "not opted in yet" state. Per explicit user
+         feedback ("if rush is misconfigured we should fail hard so that the consumer fixes it"),
+         this fails the build immediately with the exact remediation snippet, rather than silently
+         falling back to Microsoft's un-cached, un-delegated Exec (a downgrade the consumer might
+         never notice). -->
+    <PropertyGroup>
+      <_PcfCommandLineJsonPath>$(_NodeRestoreWorkspaceRoot)/common/config/rush/command-line.json</_PcfCommandLineJsonPath>
+      <_PcfCommandLineJsonText Condition="Exists('$(_PcfCommandLineJsonPath)')">$([System.IO.File]::ReadAllText('$(_PcfCommandLineJsonPath)'))</_PcfCommandLineJsonText>
+      <!-- Rush's own command-line.json JSON schema requires custom parameter longNames to be
+           lower-case and dash-delimited; it rejects camelCase names like "buildMode" outright
+           (confirmed empirically: Rush errors "must match pattern" on load). yargs (which
+           pcf-scripts uses to parse its own CLI args) enables camel-case-expansion by default, so
+           a dash-delimited "build-mode" flag on the command line is automatically also exposed as
+           argv.buildMode - confirmed empirically via a direct yargs probe. So the Rush-declared
+           parameter names must be dash-delimited even though pcf-scripts' own flags are camelCase. -->
+      <_PcfHasBuildModeParam Condition="'$(_PcfCommandLineJsonText)' != '' and $(_PcfCommandLineJsonText.Contains('&quot;--build-mode&quot;'))">true</_PcfHasBuildModeParam>
+      <_PcfHasOutDirParam Condition="'$(_PcfCommandLineJsonText)' != '' and $(_PcfCommandLineJsonText.Contains('&quot;--out-dir&quot;'))">true</_PcfHasOutDirParam>
+      <_PcfHasBuildSourceParam Condition="'$(_PcfCommandLineJsonText)' != '' and $(_PcfCommandLineJsonText.Contains('&quot;--build-source&quot;'))">true</_PcfHasBuildSourceParam>
+    </PropertyGroup>
+
+    <Error Condition="'$(_PcfHasBuildModeParam)' != 'true' or '$(_PcfHasOutDirParam)' != 'true' or '$(_PcfHasBuildSourceParam)' != 'true'"
+           Text="NodeRestore: this PCF project is registered with Rush, but '$(_PcfCommandLineJsonPath)' does not declare the --build-mode/--out-dir/--build-source custom command-line parameters this SDK requires to delegate PCF builds through Rush (see docs/NodeDependencies.md). Add the following to the 'parameters' array in that file (associatedCommands must include 'build' and 'rebuild'): { &quot;parameterKind&quot;: &quot;string&quot;, &quot;longName&quot;: &quot;--build-mode&quot;, &quot;description&quot;: &quot;PCF build mode&quot;, &quot;associatedCommands&quot;: [&quot;build&quot;,&quot;rebuild&quot;], &quot;argumentName&quot;: &quot;BUILD_MODE&quot; }, { &quot;parameterKind&quot;: &quot;string&quot;, &quot;longName&quot;: &quot;--out-dir&quot;, &quot;description&quot;: &quot;PCF build output directory&quot;, &quot;associatedCommands&quot;: [&quot;build&quot;,&quot;rebuild&quot;], &quot;argumentName&quot;: &quot;OUT_DIR&quot; }, { &quot;parameterKind&quot;: &quot;string&quot;, &quot;longName&quot;: &quot;--build-source&quot;, &quot;description&quot;: &quot;PCF build source tag&quot;, &quot;associatedCommands&quot;: [&quot;build&quot;,&quot;rebuild&quot;], &quot;argumentName&quot;: &quot;BUILD_SOURCE&quot; }" />
+
+    <!-- Second, independently-required consumer setup item, found empirically (real INT0015
+         acceptance retest): pcf-scripts itself (not Rush, not this SDK - confirmed by bypassing
+         Rush entirely and invoking pcf-scripts directly) produces a broken, oversized,
+         non-minified-scale production bundle - and never writes ControlManifest.xml - when its
+         buildMode flag is spelled dash-delimited instead of camelCase, even though both
+         spellings resolve to byte-identical internal config (confirmed via debug instrumentation;
+         root cause sits inside webpack/babel/terser, not any pcf-scripts code path, and is out of
+         this SDK's reach to fix upstream). Since Rush's own schema forces the dash-delimited
+         spelling for anything declared in command-line.json (the check above), the bridge back to
+         the camelCase spelling pcf-scripts actually needs has to live in the consumer's own
+         package.json "build" script - the one place between Rush and pcf-scripts we don't own and
+         can't patch on the consumer's behalf. A Rush-registered project with a correctly-declared
+         command-line.json but an unmodified default "build" script would otherwise silently regress
+         into this exact broken-bundle failure again, so this gets the same proactive hard-fail
+         treatment as the command-line.json check above, not just a documentation callout. -->
+    <PropertyGroup>
+      <_PcfPackageJsonPath>$(MSBuildProjectDirectory)\package.json</_PcfPackageJsonPath>
+      <_PcfPackageJsonText Condition="Exists('$(_PcfPackageJsonPath)')">$([System.IO.File]::ReadAllText('$(_PcfPackageJsonPath)'))</_PcfPackageJsonText>
+      <!-- Substring check, not full JSON parsing: MSBuild has no built-in JSON parser, and a
+           string search for the camelCase flag names is sufficient here - the remap script only
+           does its job if it literally mentions "buildMode"/"outDir" somewhere, so their absence
+           reliably means the default, un-remapped "pcf-scripts build" script is still in place. -->
+      <_PcfBuildScriptRemapped Condition="'$(_PcfPackageJsonText)' != '' and $(_PcfPackageJsonText.Contains('buildMode')) and $(_PcfPackageJsonText.Contains('outDir'))">true</_PcfBuildScriptRemapped>
+    </PropertyGroup>
+
+    <Error Condition="'$(_PcfBuildScriptRemapped)' != 'true'"
+           Text="NodeRestore: this PCF project is registered with Rush and declares the --build-mode/--out-dir/--build-source Rush parameters, but '$(_PcfPackageJsonPath)''s &quot;build&quot; script does not appear to translate them back to the camelCase flags pcf-scripts requires (--buildMode/--outDir/--buildSource) - passing Rush's dash-delimited flags straight through to pcf-scripts produces a broken, oversized production bundle and skips ControlManifest.xml generation (see docs/NodeDependencies.md). Replace the &quot;build&quot; script in that file with: node -e &quot;const a=process.argv.slice(1);const g=k=&gt;{const i=a.indexOf('--'+k);return i===-1?undefined:a[i+1];};const bm=g('build-mode');const od=g('out-dir');const bs=g('build-source');const cp=require('child_process');const args=['build'];if(bm)args.push('--buildMode',bm);if(od)args.push('--outDir',od);if(bs)args.push('--buildSource',bs);const r=cp.spawnSync('pcf-scripts',args,{stdio:'inherit',shell:true});process.exit(r.status===null?1:r.status);&quot; --" />
+
+    <!-- Scoped vs unscoped Rush command, chosen by MSBuild's own solution-vs-project signal
+         (empirically confirmed via a scratch two-project .slnx fixture: $(SolutionPath) resolves
+         to the literal "*Undefined*"/empty for a standalone "dotnet build a.csproj", and to the
+         real .sln/.slnx path for a solution-scope build - a generic MSBuild idiom, not anything
+         Rush-specific). Two distinct regressions, each needing the opposite fixed choice, are
+         resolved together by branching on this one signal instead:
+           - No solution context: scoped "rush build" targeted just at this project builds only
+             this project + its transitive Rush-graph upstream deps - keeps "build the one
+             project I'm working on after a fresh clone" fast on a large Rush repo (does not
+             build the whole graph).
+           - Solution context: plain unscoped "rush build" - whichever project's target reaches
+             this branch first builds the entire registered graph via Rush's own internal
+             parallelism support; every other project's own call to the same command hits Rush's
+             default incremental skip and returns as a fast no-op. Avoids serializing N real Node
+             builds behind Rush's one exclusive whole-repo lock, which a per-project-scoped call
+             would otherwise do (confirmed at the rushstack source level: "rush build" acquires
+             the exact same whole-repo lock as "rush update"/"install"). -->
+    <PropertyGroup>
+      <_PcfIsSolutionScope Condition="'$(SolutionPath)' != '' and '$(SolutionPath)' != '*Undefined*'">true</_PcfIsSolutionScope>
+      <_PcfRushBuildCommand Condition="'$(_PcfIsSolutionScope)' != 'true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" build --to .</_PcfRushBuildCommand>
+      <_PcfRushBuildCommand Condition="'$(_PcfIsSolutionScope)' == 'true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" build</_PcfRushBuildCommand>
+
+      <!-- Forward the exact three flags Microsoft's own Exec already passes, as Rush custom
+           command-line parameters (Finding #9's final resolution - Rush's own documented "custom
+           commands and parameters" feature, common/config/rush/command-line.json,
+           associatedCommands: ["build","rebuild"] - the same mechanism Rush's own docs use for a
+           production-build flag example) rather than a Configuration-based gate (would
+           permanently exclude production builds from Rush delegation) or build-time file patching
+           (explicitly rejected by the user as an unwanted side effect). This delegates every
+           Configuration to Rush, not just Debug/"development". Rush's build cache already
+           incorporates command-line parameters into its cache key (confirmed at the docs level),
+           so Debug/Release get distinct, correct cache entries with no extra work here.
+           Dash-delimited flags on the command line here (matching the dash-delimited longName Rush
+           requires, see the declaration check above) - yargs' camel-case-expansion inside
+           pcf-scripts turns "build-mode" back into argv.buildMode automatically, confirmed
+           empirically. -->
+      <_PcfRushBuildCommand>$(_PcfRushBuildCommand) --build-mode $(PcfBuildMode) --out-dir "$(PcfOutputPath)" --build-source $(BuildSource)</_PcfRushBuildCommand>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <_NodeRestoreRetryCommand>$(_PcfRushBuildCommand)</_NodeRestoreRetryCommand>
+      <_NodeRestoreRetryWorkingDirectory>$(MSBuildProjectDirectory)</_NodeRestoreRetryWorkingDirectory>
+    </PropertyGroup>
+    <!-- MSBuild self-invocation, not CallTarget: this same shared target already ran once during
+         this project's restore-hydration phase (_NodeRestoreRunRush, in NodeRestore.targets)
+         earlier in this same "dotnet build" - MSBuild only executes a given target name once per
+         project build regardless of CallTarget call count, so a second CallTarget here would
+         silently no-op instead of running the build command. Invoking via the MSBuild task with
+         an explicit Properties list forces a fresh, distinct execution. -->
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="_NodeRestoreExecWithRetry"
+             Properties="_NodeRestoreRetryCommand=$(_NodeRestoreRetryCommand);_NodeRestoreRetryWorkingDirectory=$(_NodeRestoreRetryWorkingDirectory)" />
   </Target>
 
   <!-- PCF projects are JavaScript/TypeScript controls, not .NET assemblies - there is nothing

--- a/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
+++ b/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
@@ -27,8 +27,12 @@
   <Target Name="CreateManifestResourceNames" />
   <Target Name="CoreCompile" />
 
-  <Target Name="NpmInstall" BeforeTargets="BeforeBuild">
-    <Exec Command="npm install" WorkingDirectory="$(MSBuildProjectDirectory)" />
+  <!-- Node dependency hydration, see NodeRestore.targets (shared, from the Tasks package) for
+       the detection/command logic. Breaking rename from the previous hardcoded "NpmInstall"
+       target - anyone hooking BeforeTargets/AfterTargets on the old name must switch to
+       "_PcfNodeRestore"/depend on the shared "NodeRestore" target directly. -->
+  <Target Name="_PcfNodeRestore" BeforeTargets="BeforeBuild">
+    <CallTarget Targets="NodeRestore" />
   </Target>
 
   <!-- Anchored to AfterTargets="PcfBuild" (not BeforeBuild/AfterBuild) so it runs after

--- a/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
+++ b/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
@@ -74,6 +74,23 @@
   <Target Name="_PcfSetNodeBuildArgs">
     <PropertyGroup>
       <_NodeBuildProjectDirectory>$(MSBuildProjectDirectory)</_NodeBuildProjectDirectory>
+      <!-- kebab-case, not camelCase: Rush's own command-line.json schema requires a custom
+           parameter's longName to match "^-(-[a-z0-9]+)+$" (lowercase kebab-case only) - a
+           camelCase flag like "buildMode" with two leading dashes is rejected outright by Rush's
+           own JSON schema validation before a build even starts. Since a Rush-registered project
+           always forwards this flag to its own npm script verbatim (Rush does not
+           rename/translate custom parameters), the flag actually reaching pcf-scripts through
+           the Rush delegation path is kebab-case regardless of what this SDK chooses - so
+           kebab-case is the only spelling that works for every Rush-registered PCF project, not
+           just a stylistic preference.
+           pcf-scripts' own CLI parses this correctly either way (yargs camel-cases dashed flags
+           by default), so the *documented*, pcf-scripts-native consumption path is unaffected.
+           The one known gotcha: a consumer that ships its own webpack.config.js which manually
+           scans raw process.argv for the literal camelCase flag name (matching Microsoft's own
+           Microsoft.PowerApps.MSBuild.Pcf.targets convention, instead of using pcf-scripts'
+           already-parsed config) will not recognize a kebab-case flag - that pattern should be
+           fixed on the consumer side to also accept kebab-case (or, better, to stop re-parsing
+           argv and rely on the mode/config values pcf-scripts already computed). -->
       <_NodeBuildModeArgName>build-mode</_NodeBuildModeArgName>
       <!-- $(PcfBuildMode) is Microsoft's own Debug/Release -> development/production mapping
            (Microsoft.PowerApps.MSBuild.Pcf.props) - reuse it as-is rather than introducing a

--- a/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
+++ b/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
@@ -27,20 +27,16 @@
   <Target Name="CreateManifestResourceNames" />
   <Target Name="CoreCompile" />
 
-  <!-- Node dependency hydration, see NodeRestore.targets (shared, from the Tasks package) for
-       the detection/command logic. Breaking rename from the previous hardcoded "NpmInstall"
-       target - anyone hooking BeforeTargets/AfterTargets on the old name must switch to
-       "_PcfNodeRestore"/depend on the shared "NodeRestore" target directly.
-       Anchored to AfterTargets="CollectPackageReferences", not BeforeTargets="BeforeBuild": NuGet's
-       solution-level restore (a bare "dotnet restore" at the repo/solution root, as opposed to a
-       single project) never runs a project's Build-side targets at all - it only runs the
-       narrower internal targets it needs to collect PackageReference items, of which
-       CollectPackageReferences is the one that reliably fires per-project for every project in a
-       solution-scope restore (empirically verified: BeforeBuild/Build never fire during solution
-       restore; CollectPackageReferences fires for every project, at both project and solution
-       scope, and also on a fresh, never-restored clone's first "dotnet build" with no explicit
-       restore first). This is what makes plain "dotnet restore" at the repo root hydrate Node
-       deps for every project, not just ones that happen to get their Build target invoked. -->
+  <!-- Node dependency hydration, see NodeRestore.targets and NodeRestore\*.targets (shared, from
+       the Tasks package) for the detection/command logic.
+       Anchored to AfterTargets="CollectPackageReferences", not BeforeTargets="BeforeBuild": a
+       solution-level restore ("dotnet restore" at the repo/solution root, as opposed to a single
+       project) never runs a project's Build-side targets - it only runs the narrower internal
+       targets needed to collect PackageReference items, of which CollectPackageReferences is the
+       one that reliably fires per-project at both project and solution scope, including on a
+       fresh clone's first "dotnet build" with no explicit restore first. This is what makes plain
+       "dotnet restore" at the repo root hydrate Node deps for every project, not just ones that
+       happen to get their Build target invoked. -->
   <Target Name="_PcfNodeRestore" AfterTargets="CollectPackageReferences">
     <CallTarget Targets="NodeRestore" />
   </Target>
@@ -56,134 +52,43 @@
 
   <!-- Rush build delegation: a full redefinition of Microsoft.PowerApps.MSBuild.Pcf's own
        "PcfBuild" target, not an AfterTargets/BeforeTargets hook - MSBuild resolves duplicate
-       target names by "last one imported wins", and this package's own .targets file is
-       empirically confirmed (via a real "dotnet restore" against locally packed nupkgs, inspecting
-       the generated .nuget.g.targets import order) to import AFTER
-       Microsoft.PowerApps.MSBuild.Pcf's, so this redefinition fully replaces Microsoft's Exec
-       body rather than running alongside/racing it. Both of Microsoft's own "_PcfNpmRunBuild"
-       (incremental) and "_PcfForceNpmRunBuild" (PcfRebuild) call "PcfBuild" by name via
-       CallTarget, so overriding it here covers both build paths with one definition - the same
-       target Microsoft itself uses as the single npm-invoking choke point.
+       target names by "last one imported wins", and this package's own .targets file imports
+       after Microsoft.PowerApps.MSBuild.Pcf's, so this redefinition fully replaces Microsoft's
+       Exec body rather than running alongside/racing it. Both of Microsoft's own
+       "_PcfNpmRunBuild" (incremental) and "_PcfForceNpmRunBuild" (PcfRebuild) call "PcfBuild" by
+       name via CallTarget, so overriding it here covers both build paths with one definition -
+       the same target Microsoft itself uses as the single npm-invoking choke point.
 
        Only takes effect once NodeRestore has resolved Rush AND this project is registered in
        rush.json - both folded into "_NodeRestoreResolvedTool" by _NodeRestoreResolve's own
-       proactive registration check (see NodeRestore.targets), so a single Condition here covers
-       "not Rush", "Rush but not yet added to rush.json" (legitimate incremental adoption), and
-       "Rush and registered" uniformly. Anything not covered keeps Microsoft's original, untouched
-       "npm run build" invocation - unaffected by this file entirely, since the whole point of
-       "last import wins" is that our redefinition is all-or-nothing per project, so the Condition
-       itself must gate the entire body, not just parts of it. -->
+       proactive registration check (see NodeRestore/Rush.targets), so a single Condition here
+       covers "not Rush", "Rush but not yet added to rush.json" (legitimate incremental
+       adoption), and "Rush and registered" uniformly. Anything not covered keeps Microsoft's
+       original, untouched "npm run build" invocation.
+
+       The actual Rush command construction, command-line.json declaration check and retry
+       wiring live in the shared _NodeRestoreDelegateBuildToRush target (NodeBuild package);
+       _PcfSetNodeBuildArgs supplies this project's arguments to it via DependsOnTargets, not
+       CallTarget - properties set in a target reached through CallTarget are not visible inside
+       the called target, only ones reached through the DependsOnTargets chain are. -->
+  <Target Name="_PcfSetNodeBuildArgs">
+    <PropertyGroup>
+      <_NodeBuildProjectDirectory>$(MSBuildProjectDirectory)</_NodeBuildProjectDirectory>
+      <_NodeBuildModeArgName>build-mode</_NodeBuildModeArgName>
+      <!-- $(PcfBuildMode) is Microsoft's own Debug/Release -> development/production mapping
+           (Microsoft.PowerApps.MSBuild.Pcf.props) - reuse it as-is rather than introducing a
+           second, parallel source of truth: this keeps an explicit override of $(PcfBuildMode)
+           (without touching $(Configuration)) working the same way whether or not Rush is in
+           play. out-dir/build-source are not forwarded: pcf-scripts' default out-dir already
+           matches this SDK's own $(PcfOutputPath) default, and build-source only affects
+           telemetry - neither needs a Rush custom-parameter declaration. -->
+      <NodeBuildConfiguration>$(PcfBuildMode)</NodeBuildConfiguration>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="PcfBuild"
-          DependsOnTargets="_NodeRestoreResolve"
+          DependsOnTargets="_NodeRestoreResolve;_PcfSetNodeBuildArgs;_NodeRestoreDelegateBuildToRush"
           Condition="'$(_NodeRestoreResolvedTool)' == 'rush'">
-
-    <!-- Hard requirement, not a graceful fallback (contrast with the rush.json registration check
-         above, which does fall back gracefully): once a Pcf project is Rush-registered, it has
-         unambiguously opted into Rush build delegation, so a command-line.json missing the
-         buildMode/outDir/buildSource custom parameters this SDK needs is a genuine, fixable
-         Rush configuration gap - not a legitimate "not opted in yet" state. Per explicit user
-         feedback ("if rush is misconfigured we should fail hard so that the consumer fixes it"),
-         this fails the build immediately with the exact remediation snippet, rather than silently
-         falling back to Microsoft's un-cached, un-delegated Exec (a downgrade the consumer might
-         never notice). -->
-    <PropertyGroup>
-      <_PcfCommandLineJsonPath>$(_NodeRestoreWorkspaceRoot)/common/config/rush/command-line.json</_PcfCommandLineJsonPath>
-      <_PcfCommandLineJsonText Condition="Exists('$(_PcfCommandLineJsonPath)')">$([System.IO.File]::ReadAllText('$(_PcfCommandLineJsonPath)'))</_PcfCommandLineJsonText>
-      <!-- Rush's own command-line.json JSON schema requires custom parameter longNames to be
-           lower-case and dash-delimited; it rejects camelCase names like "buildMode" outright
-           (confirmed empirically: Rush errors "must match pattern" on load). yargs (which
-           pcf-scripts uses to parse its own CLI args) enables camel-case-expansion by default, so
-           a dash-delimited "build-mode" flag on the command line is automatically also exposed as
-           argv.buildMode - confirmed empirically via a direct yargs probe. So the Rush-declared
-           parameter names must be dash-delimited even though pcf-scripts' own flags are camelCase. -->
-      <_PcfHasBuildModeParam Condition="'$(_PcfCommandLineJsonText)' != '' and $(_PcfCommandLineJsonText.Contains('&quot;--build-mode&quot;'))">true</_PcfHasBuildModeParam>
-      <_PcfHasOutDirParam Condition="'$(_PcfCommandLineJsonText)' != '' and $(_PcfCommandLineJsonText.Contains('&quot;--out-dir&quot;'))">true</_PcfHasOutDirParam>
-      <_PcfHasBuildSourceParam Condition="'$(_PcfCommandLineJsonText)' != '' and $(_PcfCommandLineJsonText.Contains('&quot;--build-source&quot;'))">true</_PcfHasBuildSourceParam>
-    </PropertyGroup>
-
-    <Error Condition="'$(_PcfHasBuildModeParam)' != 'true' or '$(_PcfHasOutDirParam)' != 'true' or '$(_PcfHasBuildSourceParam)' != 'true'"
-           Text="NodeRestore: this PCF project is registered with Rush, but '$(_PcfCommandLineJsonPath)' does not declare the --build-mode/--out-dir/--build-source custom command-line parameters this SDK requires to delegate PCF builds through Rush (see docs/NodeDependencies.md). Add the following to the 'parameters' array in that file (associatedCommands must include 'build' and 'rebuild'): { &quot;parameterKind&quot;: &quot;string&quot;, &quot;longName&quot;: &quot;--build-mode&quot;, &quot;description&quot;: &quot;PCF build mode&quot;, &quot;associatedCommands&quot;: [&quot;build&quot;,&quot;rebuild&quot;], &quot;argumentName&quot;: &quot;BUILD_MODE&quot; }, { &quot;parameterKind&quot;: &quot;string&quot;, &quot;longName&quot;: &quot;--out-dir&quot;, &quot;description&quot;: &quot;PCF build output directory&quot;, &quot;associatedCommands&quot;: [&quot;build&quot;,&quot;rebuild&quot;], &quot;argumentName&quot;: &quot;OUT_DIR&quot; }, { &quot;parameterKind&quot;: &quot;string&quot;, &quot;longName&quot;: &quot;--build-source&quot;, &quot;description&quot;: &quot;PCF build source tag&quot;, &quot;associatedCommands&quot;: [&quot;build&quot;,&quot;rebuild&quot;], &quot;argumentName&quot;: &quot;BUILD_SOURCE&quot; }" />
-
-    <!-- Second, independently-required consumer setup item, found empirically (real INT0015
-         acceptance retest): pcf-scripts itself (not Rush, not this SDK - confirmed by bypassing
-         Rush entirely and invoking pcf-scripts directly) produces a broken, oversized,
-         non-minified-scale production bundle - and never writes ControlManifest.xml - when its
-         buildMode flag is spelled dash-delimited instead of camelCase, even though both
-         spellings resolve to byte-identical internal config (confirmed via debug instrumentation;
-         root cause sits inside webpack/babel/terser, not any pcf-scripts code path, and is out of
-         this SDK's reach to fix upstream). Since Rush's own schema forces the dash-delimited
-         spelling for anything declared in command-line.json (the check above), the bridge back to
-         the camelCase spelling pcf-scripts actually needs has to live in the consumer's own
-         package.json "build" script - the one place between Rush and pcf-scripts we don't own and
-         can't patch on the consumer's behalf. A Rush-registered project with a correctly-declared
-         command-line.json but an unmodified default "build" script would otherwise silently regress
-         into this exact broken-bundle failure again, so this gets the same proactive hard-fail
-         treatment as the command-line.json check above, not just a documentation callout. -->
-    <PropertyGroup>
-      <_PcfPackageJsonPath>$(MSBuildProjectDirectory)\package.json</_PcfPackageJsonPath>
-      <_PcfPackageJsonText Condition="Exists('$(_PcfPackageJsonPath)')">$([System.IO.File]::ReadAllText('$(_PcfPackageJsonPath)'))</_PcfPackageJsonText>
-      <!-- Substring check, not full JSON parsing: MSBuild has no built-in JSON parser, and a
-           string search for the camelCase flag names is sufficient here - the remap script only
-           does its job if it literally mentions "buildMode"/"outDir" somewhere, so their absence
-           reliably means the default, un-remapped "pcf-scripts build" script is still in place. -->
-      <_PcfBuildScriptRemapped Condition="'$(_PcfPackageJsonText)' != '' and $(_PcfPackageJsonText.Contains('buildMode')) and $(_PcfPackageJsonText.Contains('outDir'))">true</_PcfBuildScriptRemapped>
-    </PropertyGroup>
-
-    <Error Condition="'$(_PcfBuildScriptRemapped)' != 'true'"
-           Text="NodeRestore: this PCF project is registered with Rush and declares the --build-mode/--out-dir/--build-source Rush parameters, but '$(_PcfPackageJsonPath)''s &quot;build&quot; script does not appear to translate them back to the camelCase flags pcf-scripts requires (--buildMode/--outDir/--buildSource) - passing Rush's dash-delimited flags straight through to pcf-scripts produces a broken, oversized production bundle and skips ControlManifest.xml generation (see docs/NodeDependencies.md). Replace the &quot;build&quot; script in that file with: node -e &quot;const a=process.argv.slice(1);const g=k=&gt;{const i=a.indexOf('--'+k);return i===-1?undefined:a[i+1];};const bm=g('build-mode');const od=g('out-dir');const bs=g('build-source');const cp=require('child_process');const args=['build'];if(bm)args.push('--buildMode',bm);if(od)args.push('--outDir',od);if(bs)args.push('--buildSource',bs);const r=cp.spawnSync('pcf-scripts',args,{stdio:'inherit',shell:true});process.exit(r.status===null?1:r.status);&quot; --" />
-
-    <!-- Scoped vs unscoped Rush command, chosen by MSBuild's own solution-vs-project signal
-         (empirically confirmed via a scratch two-project .slnx fixture: $(SolutionPath) resolves
-         to the literal "*Undefined*"/empty for a standalone "dotnet build a.csproj", and to the
-         real .sln/.slnx path for a solution-scope build - a generic MSBuild idiom, not anything
-         Rush-specific). Two distinct regressions, each needing the opposite fixed choice, are
-         resolved together by branching on this one signal instead:
-           - No solution context: scoped "rush build" targeted just at this project builds only
-             this project + its transitive Rush-graph upstream deps - keeps "build the one
-             project I'm working on after a fresh clone" fast on a large Rush repo (does not
-             build the whole graph).
-           - Solution context: plain unscoped "rush build" - whichever project's target reaches
-             this branch first builds the entire registered graph via Rush's own internal
-             parallelism support; every other project's own call to the same command hits Rush's
-             default incremental skip and returns as a fast no-op. Avoids serializing N real Node
-             builds behind Rush's one exclusive whole-repo lock, which a per-project-scoped call
-             would otherwise do (confirmed at the rushstack source level: "rush build" acquires
-             the exact same whole-repo lock as "rush update"/"install"). -->
-    <PropertyGroup>
-      <_PcfIsSolutionScope Condition="'$(SolutionPath)' != '' and '$(SolutionPath)' != '*Undefined*'">true</_PcfIsSolutionScope>
-      <_PcfRushBuildCommand Condition="'$(_PcfIsSolutionScope)' != 'true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" build --to .</_PcfRushBuildCommand>
-      <_PcfRushBuildCommand Condition="'$(_PcfIsSolutionScope)' == 'true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" build</_PcfRushBuildCommand>
-
-      <!-- Forward the exact three flags Microsoft's own Exec already passes, as Rush custom
-           command-line parameters (Finding #9's final resolution - Rush's own documented "custom
-           commands and parameters" feature, common/config/rush/command-line.json,
-           associatedCommands: ["build","rebuild"] - the same mechanism Rush's own docs use for a
-           production-build flag example) rather than a Configuration-based gate (would
-           permanently exclude production builds from Rush delegation) or build-time file patching
-           (explicitly rejected by the user as an unwanted side effect). This delegates every
-           Configuration to Rush, not just Debug/"development". Rush's build cache already
-           incorporates command-line parameters into its cache key (confirmed at the docs level),
-           so Debug/Release get distinct, correct cache entries with no extra work here.
-           Dash-delimited flags on the command line here (matching the dash-delimited longName Rush
-           requires, see the declaration check above) - yargs' camel-case-expansion inside
-           pcf-scripts turns "build-mode" back into argv.buildMode automatically, confirmed
-           empirically. -->
-      <_PcfRushBuildCommand>$(_PcfRushBuildCommand) --build-mode $(PcfBuildMode) --out-dir "$(PcfOutputPath)" --build-source $(BuildSource)</_PcfRushBuildCommand>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <_NodeRestoreRetryCommand>$(_PcfRushBuildCommand)</_NodeRestoreRetryCommand>
-      <_NodeRestoreRetryWorkingDirectory>$(MSBuildProjectDirectory)</_NodeRestoreRetryWorkingDirectory>
-    </PropertyGroup>
-    <!-- MSBuild self-invocation, not CallTarget: this same shared target already ran once during
-         this project's restore-hydration phase (_NodeRestoreRunRush, in NodeRestore.targets)
-         earlier in this same "dotnet build" - MSBuild only executes a given target name once per
-         project build regardless of CallTarget call count, so a second CallTarget here would
-         silently no-op instead of running the build command. Invoking via the MSBuild task with
-         an explicit Properties list forces a fresh, distinct execution. -->
-    <MSBuild Projects="$(MSBuildProjectFullPath)"
-             Targets="_NodeRestoreExecWithRetry"
-             Properties="_NodeRestoreRetryCommand=$(_NodeRestoreRetryCommand);_NodeRestoreRetryWorkingDirectory=$(_NodeRestoreRetryWorkingDirectory)" />
   </Target>
 
   <!-- PCF projects are JavaScript/TypeScript controls, not .NET assemblies - there is nothing

--- a/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
+++ b/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
@@ -74,7 +74,15 @@
   <Target Name="_PcfSetNodeBuildArgs">
     <PropertyGroup>
       <_NodeBuildProjectDirectory>$(MSBuildProjectDirectory)</_NodeBuildProjectDirectory>
-      <_NodeBuildModeArgName>build-mode</_NodeBuildModeArgName>
+      <!-- camelCase, not kebab-case: Microsoft's own Microsoft.PowerApps.MSBuild.Pcf.targets
+           invokes "npm run build" with a "buildMode" flag set to $(PcfBuildMode), and this is
+           the spelling pcf-scripts' own docs/samples use and consumers' custom webpack.config.js
+           overrides are written against (some parse raw process.argv looking for the literal
+           "buildMode" flag name, not via a flag-parsing library, so they only recognize the
+           exact camelCase spelling Microsoft uses - a kebab-case flag would be silently ignored
+           by such a webpack.config.js even though pcf-scripts' own yargs-based parsing accepts
+           either spelling). -->
+      <_NodeBuildModeArgName>buildMode</_NodeBuildModeArgName>
       <!-- $(PcfBuildMode) is Microsoft's own Debug/Release -> development/production mapping
            (Microsoft.PowerApps.MSBuild.Pcf.props) - reuse it as-is rather than introducing a
            second, parallel source of truth: this keeps an explicit override of $(PcfBuildMode)

--- a/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
+++ b/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
@@ -74,15 +74,7 @@
   <Target Name="_PcfSetNodeBuildArgs">
     <PropertyGroup>
       <_NodeBuildProjectDirectory>$(MSBuildProjectDirectory)</_NodeBuildProjectDirectory>
-      <!-- camelCase, not kebab-case: Microsoft's own Microsoft.PowerApps.MSBuild.Pcf.targets
-           invokes "npm run build" with a "buildMode" flag set to $(PcfBuildMode), and this is
-           the spelling pcf-scripts' own docs/samples use and consumers' custom webpack.config.js
-           overrides are written against (some parse raw process.argv looking for the literal
-           "buildMode" flag name, not via a flag-parsing library, so they only recognize the
-           exact camelCase spelling Microsoft uses - a kebab-case flag would be silently ignored
-           by such a webpack.config.js even though pcf-scripts' own yargs-based parsing accepts
-           either spelling). -->
-      <_NodeBuildModeArgName>buildMode</_NodeBuildModeArgName>
+      <_NodeBuildModeArgName>build-mode</_NodeBuildModeArgName>
       <!-- $(PcfBuildMode) is Microsoft's own Debug/Release -> development/production mapping
            (Microsoft.PowerApps.MSBuild.Pcf.props) - reuse it as-is rather than introducing a
            second, parallel source of truth: this keeps an explicit override of $(PcfBuildMode)

--- a/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
+++ b/src/Dataverse/Pcf/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Pcf.targets
@@ -50,21 +50,21 @@
     <CallTarget Targets="ApplyPcfVersionNumber"/>
   </Target>
 
-  <!-- Rush build delegation: a full redefinition of Microsoft.PowerApps.MSBuild.Pcf's own
-       "PcfBuild" target, not an AfterTargets/BeforeTargets hook - MSBuild resolves duplicate
-       target names by "last one imported wins", and this package's own .targets file imports
-       after Microsoft.PowerApps.MSBuild.Pcf's, so this redefinition fully replaces Microsoft's
-       Exec body rather than running alongside/racing it. Both of Microsoft's own
-       "_PcfNpmRunBuild" (incremental) and "_PcfForceNpmRunBuild" (PcfRebuild) call "PcfBuild" by
-       name via CallTarget, so overriding it here covers both build paths with one definition -
-       the same target Microsoft itself uses as the single npm-invoking choke point.
+  <!-- A full redefinition of Microsoft.PowerApps.MSBuild.Pcf's own "PcfBuild" target, not an
+       AfterTargets/BeforeTargets hook - MSBuild resolves duplicate target names by "last one
+       imported wins", and this package's own .targets file imports after
+       Microsoft.PowerApps.MSBuild.Pcf's, so this redefinition fully replaces Microsoft's Exec
+       body. Both of Microsoft's own "_PcfNpmRunBuild" (incremental) and "_PcfForceNpmRunBuild"
+       (PcfRebuild) call "PcfBuild" by name via CallTarget, so overriding it here covers both
+       build paths with one definition.
 
-       Only takes effect once NodeRestore has resolved Rush AND this project is registered in
-       rush.json - both folded into "_NodeRestoreResolvedTool" by _NodeRestoreResolve's own
-       proactive registration check (see NodeRestore/Rush.targets), so a single Condition here
-       covers "not Rush", "Rush but not yet added to rush.json" (legitimate incremental
-       adoption), and "Rush and registered" uniformly. Anything not covered keeps Microsoft's
-       original, untouched "npm run build" invocation.
+       This target has no Condition of its own and always runs both
+       _NodeRestoreDelegateBuildToRush and _NodeRestoreBuildDirect through DependsOnTargets -
+       each of those targets carries its own internal Condition on '$(_NodeRestoreResolvedTool)'
+       so exactly one of them actually invokes npm/Rush for a given project. A Condition on the
+       "PcfBuild" target declaration itself would not behave as a per-build branch: MSBuild's
+       "last declaration wins" rule means a false Condition here would make the whole target -
+       including Microsoft's original body - simply not exist, not fall back to it.
 
        The actual Rush command construction, command-line.json declaration check and retry
        wiring live in the shared _NodeRestoreDelegateBuildToRush target (NodeBuild package);
@@ -87,8 +87,7 @@
   </Target>
 
   <Target Name="PcfBuild"
-          DependsOnTargets="_NodeRestoreResolve;_PcfSetNodeBuildArgs;_NodeRestoreDelegateBuildToRush"
-          Condition="'$(_NodeRestoreResolvedTool)' == 'rush'">
+          DependsOnTargets="_NodeRestoreResolve;_PcfSetNodeBuildArgs;_NodeRestoreDelegateBuildToRush;_NodeRestoreBuildDirect">
   </Target>
 
   <!-- PCF projects are JavaScript/TypeScript controls, not .NET assemblies - there is nothing

--- a/src/Dataverse/ScriptLibrary/README.md
+++ b/src/Dataverse/ScriptLibrary/README.md
@@ -1,6 +1,6 @@
 # TALXIS.DevKit.Build.Dataverse.ScriptLibrary
 
-MSBuild integration for Dataverse web resource (JavaScript/TypeScript) projects. Automatically runs `npm install` and `npm run build` when a TypeScript project is detected, copies the compiled JS output to the build output directory, and exposes metadata targets that allow Solution projects to discover and integrate script libraries as web resources.
+MSBuild integration for Dataverse web resource (JavaScript/TypeScript) projects. Automatically restores Node dependencies (auto-detected package manager - npm, pnpm, Yarn, Bun, or Rush; see [NodeDependencies.md](../../../docs/NodeDependencies.md)) and runs `npm run build` when a TypeScript project is detected, copies the compiled JS output to the build output directory, and exposes metadata targets that allow Solution projects to discover and integrate script libraries as web resources.
 
 ## Installation
 
@@ -33,8 +33,8 @@ The package sets `ProjectType` to `ScriptLibrary` and disables `GenerateAssembly
 
 ### Build-time targets
 
-1. **CheckScriptLibraryPrereqs** -- validates that `TypeScriptDir` exists, `package.json` is present, and `node`/`npm` are on `PATH`.
-2. **BuildTypeScript** (runs before `Build`) -- executes `npm install` followed by `npm run build` in `TypeScriptDir`.
+1. **CheckScriptLibraryPrereqs** -- validates that `TypeScriptDir` exists, `package.json` is present, and `node` is on `PATH` (package manager presence is checked by `NodeRestore` itself, since it depends on what's detected).
+2. **BuildTypeScript** (runs before `Build`) -- calls the shared `NodeRestore` target (auto-detected package manager) followed by `npm run build` in `TypeScriptDir`.
 3. **CopyScriptLibraryMainToOutput** (runs after `Build`) -- copies the main JS file from `TypeScriptDir\build\` to the output directory.
 
 ### Integration targets
@@ -72,7 +72,7 @@ CompileOnly removes the referenced project from the Solution's standalone-deploy
 | Property | Default | Description |
 |----------|---------|-------------|
 | `ProjectType` | `ScriptLibrary` | Marks the project for reference discovery by Solution projects. |
-| `RunNodeBuild` | Auto-detected | Set to `true` to run `npm install` and `npm run build`. Defaults to `true` if `package.json` exists in `TypeScriptDir`. |
+| `RunNodeBuild` | Auto-detected | Set to `true` to restore Node dependencies (via `NodeRestore`) and run `npm run build`. Defaults to `true` if `package.json` exists in `TypeScriptDir`. |
 | `TypeScriptDir` | `$(MSBuildProjectDirectory)\TS` | Folder containing the TypeScript project (`package.json`, sources). |
 | `ScriptLibraryMainFile` | _(none)_ | Main script file path used by consuming targets. |
 | `<ProjectReference>` metadata `ScriptLibraryMode` | `Separate` | Controls the relationship to another referenced ScriptLibrary project: `Separate` or `CompileOnly`. See [Cross-ScriptLibrary references](#cross-scriptlibrary-references). |

--- a/src/Dataverse/ScriptLibrary/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.targets
+++ b/src/Dataverse/ScriptLibrary/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.targets
@@ -18,55 +18,32 @@
        BeforeTargets="Build"/inlined into BuildTypeScript below) so it also fires during a bare
        "dotnet restore" at the repo/solution root, not just when this project's own Build target
        actually runs - CollectPackageReferences is the only per-project target NuGet's
-       solution-level restore reliably invokes for every project (empirically verified, see
-       NodeRestore.targets), which is what makes "dotnet restore" at the repo root hydrate Node
-       deps too, the same way it already hydrates NuGet ones. -->
+       solution-level restore reliably invokes for every project, which is what makes "dotnet
+       restore" at the repo root hydrate Node deps too, the same way it already hydrates NuGet
+       ones. -->
   <Target Name="_ScriptLibraryNodeRestore" AfterTargets="CollectPackageReferences" Condition="'$(RunNodeBuild)'=='true'">
     <CallTarget Targets="NodeRestore" />
   </Target>
 
+  <!-- Supplies this project's arguments to the shared NodeBuild targets via DependsOnTargets, not
+       CallTarget - properties set in a target reached through CallTarget are not visible inside
+       the called target, only ones reached through the DependsOnTargets chain are. -->
+  <Target Name="_ScriptLibrarySetNodeBuildArgs">
+    <PropertyGroup>
+      <_NodeBuildProjectDirectory>$(TypeScriptDir)</_NodeBuildProjectDirectory>
+      <_NodeBuildExtraArgs></_NodeBuildExtraArgs>
+      <_NodeBuildRequiredRushParams></_NodeBuildRequiredRushParams>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="BuildTypeScript"
-    DependsOnTargets="CheckScriptLibraryPrereqs;_NodeRestoreResolve"
+    DependsOnTargets="CheckScriptLibraryPrereqs;_NodeRestoreResolve;_ScriptLibrarySetNodeBuildArgs;_NodeRestoreDelegateBuildToRush;_NodeRestoreBuildDirect"
     BeforeTargets="Build"
     Condition="'$(RunNodeBuild)'=='true'">
     <Message Text="Building TypeScript in $(TypeScriptDir)" Importance="High" />
-
-    <!-- When Rush is resolved for this project (and it is registered in rush.json - folded into
-         _NodeRestoreResolvedTool by _NodeRestoreResolve's own proactive registration check, see
-         NodeRestore.targets), delegate the build itself to Rush too, not just dependency
-         hydration, so Rush's own content-hash incremental skip + build cache actually apply
-         (Finding #7) - a direct "npm run build" every time has zero incrementality of its own.
-         Scoped vs unscoped chosen by $(SolutionPath), identical reasoning to Pcf's PcfBuild
-         override (see TALXIS.DevKit.Build.Dataverse.Pcf.targets): a standalone build stays fast
-         (only this project's own Rush-graph subset), a solution-scope build avoids serializing N
-         projects behind Rush's one exclusive whole-repo lock. -->
-    <PropertyGroup Condition="'$(_NodeRestoreResolvedTool)' == 'rush'">
-      <_ScriptLibraryIsSolutionScope Condition="'$(SolutionPath)' != '' and '$(SolutionPath)' != '*Undefined*'">true</_ScriptLibraryIsSolutionScope>
-      <_ScriptLibraryRushBuildCommand Condition="'$(_ScriptLibraryIsSolutionScope)' != 'true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" build --to .</_ScriptLibraryRushBuildCommand>
-      <_ScriptLibraryRushBuildCommand Condition="'$(_ScriptLibraryIsSolutionScope)' == 'true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" build</_ScriptLibraryRushBuildCommand>
-      <_NodeRestoreRetryCommand>$(_ScriptLibraryRushBuildCommand)</_NodeRestoreRetryCommand>
-      <_NodeRestoreRetryWorkingDirectory>$(TypeScriptDir)</_NodeRestoreRetryWorkingDirectory>
-    </PropertyGroup>
-    <!-- MSBuild self-invocation, not CallTarget: this same shared target already ran once during
-         this project's restore-hydration phase (_NodeRestoreRunRush, in NodeRestore.targets)
-         earlier in this same "dotnet build" - MSBuild only executes a given target name once per
-         project build regardless of CallTarget call count, so a second CallTarget here would
-         silently no-op instead of running the build command. Invoking via the MSBuild task with
-         an explicit Properties list forces a fresh, distinct execution. -->
-    <MSBuild Projects="$(MSBuildProjectFullPath)"
-             Targets="_NodeRestoreExecWithRetry"
-             Properties="_NodeRestoreRetryCommand=$(_NodeRestoreRetryCommand);_NodeRestoreRetryWorkingDirectory=$(_NodeRestoreRetryWorkingDirectory)"
-             Condition="'$(_NodeRestoreResolvedTool)' == 'rush'" />
-
-    <!-- Non-Rush tools (pnpm/yarn/npm/bun/no orchestrator): unchanged direct invocation - none of
-         those ship an equivalent workspace-wide build cache to delegate to in scope here;
-         over-solving for them repeats the over-engineering already rejected earlier in this
-         design. -->
-    <Exec WorkingDirectory="$(TypeScriptDir)" Command="npm run build" Condition="'$(_NodeRestoreResolvedTool)' != 'rush'" />
   </Target>
 
-  <!-- Removes this project's own JS build-output folder on "dotnet clean" (Finding #4 - a real
-       gap before this: dotnet clean left stale JS bundles behind silently). Plain RemoveDir, no
+  <!-- Removes this project's own JS build-output folder on "dotnet clean". Plain RemoveDir, no
        process invocation - Clean needs no Node toolchain present at all here. Deliberately never
        touches node_modules or any shared Rush/pnpm workspace state: npm-land treats "clean" and
        "prune deps" as different operations, and node_modules removal is a far more expensive,

--- a/src/Dataverse/ScriptLibrary/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.targets
+++ b/src/Dataverse/ScriptLibrary/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.targets
@@ -40,7 +40,7 @@
     DependsOnTargets="CheckScriptLibraryPrereqs;_NodeRestoreResolve;_ScriptLibrarySetNodeBuildArgs;_NodeRestoreDelegateBuildToRush;_NodeRestoreBuildDirect"
     BeforeTargets="Build"
     Condition="'$(RunNodeBuild)'=='true'">
-    <Message Text="Building TypeScript in $(TypeScriptDir)" Importance="High" />
+    <Message Text="Node build for ScriptLibrary in $(TypeScriptDir) completed (or was already up to date)." Importance="High" />
   </Target>
 
   <!-- Removes this project's own JS build-output folder on "dotnet clean". Plain RemoveDir, no

--- a/src/Dataverse/ScriptLibrary/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.targets
+++ b/src/Dataverse/ScriptLibrary/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.targets
@@ -13,7 +13,10 @@
     BeforeTargets="Build"
     Condition="'$(RunNodeBuild)'=='true'">
     <Message Text="Building TypeScript in $(TypeScriptDir)" Importance="High" />
-    <Exec WorkingDirectory="$(TypeScriptDir)" Command="npm install" />
+    <PropertyGroup>
+      <NodeRestoreProjectDirectory>$(TypeScriptDir)</NodeRestoreProjectDirectory>
+    </PropertyGroup>
+    <CallTarget Targets="NodeRestore" />
     <Exec WorkingDirectory="$(TypeScriptDir)" Command="npm run build" />
   </Target>
   
@@ -21,10 +24,12 @@
     Condition="'$(RunNodeBuild)'=='true'">
     <Error Condition="!Exists('$(TypeScriptDir)')" Text="ScriptLibrary TS directory not found: $(TypeScriptDir)" />
     <Error Condition="!Exists('$(TypeScriptDir)/package.json')" Text="ScriptLibrary package.json not found in $(TypeScriptDir)" />
+    <!-- Only Node.js itself is a hard prerequisite here - which package manager binary is
+         actually required depends on what NodeRestore below detects (npm/pnpm/yarn/bun/rush),
+         so that check is left to NodeRestore's own Exec failing clearly if the resolved tool
+         isn't on PATH, rather than hardcoding a single tool's presence here. -->
     <Exec Command="where node" IgnoreExitCode="true" />
     <Error Condition="'$(MSBuildLastTaskResult)'!='True'" Text="Node.js not found in PATH. Install Node.js to build ScriptLibrary." />
-    <Exec Command="where npm" IgnoreExitCode="true" />
-    <Error Condition="'$(MSBuildLastTaskResult)'!='True'" Text="npm not found in PATH. Install Node.js (includes npm) to build ScriptLibrary." />
   </Target>
 
   <ItemGroup>

--- a/src/Dataverse/ScriptLibrary/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.targets
+++ b/src/Dataverse/ScriptLibrary/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.targets
@@ -6,18 +6,73 @@
 
     <RunNodeBuild Condition="'$(RunNodeBuild)'=='' and Exists('$(TypeScriptDir)/package.json')">true</RunNodeBuild>
     <RunNodeBuild Condition="'$(RunNodeBuild)'==''">false</RunNodeBuild>
+
+    <!-- ScriptLibrary's Node project lives under $(TypeScriptDir), not $(MSBuildProjectDirectory)
+         (NodeRestore's own default) - set once, at project-evaluation time, so every target below
+         (the restore hook, the build step, and _NodeRestoreResolve's own DependsOnTargets chain)
+         all resolve against the same directory without each needing to repeat this override. -->
+    <NodeRestoreProjectDirectory Condition="'$(RunNodeBuild)'=='true' and '$(NodeRestoreProjectDirectory)'==''">$(TypeScriptDir)</NodeRestoreProjectDirectory>
   </PropertyGroup>
 
+  <!-- Node dependency hydration, anchored to AfterTargets="CollectPackageReferences" (not
+       BeforeTargets="Build"/inlined into BuildTypeScript below) so it also fires during a bare
+       "dotnet restore" at the repo/solution root, not just when this project's own Build target
+       actually runs - CollectPackageReferences is the only per-project target NuGet's
+       solution-level restore reliably invokes for every project (empirically verified, see
+       NodeRestore.targets), which is what makes "dotnet restore" at the repo root hydrate Node
+       deps too, the same way it already hydrates NuGet ones. -->
+  <Target Name="_ScriptLibraryNodeRestore" AfterTargets="CollectPackageReferences" Condition="'$(RunNodeBuild)'=='true'">
+    <CallTarget Targets="NodeRestore" />
+  </Target>
+
   <Target Name="BuildTypeScript"
-    DependsOnTargets="CheckScriptLibraryPrereqs"
+    DependsOnTargets="CheckScriptLibraryPrereqs;_NodeRestoreResolve"
     BeforeTargets="Build"
     Condition="'$(RunNodeBuild)'=='true'">
     <Message Text="Building TypeScript in $(TypeScriptDir)" Importance="High" />
-    <PropertyGroup>
-      <NodeRestoreProjectDirectory>$(TypeScriptDir)</NodeRestoreProjectDirectory>
+
+    <!-- When Rush is resolved for this project (and it is registered in rush.json - folded into
+         _NodeRestoreResolvedTool by _NodeRestoreResolve's own proactive registration check, see
+         NodeRestore.targets), delegate the build itself to Rush too, not just dependency
+         hydration, so Rush's own content-hash incremental skip + build cache actually apply
+         (Finding #7) - a direct "npm run build" every time has zero incrementality of its own.
+         Scoped vs unscoped chosen by $(SolutionPath), identical reasoning to Pcf's PcfBuild
+         override (see TALXIS.DevKit.Build.Dataverse.Pcf.targets): a standalone build stays fast
+         (only this project's own Rush-graph subset), a solution-scope build avoids serializing N
+         projects behind Rush's one exclusive whole-repo lock. -->
+    <PropertyGroup Condition="'$(_NodeRestoreResolvedTool)' == 'rush'">
+      <_ScriptLibraryIsSolutionScope Condition="'$(SolutionPath)' != '' and '$(SolutionPath)' != '*Undefined*'">true</_ScriptLibraryIsSolutionScope>
+      <_ScriptLibraryRushBuildCommand Condition="'$(_ScriptLibraryIsSolutionScope)' != 'true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" build --to .</_ScriptLibraryRushBuildCommand>
+      <_ScriptLibraryRushBuildCommand Condition="'$(_ScriptLibraryIsSolutionScope)' == 'true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" build</_ScriptLibraryRushBuildCommand>
+      <_NodeRestoreRetryCommand>$(_ScriptLibraryRushBuildCommand)</_NodeRestoreRetryCommand>
+      <_NodeRestoreRetryWorkingDirectory>$(TypeScriptDir)</_NodeRestoreRetryWorkingDirectory>
     </PropertyGroup>
-    <CallTarget Targets="NodeRestore" />
-    <Exec WorkingDirectory="$(TypeScriptDir)" Command="npm run build" />
+    <!-- MSBuild self-invocation, not CallTarget: this same shared target already ran once during
+         this project's restore-hydration phase (_NodeRestoreRunRush, in NodeRestore.targets)
+         earlier in this same "dotnet build" - MSBuild only executes a given target name once per
+         project build regardless of CallTarget call count, so a second CallTarget here would
+         silently no-op instead of running the build command. Invoking via the MSBuild task with
+         an explicit Properties list forces a fresh, distinct execution. -->
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="_NodeRestoreExecWithRetry"
+             Properties="_NodeRestoreRetryCommand=$(_NodeRestoreRetryCommand);_NodeRestoreRetryWorkingDirectory=$(_NodeRestoreRetryWorkingDirectory)"
+             Condition="'$(_NodeRestoreResolvedTool)' == 'rush'" />
+
+    <!-- Non-Rush tools (pnpm/yarn/npm/bun/no orchestrator): unchanged direct invocation - none of
+         those ship an equivalent workspace-wide build cache to delegate to in scope here;
+         over-solving for them repeats the over-engineering already rejected earlier in this
+         design. -->
+    <Exec WorkingDirectory="$(TypeScriptDir)" Command="npm run build" Condition="'$(_NodeRestoreResolvedTool)' != 'rush'" />
+  </Target>
+
+  <!-- Removes this project's own JS build-output folder on "dotnet clean" (Finding #4 - a real
+       gap before this: dotnet clean left stale JS bundles behind silently). Plain RemoveDir, no
+       process invocation - Clean needs no Node toolchain present at all here. Deliberately never
+       touches node_modules or any shared Rush/pnpm workspace state: npm-land treats "clean" and
+       "prune deps" as different operations, and node_modules removal is a far more expensive,
+       disruptive step that must not be a silent side effect of every "dotnet clean". -->
+  <Target Name="CleanScriptLibrary" AfterTargets="Clean" Condition="'$(RunNodeBuild)'=='true'">
+    <RemoveDir Directories="$(TypeScriptDir)/build" Condition="Exists('$(TypeScriptDir)/build')" />
   </Target>
   
   <Target Name="CheckScriptLibraryPrereqs"

--- a/src/Dataverse/Tasks/Tasks/ExecWithRetry.cs
+++ b/src/Dataverse/Tasks/Tasks/ExecWithRetry.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 using System.Threading;
 using Microsoft.Build.Framework;
@@ -109,6 +110,11 @@ public class ExecWithRetry : Task, ICancelableTask
                 WaitForRetryDelay(delay);
             }
         }
+        catch (ArgumentException ex)
+        {
+            Log.LogError(ex.Message);
+            return false;
+        }
         catch (OperationCanceledException)
         {
             return false;
@@ -126,7 +132,13 @@ public class ExecWithRetry : Task, ICancelableTask
         var delays = new int[parts.Length];
         for (var i = 0; i < parts.Length; i++)
         {
-            delays[i] = int.Parse(parts[i].Trim());
+            var part = parts[i].Trim();
+            if (!int.TryParse(part, NumberStyles.None, CultureInfo.InvariantCulture, out var delay) || delay < 0)
+            {
+                throw new ArgumentException($"Invalid DelaysMilliseconds value '{raw}'. Expected a semicolon-separated list of non-negative integer millisecond values, for example '1000;2000;4000'.");
+            }
+
+            delays[i] = delay;
         }
         return delays;
     }

--- a/src/Dataverse/Tasks/Tasks/ExecWithRetry.cs
+++ b/src/Dataverse/Tasks/Tasks/ExecWithRetry.cs
@@ -1,0 +1,281 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+/// <summary>
+/// Runs a shell command, retrying with backoff whenever the process's combined stdout/stderr
+/// contains a specific message and the process fails. Any other failure propagates immediately,
+/// with its full output surfaced at high importance so it remains visible at default MSBuild
+/// verbosity.
+/// </summary>
+public class ExecWithRetry : Task, ICancelableTask
+{
+    private static readonly int[] DefaultDelaysMilliseconds = { 1000, 2000, 4000, 8000, 16000 };
+    private const int DefaultMaxAttempts = 45;
+    private const int DefaultFallbackDelayMilliseconds = 30000;
+
+    private readonly CancellationTokenSource cancellationSource = new();
+    private readonly object processLock = new();
+    private Process currentProcess;
+
+    [Required]
+    public string Command { get; set; } = string.Empty;
+
+    public string WorkingDirectory { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Additional environment variables for the spawned process, one "NAME=value" entry per
+    /// item - matching MSBuild's own Exec.EnvironmentVariables convention.
+    /// </summary>
+    public string[] EnvironmentVariables { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Substring to look for in the process's combined stdout+stderr. When a failed attempt's
+    /// output contains this message, the command is retried with backoff. When empty, the
+    /// command runs once and any failure is propagated immediately.
+    /// </summary>
+    public string LockMessage { get; set; } = string.Empty;
+
+    public int MaxAttempts { get; set; } = DefaultMaxAttempts;
+
+    /// <summary>
+    /// Semicolon-separated backoff delays in milliseconds for the first attempts. Any attempt
+    /// beyond the list uses <see cref="FallbackDelayMilliseconds"/>.
+    /// </summary>
+    public string DelaysMilliseconds { get; set; } = string.Empty;
+
+    public int FallbackDelayMilliseconds { get; set; } = DefaultFallbackDelayMilliseconds;
+
+    /// <summary>
+    /// Signals cancellation to the running command and interrupts any backoff delay immediately.
+    /// </summary>
+    public void Cancel()
+    {
+        Process processToTerminate;
+        lock (processLock)
+        {
+            if (cancellationSource.IsCancellationRequested)
+            {
+                return;
+            }
+
+            cancellationSource.Cancel();
+            processToTerminate = currentProcess;
+        }
+
+        TryTerminateProcess(processToTerminate);
+    }
+
+    public override bool Execute()
+    {
+        try
+        {
+            var delays = ParseDelays(DelaysMilliseconds);
+            var attempt = 0;
+
+            while (true)
+            {
+                cancellationSource.Token.ThrowIfCancellationRequested();
+                attempt++;
+                var result = RunOnce(Command, WorkingDirectory, EnvironmentVariables);
+
+                if (result.ExitCode == 0)
+                {
+                    return true;
+                }
+
+                var isRetryableConflict = !string.IsNullOrEmpty(LockMessage) && result.Output.Contains(LockMessage);
+
+                if (!isRetryableConflict)
+                {
+                    Log.LogMessage(MessageImportance.High, result.Output);
+                    Log.LogError($"Command failed with exit code {result.ExitCode}: {Command}");
+                    return false;
+                }
+
+                if (attempt >= MaxAttempts)
+                {
+                    Log.LogMessage(MessageImportance.High, result.Output);
+                    Log.LogError($"Command is still locked by another process after {attempt} attempts, giving up: {Command}");
+                    return false;
+                }
+
+                var delay = attempt - 1 < delays.Length ? delays[attempt - 1] : FallbackDelayMilliseconds;
+                Log.LogMessage(MessageImportance.Normal, $"Waiting for another process to finish, retrying ({attempt}/{MaxAttempts}) in {delay / 1000}s...");
+                WaitForRetryDelay(delay);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+    }
+
+    private static int[] ParseDelays(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return DefaultDelaysMilliseconds;
+        }
+
+        var parts = raw.Split(';');
+        var delays = new int[parts.Length];
+        for (var i = 0; i < parts.Length; i++)
+        {
+            delays[i] = int.Parse(parts[i].Trim());
+        }
+        return delays;
+    }
+
+    private (int ExitCode, string Output) RunOnce(string command, string workingDirectory, string[] environmentVariables)
+    {
+        var startInfo = CreateShellStartInfo(command, workingDirectory, environmentVariables);
+        var buffer = new StringBuilder();
+        var bufferLock = new object();
+
+        using var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data == null)
+            {
+                return;
+            }
+            Log.LogMessage(MessageImportance.Low, e.Data);
+            lock (bufferLock)
+            {
+                buffer.AppendLine(e.Data);
+            }
+        };
+
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data == null)
+            {
+                return;
+            }
+            Log.LogMessage(MessageImportance.Low, e.Data);
+            lock (bufferLock)
+            {
+                buffer.AppendLine(e.Data);
+            }
+        };
+
+        try
+        {
+            lock (processLock)
+            {
+                cancellationSource.Token.ThrowIfCancellationRequested();
+                process.Start();
+                currentProcess = process;
+            }
+
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            WaitForExit(process);
+            process.WaitForExit();
+
+            lock (bufferLock)
+            {
+                return (process.ExitCode, buffer.ToString());
+            }
+        }
+        catch
+        {
+            TryTerminateProcess(process);
+            throw;
+        }
+        finally
+        {
+            lock (processLock)
+            {
+                if (ReferenceEquals(currentProcess, process))
+                {
+                    currentProcess = null;
+                }
+            }
+        }
+    }
+
+    private void WaitForRetryDelay(int delayMilliseconds)
+    {
+        if (delayMilliseconds <= 0)
+        {
+            cancellationSource.Token.ThrowIfCancellationRequested();
+            return;
+        }
+
+        cancellationSource.Token.WaitHandle.WaitOne(delayMilliseconds);
+        cancellationSource.Token.ThrowIfCancellationRequested();
+    }
+
+    private void WaitForExit(Process process)
+    {
+        while (!process.WaitForExit(250))
+        {
+            cancellationSource.Token.ThrowIfCancellationRequested();
+        }
+    }
+
+    private static void TryTerminateProcess(Process process)
+    {
+        if (process == null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (process.HasExited)
+            {
+                return;
+            }
+
+            process.Kill(entireProcessTree: true);
+        }
+        catch (InvalidOperationException)
+        {
+        }
+        catch (Win32Exception)
+        {
+        }
+    }
+
+    private static ProcessStartInfo CreateShellStartInfo(string command, string workingDirectory, string[] environmentVariables)
+    {
+        var startInfo = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo
+            {
+                FileName = "cmd.exe",
+                ArgumentList = { "/d", "/s", "/c", command }
+            }
+            : new ProcessStartInfo
+            {
+                FileName = "/bin/sh",
+                ArgumentList = { "-c", command }
+            };
+
+        startInfo.WorkingDirectory = string.IsNullOrWhiteSpace(workingDirectory) ? Environment.CurrentDirectory : workingDirectory;
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+        startInfo.UseShellExecute = false;
+        startInfo.CreateNoWindow = true;
+
+        foreach (var entry in environmentVariables ?? Array.Empty<string>())
+        {
+            var separatorIndex = entry.IndexOf('=');
+            if (separatorIndex <= 0)
+            {
+                continue;
+            }
+
+            startInfo.EnvironmentVariables[entry.Substring(0, separatorIndex)] = entry.Substring(separatorIndex + 1);
+        }
+
+        return startInfo;
+    }
+}

--- a/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.targets
@@ -44,4 +44,5 @@
     <UsingTask TaskName="GenerateGenPageProjectXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
     <UsingTask TaskName="GenerateGenPageFileXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
     <UsingTask TaskName="ExtractPdPackageDataFolderName" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ExecWithRetry" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
 </Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild.targets
@@ -29,7 +29,7 @@
 
     Implementation is split across NodeBuild\*.targets by concern:
       Direct.targets          The "no orchestrator" build branch: runs the project's own build
-                              script directly (npm run build).
+                              script through the resolved plain package manager.
       RushDelegation.targets  The shared Rush build-delegation branch: solution-vs-project scope
                               detection, Rush command construction, extra-argument declaration
                               check, retry wiring. One instance of this used by every project

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild.targets
@@ -1,0 +1,54 @@
+<Project>
+  <!--
+    NodeBuild: the generic "build the JS/TS side of this project" concept, shared by every
+    project type that has one (Pcf, ScriptLibrary, CodeApp today). Depends on NodeRestore having
+    already resolved which package manager/orchestrator governs the project
+    (_NodeRestoreResolvedTool, _NodeRestoreWorkspaceRoot) - project-type targets already
+    DependsOnTargets="_NodeRestoreResolve" before reaching this file.
+
+    Properties:
+      NodeBuildConfiguration  'production' | 'development'. Defaults from $(Configuration):
+                              Release -> production, anything else -> development. Explicitly
+                              overridable per-project the same way NodePackageManager is. This is
+                              the one signal every project type maps to consistently, mirroring the
+                              exact Debug/Release convention Microsoft's own
+                              Microsoft.PowerApps.MSBuild.Pcf.props already established for PCF's
+                              $(PcfBuildMode) - a developer runs "dotnet build" for an unminified,
+                              source-mapped build or "dotnet build -c Release" for a
+                              minified production build, the same way, for every project type.
+                              Reaches the underlying build tool two ways, both always applied:
+                                - NODE_ENV=<value> environment variable on the build invocation.
+                                - a mode CLI argument appended with the same value (or a Rush custom
+                                  command-line parameter when Rush build-delegation is in play).
+      _NodeBuildModeArgName   The long-form flag name (without a leading dash pair) the mode value is
+                              passed as, e.g. "mode" -> a "mode" flag of "production". Defaults to "mode";
+                              a project type whose own build tool expects a different spelling
+                              (e.g. PCF's pcf-scripts, which reads a "build-mode" flag) overrides this
+                              rather than forwarding a second, tool-specific flag alongside the
+                              generic one.
+
+    Implementation is split across NodeBuild\*.targets by concern:
+      Direct.targets          The "no orchestrator" build branch: runs the project's own build
+                              script directly (npm run build).
+      RushDelegation.targets  The shared Rush build-delegation branch: solution-vs-project scope
+                              detection, Rush command construction, extra-argument declaration
+                              check, retry wiring. One instance of this used by every project
+                              type instead of each re-implementing it.
+
+    Project-type targets (Pcf/ScriptLibrary/CodeApp) call _NodeRestoreBuildDirect or
+    _NodeRestoreDelegateBuildToRush from their own build-override target, after setting
+    _NodeBuildProjectDirectory and _NodeBuildExtraArgs (and, for Rush delegation,
+    _NodeBuildRequiredRushParams). Adding a new monorepo orchestrator that supports build
+    delegation only requires a new NodeBuild\<Name>Delegation.targets file with its own
+    _NodeRestoreDelegateBuildTo<Name> target - no changes needed to the files above.
+  -->
+
+  <PropertyGroup>
+    <NodeBuildConfiguration Condition="'$(NodeBuildConfiguration)'=='' and '$(Configuration)'=='Release'">production</NodeBuildConfiguration>
+    <NodeBuildConfiguration Condition="'$(NodeBuildConfiguration)'==''">development</NodeBuildConfiguration>
+    <_NodeBuildModeArgName Condition="'$(_NodeBuildModeArgName)'==''">mode</_NodeBuildModeArgName>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)NodeBuild\*.targets" />
+
+</Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild/Direct.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild/Direct.targets
@@ -1,8 +1,6 @@
 <Project>
   <!-- The "no orchestrator" build branch: runs the project's own package.json "build" script
-       directly. Used by ScriptLibrary/CodeApp whenever Rush isn't resolved for the project; PCF
-       keeps Microsoft's own untouched pcf-scripts direct path instead of this target, since it
-       already ships its own build invocation. -->
+       directly. Used by Pcf/ScriptLibrary/CodeApp whenever Rush isn't resolved for the project. -->
   <Target Name="_NodeRestoreBuildDirect"
           Condition="'$(_NodeRestoreResolvedTool)' != 'rush'">
     <Exec WorkingDirectory="$(_NodeBuildProjectDirectory)"

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild/Direct.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild/Direct.targets
@@ -1,10 +1,17 @@
 <Project>
   <!-- The "no orchestrator" build branch: runs the project's own package.json "build" script
-       directly. Used by Pcf/ScriptLibrary/CodeApp whenever Rush isn't resolved for the project. -->
+       through whichever plain package manager NodeRestore resolved for the workspace. Used by
+       Pcf/ScriptLibrary/CodeApp whenever Rush isn't resolved for the project. -->
   <Target Name="_NodeRestoreBuildDirect"
           Condition="'$(_NodeRestoreResolvedTool)' != 'rush'">
+    <PropertyGroup>
+      <_NodeBuildDirectCommand Condition="'$(_NodeRestoreResolvedTool)'=='pnpm'">pnpm run build --</_NodeBuildDirectCommand>
+      <_NodeBuildDirectCommand Condition="'$(_NodeRestoreResolvedTool)'=='yarn'">yarn run build</_NodeBuildDirectCommand>
+      <_NodeBuildDirectCommand Condition="'$(_NodeRestoreResolvedTool)'=='bun'">bun run build</_NodeBuildDirectCommand>
+      <_NodeBuildDirectCommand Condition="'$(_NodeBuildDirectCommand)'==''">npm run build --</_NodeBuildDirectCommand>
+    </PropertyGroup>
     <Exec WorkingDirectory="$(_NodeBuildProjectDirectory)"
-          Command="npm run build -- --$(_NodeBuildModeArgName) $(NodeBuildConfiguration) $(_NodeBuildExtraArgs)"
+          Command="$(_NodeBuildDirectCommand) --$(_NodeBuildModeArgName) $(NodeBuildConfiguration) $(_NodeBuildExtraArgs)"
           EnvironmentVariables="NODE_ENV=$(NodeBuildConfiguration)" />
   </Target>
 </Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild/Direct.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild/Direct.targets
@@ -1,0 +1,12 @@
+<Project>
+  <!-- The "no orchestrator" build branch: runs the project's own package.json "build" script
+       directly. Used by ScriptLibrary/CodeApp whenever Rush isn't resolved for the project; PCF
+       keeps Microsoft's own untouched pcf-scripts direct path instead of this target, since it
+       already ships its own build invocation. -->
+  <Target Name="_NodeRestoreBuildDirect"
+          Condition="'$(_NodeRestoreResolvedTool)' != 'rush'">
+    <Exec WorkingDirectory="$(_NodeBuildProjectDirectory)"
+          Command="npm run build -- --$(_NodeBuildModeArgName) $(NodeBuildConfiguration) $(_NodeBuildExtraArgs)"
+          EnvironmentVariables="NODE_ENV=$(NodeBuildConfiguration)" />
+  </Target>
+</Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild/RushDelegation.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild/RushDelegation.targets
@@ -1,0 +1,93 @@
+<Project>
+  <!-- Shared Rush build-delegation branch, used by every project type once Rush is resolved and
+       the project is registered in rush.json. Delegating the actual build to Rush (rather than
+       invoking the build tool directly) lets Rush's own content-hash incremental skip and build
+       cache apply - a direct "npm run build" every time has no incrementality of its own.
+
+       Callers set, before depending on this target:
+         _NodeBuildProjectDirectory     This project's own directory (used for the scoped rush build,
+                                         Rush invocation and as the working directory).
+         _NodeBuildModeArgName          (see NodeBuild.targets) the mode flag's long-form name,
+                                         without a leading dash pair. Defaults to "mode".
+         _NodeBuildExtraArgs            Extra CLI args this project type needs forwarded to its
+                                         own build script beyond the mode flag. Empty string if
+                                         none.
+         _NodeBuildRequiredRushParams   Semicolon-separated Rush custom-parameter longNames
+                                         (beyond the mode flag, which is always required) that must be
+                                         declared in command-line.json for _NodeBuildExtraArgs to
+                                         actually reach the build script. Empty string if none.
+
+       NodeBuildConfiguration (see NodeBuild.targets) always reaches the build both as
+       NODE_ENV=<value> and as a $(_NodeBuildModeArgName) flag on the Rush custom
+       command-line parameter list, so a Rush-registered project must declare that flag in
+       command-line.json the same way it declares any other custom parameter. -->
+  <Target Name="_NodeRestoreDelegateBuildToRush"
+          Condition="'$(_NodeRestoreResolvedTool)' == 'rush'">
+
+    <!-- Once a project is Rush-registered, it has unambiguously opted into Rush build
+         delegation, so a command-line.json missing a required custom parameter is a genuine,
+         fixable Rush configuration gap - not a legitimate "not opted in yet" state (contrast with
+         the rush.json registration check in NodeRestore/Rush.targets, which does fall back
+         gracefully). This fails the build immediately rather than silently falling back to an
+         un-cached, un-delegated direct build the consumer might never notice. -->
+    <PropertyGroup>
+      <_NodeBuildCommandLineJsonPath>$(_NodeRestoreWorkspaceRoot)/common/config/rush/command-line.json</_NodeBuildCommandLineJsonPath>
+      <_NodeBuildCommandLineJsonText Condition="Exists('$(_NodeBuildCommandLineJsonPath)')">$([System.IO.File]::ReadAllText('$(_NodeBuildCommandLineJsonPath)'))</_NodeBuildCommandLineJsonText>
+      <_NodeBuildAllRequiredRushParams Condition="'$(_NodeBuildRequiredRushParams)' == ''">--$(_NodeBuildModeArgName)</_NodeBuildAllRequiredRushParams>
+      <_NodeBuildAllRequiredRushParams Condition="'$(_NodeBuildAllRequiredRushParams)' == ''">--$(_NodeBuildModeArgName);$(_NodeBuildRequiredRushParams)</_NodeBuildAllRequiredRushParams>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_NodeBuildRequiredRushParam Remove="@(_NodeBuildRequiredRushParam)" />
+      <_NodeBuildRequiredRushParam Include="$(_NodeBuildAllRequiredRushParams)" />
+      <_NodeBuildRequiredRushParam>
+        <IsDeclared Condition="'$(_NodeBuildCommandLineJsonText)' != '' and $(_NodeBuildCommandLineJsonText.Contains('&quot;%(Identity)&quot;'))">true</IsDeclared>
+      </_NodeBuildRequiredRushParam>
+      <_NodeBuildMissingRushParam Remove="@(_NodeBuildMissingRushParam)" />
+      <_NodeBuildMissingRushParam Include="@(_NodeBuildRequiredRushParam)" Condition="'%(_NodeBuildRequiredRushParam.IsDeclared)' != 'true'" />
+    </ItemGroup>
+
+    <Error Condition="'@(_NodeBuildMissingRushParam)' != ''"
+           Text="NodeBuild: this project is registered with Rush, but '$(_NodeBuildCommandLineJsonPath)' does not declare the following custom command-line parameter(s) this SDK needs to delegate its build through Rush: @(_NodeBuildMissingRushParam). Add each one to the 'parameters' array in that file, with associatedCommands including 'build' and 'rebuild' - see docs/NodeDependencies.md for the exact snippet format." />
+
+    <!-- Scoped vs unscoped Rush command, chosen by MSBuild's own solution-vs-project signal:
+         $(SolutionPath) resolves to "*Undefined*"/empty for a standalone "dotnet build a.csproj",
+         and to the real .sln/.slnx path for a solution-scope build.
+           - No solution context: a scoped, project-targeted rush build builds only this project plus its
+             transitive Rush-graph upstream dependencies, keeping a single-project build fast on
+             a large Rush repo.
+           - Solution context: an unscoped "rush build" builds the entire registered graph via
+             Rush's own internal parallelism; whichever project's target reaches this branch
+             first does the real work, every other project's own call hits Rush's incremental
+             skip and returns as a fast no-op. This avoids serializing N real Node builds behind
+             Rush's one exclusive whole-repo lock, which a per-project-scoped call would
+             otherwise do - "rush build" acquires the same whole-repo lock as "rush
+             update"/"install". -->
+    <PropertyGroup>
+      <_NodeBuildIsSolutionScope Condition="'$(SolutionPath)' != '' and '$(SolutionPath)' != '*Undefined*'">true</_NodeBuildIsSolutionScope>
+      <_NodeBuildRushCommand Condition="'$(_NodeBuildIsSolutionScope)' != 'true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" build --to .</_NodeBuildRushCommand>
+      <_NodeBuildRushCommand Condition="'$(_NodeBuildIsSolutionScope)' == 'true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" build</_NodeBuildRushCommand>
+
+      <!-- The mode flag is forwarded as a Rush custom command-line parameter, the same mechanism used
+           for every other project-type-specific flag - Rush's own build cache already
+           incorporates command-line parameters into its cache key, so Debug/Release get
+           distinct, correct cache entries with no extra work here. -->
+      <_NodeBuildRushCommand>$(_NodeBuildRushCommand) --$(_NodeBuildModeArgName) $(NodeBuildConfiguration) $(_NodeBuildExtraArgs)</_NodeBuildRushCommand>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <_NodeRestoreRetryCommand>$(_NodeBuildRushCommand)</_NodeRestoreRetryCommand>
+      <_NodeRestoreRetryWorkingDirectory>$(_NodeBuildProjectDirectory)</_NodeRestoreRetryWorkingDirectory>
+      <_NodeRestoreRetryEnvironmentVariables>NODE_ENV=$(NodeBuildConfiguration)</_NodeRestoreRetryEnvironmentVariables>
+    </PropertyGroup>
+    <!-- MSBuild self-invocation, not CallTarget: this same shared target already ran once during
+         this project's restore-hydration phase (_NodeRestoreRunRush, in NodeRestore/Rush.targets)
+         earlier in this same build - MSBuild only executes a given target name once per project
+         build regardless of CallTarget call count, so a second CallTarget here would silently
+         no-op instead of running the build command. Invoking via the MSBuild task with an
+         explicit Properties list forces a fresh, distinct execution. -->
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="_NodeRestoreExecWithRetry"
+             Properties="_NodeRestoreRetryCommand=$(_NodeRestoreRetryCommand);_NodeRestoreRetryWorkingDirectory=$(_NodeRestoreRetryWorkingDirectory);_NodeRestoreRetryEnvironmentVariables=$(_NodeRestoreRetryEnvironmentVariables)" />
+  </Target>
+</Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore.targets
@@ -1,0 +1,214 @@
+<Project>
+  <!--
+    NodeRestore: package-manager-agnostic Node dependency hydration.
+    Closes #88, #90. Implements #93.
+
+    Replaces the previously hardcoded "npm install" in Pcf/ScriptLibrary/CodeApp. Detection is
+    plain MSBuild (GetDirectoryNameOfFileAbove over a small, stable set of marker files) - no
+    bundled Node script, no extra process, no library dependency to track for updates.
+
+    Consumers call this via <CallTarget Targets="NodeRestore" /> from their own anchor target
+    (mirrors how GenerateVersionNumber/ApplyPcfVersionNumber etc. are invoked elsewhere in this
+    repo), after setting NodeRestoreProjectDirectory if the Node project lives somewhere other
+    than $(MSBuildProjectDirectory) (e.g. ScriptLibrary's $(TypeScriptDir)).
+
+    Properties:
+      NodeRestoreProjectDirectory  Directory containing package.json. Default: $(MSBuildProjectDirectory).
+      NodePackageManager           '' (auto, default) | None | npm | pnpm | yarn | bun | rush.
+                                    None = dependencies hydrated externally; do nothing.
+      NodeRestoreCommand           Raw command override. Wins over everything else below.
+  -->
+
+  <PropertyGroup>
+    <NodeRestoreProjectDirectory Condition="'$(NodeRestoreProjectDirectory)'==''">$(MSBuildProjectDirectory)</NodeRestoreProjectDirectory>
+    <NodePackageManager Condition="'$(NodePackageManager)'==''"></NodePackageManager>
+    <NodeRestoreCommand Condition="'$(NodeRestoreCommand)'==''"></NodeRestoreCommand>
+  </PropertyGroup>
+
+  <!--
+    CI detection deliberately mirrors GenerateGitVersion.DetectIsRunningInCI (same property, same
+    env-var list) instead of defining a second notion of "what counts as CI" to keep in sync.
+    IsRunningInCI itself is empty unless a consumer sets it explicitly or GenerateVersionNumber
+    already ran and exported it back as a property - so this file re-detects independently rather
+    than depending on version-numbering having run first.
+  -->
+  <PropertyGroup>
+    <_NodeRestoreIsCI Condition="'$(IsRunningInCI)'!=''">$(IsRunningInCI)</_NodeRestoreIsCI>
+    <_NodeRestoreIsCI Condition="'$(_NodeRestoreIsCI)'=='' and (
+        '$(CI)'=='true' or
+        '$(TF_BUILD)'=='True' or '$(TF_BUILD)'=='true' or
+        '$(GITHUB_ACTIONS)'=='true' or
+        '$(GITLAB_CI)'=='true' or
+        '$(CIRCLECI)'=='true' or
+        '$(JENKINS_URL)'!='' or
+        '$(TEAMCITY_VERSION)'!='')">true</_NodeRestoreIsCI>
+    <_NodeRestoreIsCI Condition="'$(_NodeRestoreIsCI)'==''">false</_NodeRestoreIsCI>
+  </PropertyGroup>
+
+  <!--
+    Pure resolution - no side effects. Runs once per project build (cheap: a handful of ancestor
+    directory walks), computing which tool/command/workspace-root everything downstream uses.
+  -->
+  <Target Name="_NodeRestoreResolve" Condition="'$(NodePackageManager)' != 'None'">
+
+    <!-- Marker walk-up, in precedence order. Only the first match (per project) needs finding,
+         but each Condition short-circuits once an earlier one has already matched, so at most
+         one GetDirectoryNameOfFileAbove call actually walks the disk per project in practice. -->
+    <PropertyGroup>
+      <_NodeRestoreRushRoot>$([MSBuild]::GetDirectoryNameOfFileAbove('$(NodeRestoreProjectDirectory)', 'rush.json'))</_NodeRestoreRushRoot>
+      <_NodeRestorePnpmRoot Condition="'$(_NodeRestoreRushRoot)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(NodeRestoreProjectDirectory)', 'pnpm-lock.yaml'))</_NodeRestorePnpmRoot>
+      <_NodeRestoreYarnRoot Condition="'$(_NodeRestoreRushRoot)'=='' and '$(_NodeRestorePnpmRoot)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(NodeRestoreProjectDirectory)', 'yarn.lock'))</_NodeRestoreYarnRoot>
+      <_NodeRestoreBunRoot Condition="'$(_NodeRestoreRushRoot)'=='' and '$(_NodeRestorePnpmRoot)'=='' and '$(_NodeRestoreYarnRoot)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(NodeRestoreProjectDirectory)', 'bun.lockb'))</_NodeRestoreBunRoot>
+      <_NodeRestoreNpmRoot Condition="'$(_NodeRestoreRushRoot)'=='' and '$(_NodeRestorePnpmRoot)'=='' and '$(_NodeRestoreYarnRoot)'=='' and '$(_NodeRestoreBunRoot)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(NodeRestoreProjectDirectory)', 'package-lock.json'))</_NodeRestoreNpmRoot>
+    </PropertyGroup>
+
+    <!-- Auto-detected tool + the root the matching marker was found in. Falls back to plain npm
+         in the project directory itself when nothing is found anywhere above it - today's
+         behavior for a bare project with no committed lockfile. -->
+    <PropertyGroup>
+      <_NodeRestoreDetectedTool Condition="'$(_NodeRestoreRushRoot)'!=''">rush</_NodeRestoreDetectedTool>
+      <_NodeRestoreDetectedTool Condition="'$(_NodeRestoreDetectedTool)'=='' and '$(_NodeRestorePnpmRoot)'!=''">pnpm</_NodeRestoreDetectedTool>
+      <_NodeRestoreDetectedTool Condition="'$(_NodeRestoreDetectedTool)'=='' and '$(_NodeRestoreYarnRoot)'!=''">yarn</_NodeRestoreDetectedTool>
+      <_NodeRestoreDetectedTool Condition="'$(_NodeRestoreDetectedTool)'=='' and '$(_NodeRestoreBunRoot)'!=''">bun</_NodeRestoreDetectedTool>
+      <_NodeRestoreDetectedTool Condition="'$(_NodeRestoreDetectedTool)'=='' and '$(_NodeRestoreNpmRoot)'!=''">npm</_NodeRestoreDetectedTool>
+      <_NodeRestoreDetectedTool Condition="'$(_NodeRestoreDetectedTool)'==''">npm</_NodeRestoreDetectedTool>
+
+      <_NodeRestoreDetectedRoot Condition="'$(_NodeRestoreDetectedTool)'=='rush'">$(_NodeRestoreRushRoot)</_NodeRestoreDetectedRoot>
+      <_NodeRestoreDetectedRoot Condition="'$(_NodeRestoreDetectedTool)'=='pnpm'">$(_NodeRestorePnpmRoot)</_NodeRestoreDetectedRoot>
+      <_NodeRestoreDetectedRoot Condition="'$(_NodeRestoreDetectedTool)'=='yarn'">$(_NodeRestoreYarnRoot)</_NodeRestoreDetectedRoot>
+      <_NodeRestoreDetectedRoot Condition="'$(_NodeRestoreDetectedTool)'=='bun'">$(_NodeRestoreBunRoot)</_NodeRestoreDetectedRoot>
+      <_NodeRestoreDetectedRoot Condition="'$(_NodeRestoreDetectedTool)'=='npm' and '$(_NodeRestoreNpmRoot)'!=''">$(_NodeRestoreNpmRoot)</_NodeRestoreDetectedRoot>
+      <_NodeRestoreDetectedRoot Condition="'$(_NodeRestoreDetectedRoot)'==''">$(NodeRestoreProjectDirectory)</_NodeRestoreDetectedRoot>
+    </PropertyGroup>
+
+    <!-- Explicit NodePackageManager overrides the tool choice only - workspace root is still
+         resolved via the same walk-up as auto-detection (so an override doesn't also have to
+         re-specify where the project root lives). -->
+    <PropertyGroup>
+      <_NodeRestoreResolvedTool Condition="'$(NodePackageManager)' != ''">$(NodePackageManager)</_NodeRestoreResolvedTool>
+      <_NodeRestoreResolvedTool Condition="'$(_NodeRestoreResolvedTool)'==''">$(_NodeRestoreDetectedTool)</_NodeRestoreResolvedTool>
+      <_NodeRestoreWorkspaceRoot>$(_NodeRestoreDetectedRoot)</_NodeRestoreWorkspaceRoot>
+
+      <!-- Yarn Berry vs Classic only changes which frozen flag applies. -->
+      <_NodeRestoreYarnBerry Condition="'$(_NodeRestoreResolvedTool)'=='yarn' and Exists('$(_NodeRestoreWorkspaceRoot)/.yarnrc.yml')">true</_NodeRestoreYarnBerry>
+    </PropertyGroup>
+
+    <!-- Frozen/CI-safe variant (npm ci, pnpm's frozen-lockfile flag, ...) per #88: requires CI AND an
+         actual lockfile at the resolved root - never CI alone, since that's exactly what makes
+         "npm ci" hard-fail when no lockfile exists, and never for the plain "no lockfile found
+         anywhere" npm fallback either. Rush always counts as having a lockfile equivalent: its
+         own install-run-rush.js already enforces install-vs-update semantics internally. -->
+    <PropertyGroup>
+      <_NodeRestoreHasLockfile Condition="'$(_NodeRestoreResolvedTool)'=='rush'">true</_NodeRestoreHasLockfile>
+      <_NodeRestoreHasLockfile Condition="'$(_NodeRestoreHasLockfile)'=='' and '$(_NodeRestoreResolvedTool)'=='pnpm' and Exists('$(_NodeRestoreWorkspaceRoot)/pnpm-lock.yaml')">true</_NodeRestoreHasLockfile>
+      <_NodeRestoreHasLockfile Condition="'$(_NodeRestoreHasLockfile)'=='' and '$(_NodeRestoreResolvedTool)'=='yarn' and Exists('$(_NodeRestoreWorkspaceRoot)/yarn.lock')">true</_NodeRestoreHasLockfile>
+      <_NodeRestoreHasLockfile Condition="'$(_NodeRestoreHasLockfile)'=='' and '$(_NodeRestoreResolvedTool)'=='bun' and Exists('$(_NodeRestoreWorkspaceRoot)/bun.lockb')">true</_NodeRestoreHasLockfile>
+      <_NodeRestoreHasLockfile Condition="'$(_NodeRestoreHasLockfile)'=='' and '$(_NodeRestoreResolvedTool)'=='npm' and Exists('$(_NodeRestoreWorkspaceRoot)/package-lock.json')">true</_NodeRestoreHasLockfile>
+      <_NodeRestoreHasLockfile Condition="'$(_NodeRestoreHasLockfile)'==''">false</_NodeRestoreHasLockfile>
+
+      <_NodeRestoreUseFrozen Condition="'$(_NodeRestoreIsCI)'=='true' and '$(_NodeRestoreHasLockfile)'=='true'">true</_NodeRestoreUseFrozen>
+      <_NodeRestoreUseFrozen Condition="'$(_NodeRestoreUseFrozen)'==''">false</_NodeRestoreUseFrozen>
+    </PropertyGroup>
+
+    <!-- Single, always-existing incremental-check key for the non-Rush stamp target below: the
+         actual lockfile that was matched, or package.json when no lockfile exists anywhere -
+         a single known-to-exist path avoids relying on MSBuild's handling of missing Input files. -->
+    <PropertyGroup>
+      <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreResolvedTool)'=='pnpm' and '$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestoreWorkspaceRoot)/pnpm-lock.yaml</_NodeRestoreLockfilePath>
+      <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreLockfilePath)'=='' and '$(_NodeRestoreResolvedTool)'=='yarn' and '$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestoreWorkspaceRoot)/yarn.lock</_NodeRestoreLockfilePath>
+      <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreLockfilePath)'=='' and '$(_NodeRestoreResolvedTool)'=='bun' and '$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestoreWorkspaceRoot)/bun.lockb</_NodeRestoreLockfilePath>
+      <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreLockfilePath)'=='' and '$(_NodeRestoreResolvedTool)'=='npm' and '$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestoreWorkspaceRoot)/package-lock.json</_NodeRestoreLockfilePath>
+      <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreLockfilePath)'==''">$(_NodeRestoreWorkspaceRoot)/package.json</_NodeRestoreLockfilePath>
+    </PropertyGroup>
+
+    <!-- Command table: local variant / frozen-CI variant per tool. -->
+    <PropertyGroup>
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='rush' and '$(_NodeRestoreUseFrozen)'!='true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" update</_NodeRestoreResolvedCommand>
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='rush' and '$(_NodeRestoreUseFrozen)'=='true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" install</_NodeRestoreResolvedCommand>
+
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='pnpm' and '$(_NodeRestoreUseFrozen)'!='true'">pnpm install</_NodeRestoreResolvedCommand>
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='pnpm' and '$(_NodeRestoreUseFrozen)'=='true'">pnpm install --frozen-lockfile</_NodeRestoreResolvedCommand>
+
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='yarn' and '$(_NodeRestoreUseFrozen)'!='true'">yarn install</_NodeRestoreResolvedCommand>
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='yarn' and '$(_NodeRestoreUseFrozen)'=='true' and '$(_NodeRestoreYarnBerry)'=='true'">yarn install --immutable</_NodeRestoreResolvedCommand>
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='yarn' and '$(_NodeRestoreUseFrozen)'=='true' and '$(_NodeRestoreYarnBerry)'!='true'">yarn install --frozen-lockfile</_NodeRestoreResolvedCommand>
+
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='bun' and '$(_NodeRestoreUseFrozen)'!='true'">bun install</_NodeRestoreResolvedCommand>
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='bun' and '$(_NodeRestoreUseFrozen)'=='true'">bun install --frozen-lockfile</_NodeRestoreResolvedCommand>
+
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='npm' and '$(_NodeRestoreUseFrozen)'!='true'">npm install</_NodeRestoreResolvedCommand>
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='npm' and '$(_NodeRestoreUseFrozen)'=='true'">npm ci</_NodeRestoreResolvedCommand>
+    </PropertyGroup>
+
+    <!-- Explicit NodeRestoreCommand wins over everything computed above. -->
+    <PropertyGroup Condition="'$(NodeRestoreCommand)' != ''">
+      <_NodeRestoreResolvedCommand>$(NodeRestoreCommand)</_NodeRestoreResolvedCommand>
+    </PropertyGroup>
+
+    <Warning Condition="'$(NodeRestoreCommand)'=='' and '$(_NodeRestoreIsCI)'=='true' and '$(_NodeRestoreResolvedTool)'=='npm' and '$(_NodeRestoreHasLockfile)'!='true'"
+             Text="NodeRestore: running in CI with no package-lock.json found at '$(_NodeRestoreWorkspaceRoot)' - falling back to 'npm install' instead of the reproducible, cache-friendly 'npm ci'. Commit a lockfile to fix this (see #88)." />
+
+    <Error Condition="'$(_NodeRestoreResolvedCommand)' == ''"
+           Text="NodeRestore: could not resolve a Node install command for '$(NodeRestoreProjectDirectory)'. Set the NodeRestoreCommand MSBuild property to the exact command to run, or NodePackageManager=None if dependencies are hydrated externally." />
+  </Target>
+
+  <!-- Explicit raw override: run exactly the given command, every build. No incremental
+       caching here - we don't know the shape of a user-supplied command well enough to key an
+       up-to-date check on it, so this mirrors today's "runs every build" npm install behavior. -->
+  <Target Name="_NodeRestoreRunCustom"
+          DependsOnTargets="_NodeRestoreResolve"
+          Condition="'$(NodePackageManager)' != 'None' and '$(NodeRestoreCommand)' != ''">
+    <Exec Command="$(_NodeRestoreResolvedCommand)"
+          WorkingDirectory="$(NodeRestoreProjectDirectory)"
+          StandardOutputImportance="Low"
+          StandardErrorImportance="High" />
+  </Target>
+
+  <!-- Rush is already self-idempotent (state hash vs common/temp/last-install.flag) and
+       self-serializing (its own common/temp/rush#<pid>.lock) - invoke it unconditionally on
+       every build and let Rush's own fast-path absorb the cost. Adding a second, custom
+       stamp-file gate on top of Rush's own would duplicate an incrementality mechanism Rush
+       already owns, and would be a likely source of "not implemented correctly" bugs (our
+       stamp going stale relative to Rush's own state, or vice versa). -->
+  <Target Name="_NodeRestoreRunRush"
+          DependsOnTargets="_NodeRestoreResolve"
+          Condition="'$(NodePackageManager)' != 'None' and '$(NodeRestoreCommand)' == '' and '$(_NodeRestoreResolvedTool)' == 'rush'">
+    <Exec Command="$(_NodeRestoreResolvedCommand)"
+          WorkingDirectory="$(_NodeRestoreWorkspaceRoot)"
+          StandardOutputImportance="Low"
+          StandardErrorImportance="High" />
+  </Target>
+
+  <!-- Non-Rush tools: gated by Target Inputs/Outputs against a stamp file next to node_modules,
+       keyed on the lockfile (or package.json when no lockfile exists at all). The second,
+       third, ... project sharing the same workspace root in one build sees this target as
+       already up-to-date and skips the Exec entirely - the "once per workspace, not once per
+       project" guarantee from #93.
+       Documented limitation, not solved with a custom lock: concurrent multi-proc MSBuild
+       builds of independent projects sharing one workspace root can still race to invoke
+       install simultaneously, since none of npm/pnpm/yarn/bun ship a cross-process lock of
+       their own (unlike Rush, see above). -->
+  <Target Name="_NodeRestoreRunOther"
+          DependsOnTargets="_NodeRestoreResolve"
+          Condition="'$(NodePackageManager)' != 'None' and '$(NodeRestoreCommand)' == '' and '$(_NodeRestoreResolvedTool)' != 'rush'"
+          Inputs="$(_NodeRestoreLockfilePath)"
+          Outputs="$(_NodeRestoreWorkspaceRoot)/node_modules/.node-restore-stamp">
+    <MakeDir Directories="$(_NodeRestoreWorkspaceRoot)/node_modules" Condition="!Exists('$(_NodeRestoreWorkspaceRoot)/node_modules')" />
+    <Exec Command="$(_NodeRestoreResolvedCommand)"
+          WorkingDirectory="$(_NodeRestoreWorkspaceRoot)"
+          StandardOutputImportance="Low"
+          StandardErrorImportance="High" />
+    <Touch Files="$(_NodeRestoreWorkspaceRoot)/node_modules/.node-restore-stamp" AlwaysCreate="true" />
+  </Target>
+
+  <!-- NodeRestore explicitly runs _NodeRestoreResolve FIRST (not merely via each branch's own
+       DependsOnTargets). MSBuild evaluates a target's own Condition BEFORE running its
+       DependsOnTargets, so a Condition referencing a property that only _NodeRestoreResolve sets
+       would otherwise see it as still-empty at check time for whichever branch is evaluated
+       first in the list - silently mis-routing every tool (including Rush) into the wrong branch.
+       Listing _NodeRestoreResolve first here guarantees it has already run - and _NodeRestoreResolvedTool
+       etc. are already correct - by the time _NodeRestoreRunRush/_NodeRestoreRunOther's own
+       Conditions are checked. -->
+  <Target Name="NodeRestore" DependsOnTargets="_NodeRestoreResolve;_NodeRestoreRunCustom;_NodeRestoreRunRush;_NodeRestoreRunOther" />
+
+</Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore.targets
@@ -93,6 +93,38 @@
       <_NodeRestoreYarnBerry Condition="'$(_NodeRestoreResolvedTool)'=='yarn' and Exists('$(_NodeRestoreWorkspaceRoot)/.yarnrc.yml')">true</_NodeRestoreYarnBerry>
     </PropertyGroup>
 
+    <!-- Proactive rush.json registration check, not reactive error-matching. Once Build
+         delegation routes through an unscoped "rush build" (see Pcf/ScriptLibrary/CodeApp
+         targets), Rush silently skips any project absent from its own rush.json "projects" array
+         instead of erroring - so a failed-command/error-text check can no longer detect "this
+         project isn't registered with Rush yet" (a legitimate incremental-adoption state: a
+         project can sit under a Rush-marked directory tree before its own package.json has been
+         added to rush.json - not a misconfiguration). Checked once, here, so both this restore
+         branch and every build-delegation branch downstream share one answer. Deliberately a
+         lightweight substring check (is "<relative-project-dir>" quoted anywhere in rush.json),
+         not a full JSON parse - false negatives only cost an extra graceful-fallback warning, not
+         a silent incorrectness, so the lower-maintenance check is the right trade-off here. -->
+    <PropertyGroup Condition="'$(_NodeRestoreResolvedTool)'=='rush'">
+      <_NodeRestoreRushRelativeDir>$([MSBuild]::MakeRelative('$(_NodeRestoreWorkspaceRoot)\', '$(NodeRestoreProjectDirectory)\'))</_NodeRestoreRushRelativeDir>
+      <_NodeRestoreRushRelativeDir>$(_NodeRestoreRushRelativeDir.Replace('\', '/').TrimEnd('/'))</_NodeRestoreRushRelativeDir>
+      <_NodeRestoreRushJsonText Condition="Exists('$(_NodeRestoreWorkspaceRoot)/rush.json')">$([System.IO.File]::ReadAllText('$(_NodeRestoreWorkspaceRoot)/rush.json'))</_NodeRestoreRushJsonText>
+      <_NodeRestoreIsRushRegistered Condition="'$(_NodeRestoreRushJsonText)' != '' and $(_NodeRestoreRushJsonText.Contains('&quot;$(_NodeRestoreRushRelativeDir)&quot;'))">true</_NodeRestoreIsRushRegistered>
+      <_NodeRestoreIsRushRegistered Condition="'$(_NodeRestoreIsRushRegistered)' == ''">false</_NodeRestoreIsRushRegistered>
+    </PropertyGroup>
+
+    <Warning Condition="'$(_NodeRestoreResolvedTool)'=='rush' and '$(_NodeRestoreIsRushRegistered)' == 'false'"
+             Text="NodeRestore: '$(NodeRestoreProjectDirectory)' sits under a Rush workspace ('$(_NodeRestoreWorkspaceRoot)/rush.json') but is not yet listed in its 'projects' array - falling back to a direct npm install/build for this project instead of Rush. Add it to rush.json to have Rush manage (and cache) it." />
+
+    <!-- Not registered yet: fall back to plain npm, scoped to this project's own directory - a
+         graceful downgrade (unlike the hard-fail used for Pcf's command-line.json check, see
+         TALXIS.DevKit.Build.Dataverse.Pcf.targets/Finding #9): an unregistered project is
+         legitimately mid-incremental-adoption, which this SDK cannot distinguish from "forgot to
+         register it," so it must not hard-fail here. -->
+    <PropertyGroup Condition="'$(_NodeRestoreResolvedTool)'=='rush' and '$(_NodeRestoreIsRushRegistered)' != 'true'">
+      <_NodeRestoreResolvedTool>npm</_NodeRestoreResolvedTool>
+      <_NodeRestoreWorkspaceRoot>$(NodeRestoreProjectDirectory)</_NodeRestoreWorkspaceRoot>
+    </PropertyGroup>
+
     <!-- Frozen/CI-safe variant (npm ci, pnpm's frozen-lockfile flag, ...) per #88: requires CI AND an
          actual lockfile at the resolved root - never CI alone, since that's exactly what makes
          "npm ci" hard-fail when no lockfile exists, and never for the plain "no lockfile found
@@ -152,6 +184,72 @@
            Text="NodeRestore: could not resolve a Node install command for '$(NodeRestoreProjectDirectory)'. Set the NodeRestoreCommand MSBuild property to the exact command to run, or NodePackageManager=None if dependencies are hydrated externally." />
   </Target>
 
+  <!--
+    Shared retry-on-lock-contention helper, used by both the Rush install/update branch below and
+    the Rush build-delegation branches in Pcf/ScriptLibrary/CodeApp (see their PcfBuild/
+    BuildTypeScript/BuildCodeApp overrides). Rush's own whole-repo lock
+    (common/temp/rush#<pid>.lock) is fail-fast, not wait-based: a second concurrent Rush
+    invocation (install/update OR build - both acquire the exact same lock, confirmed at the
+    rushstack source level) errors immediately with "Another Rush command is already running in
+    this repository" instead of queuing. That is exactly the shape multiple MSBuild
+    projects/solution-level parallel builds create once every Rush-registered project's restore
+    and build both route through Rush. Rather than inventing our own generic cross-process lock,
+    this helper makes NodeRestore resilient to that one, already-known, already-documented Rush
+    failure mode: whichever invocation wins already does the complete job for the entire Rush
+    workspace (rush update/install/build are never project-scoped in a way that leaves other
+    projects unrestored/unbuilt), so a retry after the winner finishes is either an instant no-op
+    (Rush's own state hash / incremental-skip already satisfied) or, worst case, just waits out
+    the real work already happening on its behalf.
+
+    One unified retry budget serves every call site (install/update AND build): once build
+    delegation uses a single unscoped "rush build" per solution-scope invocation (matching how
+    install/update already works), both call sites share the identical risk profile - "first
+    invocation does the real work, every other invocation gets a fast no-op" - so there is no
+    reason to size install/update's budget any differently than build's. Exponential backoff for
+    the first few attempts (1/2/4/8/16s), then capped at 30s/attempt, ~45 attempts (~20 minute
+    ceiling) before propagating Rush's own real exit code - long enough to outlast a legitimately
+    slow cold install/build elsewhere in the repo, short enough to still fail loudly if Rush's
+    lock is genuinely stuck.
+
+    Implemented as a single inline "node -e" snippet (no new shipped .js file, no NuGet content
+    wiring - keeps this SDK from owning a JS build pipeline) rather than MSBuild-native retry
+    logic, because MSBuild has no looping construct suitable for "run a process, inspect its
+    output, conditionally retry with backoff." stdio is streamed live (not buffered) to the
+    MSBuild log exactly as today's direct Exec does - we only ever wrap retry *decision* logic
+    around Rush's own output, never swallow or summarize it. Any failure that is NOT Rush's own
+    lock-contention message propagates immediately with its real exit code - no retry, no masking
+    of a genuine install/build error.
+
+    Callers set _NodeRestoreRetryCommand/_NodeRestoreRetryWorkingDirectory and invoke this target
+    via the MSBuild task (self-invocation of $(MSBuildProjectFullPath)), NOT CallTarget. This
+    matters because a single "dotnet build" runs both the restore-hydration branch
+    (_NodeRestoreRunRush) and, for Rush-registered projects, the build-delegation branch in the
+    same project instance/same build - i.e. this target legitimately needs to run twice per
+    build, once per phase, with different command/working-directory values each time. MSBuild
+    only executes a given target name once per project build no matter how many times CallTarget
+    references it (confirmed empirically); a second CallTarget call in the same build silently
+    no-ops instead of running with the new property values. Invoking via the MSBuild task with an
+    explicit Properties list creates a distinct (project, global-properties) build request each
+    time, which MSBuild always executes fresh - the correct, documented way to invoke the same
+    target repeatedly with different arguments within one build.
+  -->
+  <PropertyGroup>
+    <_NodeRestoreRushLockMessage>Another Rush command is already running in this repository</_NodeRestoreRushLockMessage>
+  </PropertyGroup>
+  <Target Name="_NodeRestoreExecWithRetry">
+    <!-- Buffers BOTH stdout and stderr for the lock-message match, not stderr alone - confirmed
+         empirically (direct concurrent-spawn test against a real Rush workspace) that Rush prints
+         "Another Rush command is already running in this repository." to STDOUT, not stderr. A
+         stderr-only buffer would never detect this condition and would treat every lock conflict
+         as an unconditional real failure instead of retrying - exactly the false-failure scenario
+         this whole mechanism exists to prevent. -->
+    <Exec Command="node -e &quot;const{spawn}=require('child_process');const cmd=process.env.NR_CMD;const cwd=process.env.NR_CWD;const lockMsg=process.env.NR_LOCK_MSG;const delays=[1000,2000,4000,8000,16000];const maxAttempts=45;function run(){return new Promise(function(resolve){const isWin=process.platform==='win32';const shell=isWin?'cmd.exe':'/bin/sh';const args=isWin?['/d','/s','/c',cmd]:['-c',cmd];const child=spawn(shell,args,{cwd:cwd,stdio:['inherit','pipe','pipe']});let outBuf='';child.stdout.on('data',function(d){process.stdout.write(d);outBuf+=d.toString();});child.stderr.on('data',function(d){process.stderr.write(d);outBuf+=d.toString();});child.on('close',function(code){resolve({code:code,outBuf:outBuf});});});}function wait(ms){return new Promise(function(r){setTimeout(r,ms);});}(async function(){let attempt=0;while(true){attempt=attempt+1;const result=await run();if(result.code===0){process.exit(0);}const isLockConflict=result.outBuf.indexOf(lockMsg)!==-1;if(!isLockConflict){process.exit(result.code);}if(attempt&gt;=maxAttempts){console.error('NodeRestore: Rush lock held by another process for over 20 minutes, giving up after '+attempt+' attempts.');process.exit(result.code);}const idx=attempt-1;const delay=idx&lt;delays.length?delays[idx]:30000;console.log('NodeRestore: Rush is busy, retrying ('+attempt+'/'+maxAttempts+') in '+(delay/1000)+'s...');await wait(delay);}})();&quot;"
+          WorkingDirectory="$(_NodeRestoreRetryWorkingDirectory)"
+          EnvironmentVariables="NR_CMD=$(_NodeRestoreRetryCommand);NR_CWD=$(_NodeRestoreRetryWorkingDirectory);NR_LOCK_MSG=$(_NodeRestoreRushLockMessage)"
+          StandardOutputImportance="Low"
+          StandardErrorImportance="High" />
+  </Target>
+
   <!-- Explicit raw override: run exactly the given command, every build. No incremental
        caching here - we don't know the shape of a user-supplied command well enough to key an
        up-to-date check on it, so this mirrors today's "runs every build" npm install behavior. -->
@@ -173,10 +271,17 @@
   <Target Name="_NodeRestoreRunRush"
           DependsOnTargets="_NodeRestoreResolve"
           Condition="'$(NodePackageManager)' != 'None' and '$(NodeRestoreCommand)' == '' and '$(_NodeRestoreResolvedTool)' == 'rush'">
-    <Exec Command="$(_NodeRestoreResolvedCommand)"
-          WorkingDirectory="$(_NodeRestoreWorkspaceRoot)"
-          StandardOutputImportance="Low"
-          StandardErrorImportance="High" />
+    <PropertyGroup>
+      <_NodeRestoreRetryCommand>$(_NodeRestoreResolvedCommand)</_NodeRestoreRetryCommand>
+      <_NodeRestoreRetryWorkingDirectory>$(_NodeRestoreWorkspaceRoot)</_NodeRestoreRetryWorkingDirectory>
+    </PropertyGroup>
+    <!-- MSBuild self-invocation, not CallTarget - see the "why" comment on
+         _NodeRestoreExecWithRetry above: this same target also runs from the build-delegation
+         branch later in the same "dotnet build", and CallTarget would silently no-op the second
+         call. -->
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="_NodeRestoreExecWithRetry"
+             Properties="_NodeRestoreRetryCommand=$(_NodeRestoreRetryCommand);_NodeRestoreRetryWorkingDirectory=$(_NodeRestoreRetryWorkingDirectory)" />
   </Target>
 
   <!-- Non-Rush tools: gated by Target Inputs/Outputs against a stamp file next to node_modules,

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore.targets
@@ -1,11 +1,10 @@
 <Project>
   <!--
     NodeRestore: package-manager-agnostic Node dependency hydration.
-    Closes #88, #90. Implements #93.
 
-    Replaces the previously hardcoded "npm install" in Pcf/ScriptLibrary/CodeApp. Detection is
-    plain MSBuild (GetDirectoryNameOfFileAbove over a small, stable set of marker files) - no
-    bundled Node script, no extra process, no library dependency to track for updates.
+    Detection is plain MSBuild (GetDirectoryNameOfFileAbove over a small, stable set of marker
+    files) - no bundled Node script, no extra process, no library dependency to track for
+    updates.
 
     Consumers call this via <CallTarget Targets="NodeRestore" /> from their own anchor target
     (mirrors how GenerateVersionNumber/ApplyPcfVersionNumber etc. are invoked elsewhere in this
@@ -17,6 +16,20 @@
       NodePackageManager           '' (auto, default) | None | npm | pnpm | yarn | bun | rush.
                                     None = dependencies hydrated externally; do nothing.
       NodeRestoreCommand           Raw command override. Wins over everything else below.
+
+    Implementation is split across NodeRestore\*.targets by concern:
+      Detection.targets     Tool/workspace-root resolution, shared by every branch below.
+      Rush.targets           Rush-specific install/update (Rush is a monorepo orchestrator that
+                              delegates its own dependency install to pnpm, not a package manager
+                              in its own right).
+      Generic.targets        npm/pnpm/yarn/bun install (used whenever no orchestrator is present).
+      CustomCommand.targets  Explicit NodeRestoreCommand override, independent of any tool.
+      Retry.targets          Shared retry-with-backoff helper for Rush's lock contention, also
+                              used by build delegation (see NodeBuild\RushDelegation.targets).
+
+    Adding a new package manager or orchestrator only requires a new NodeRestore\<Name>.targets
+    file with its own detection property and _NodeRestoreRun<Name> target, wired into this file's
+    DependsOnTargets list below - no changes needed to the files above.
   -->
 
   <PropertyGroup>
@@ -25,295 +38,14 @@
     <NodeRestoreCommand Condition="'$(NodeRestoreCommand)'==''"></NodeRestoreCommand>
   </PropertyGroup>
 
-  <!--
-    CI detection deliberately mirrors GenerateGitVersion.DetectIsRunningInCI (same property, same
-    env-var list) instead of defining a second notion of "what counts as CI" to keep in sync.
-    IsRunningInCI itself is empty unless a consumer sets it explicitly or GenerateVersionNumber
-    already ran and exported it back as a property - so this file re-detects independently rather
-    than depending on version-numbering having run first.
-  -->
-  <PropertyGroup>
-    <_NodeRestoreIsCI Condition="'$(IsRunningInCI)'!=''">$(IsRunningInCI)</_NodeRestoreIsCI>
-    <_NodeRestoreIsCI Condition="'$(_NodeRestoreIsCI)'=='' and (
-        '$(CI)'=='true' or
-        '$(TF_BUILD)'=='True' or '$(TF_BUILD)'=='true' or
-        '$(GITHUB_ACTIONS)'=='true' or
-        '$(GITLAB_CI)'=='true' or
-        '$(CIRCLECI)'=='true' or
-        '$(JENKINS_URL)'!='' or
-        '$(TEAMCITY_VERSION)'!='')">true</_NodeRestoreIsCI>
-    <_NodeRestoreIsCI Condition="'$(_NodeRestoreIsCI)'==''">false</_NodeRestoreIsCI>
-  </PropertyGroup>
-
-  <!--
-    Pure resolution - no side effects. Runs once per project build (cheap: a handful of ancestor
-    directory walks), computing which tool/command/workspace-root everything downstream uses.
-  -->
-  <Target Name="_NodeRestoreResolve" Condition="'$(NodePackageManager)' != 'None'">
-
-    <!-- Marker walk-up, in precedence order. Only the first match (per project) needs finding,
-         but each Condition short-circuits once an earlier one has already matched, so at most
-         one GetDirectoryNameOfFileAbove call actually walks the disk per project in practice. -->
-    <PropertyGroup>
-      <_NodeRestoreRushRoot>$([MSBuild]::GetDirectoryNameOfFileAbove('$(NodeRestoreProjectDirectory)', 'rush.json'))</_NodeRestoreRushRoot>
-      <_NodeRestorePnpmRoot Condition="'$(_NodeRestoreRushRoot)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(NodeRestoreProjectDirectory)', 'pnpm-lock.yaml'))</_NodeRestorePnpmRoot>
-      <_NodeRestoreYarnRoot Condition="'$(_NodeRestoreRushRoot)'=='' and '$(_NodeRestorePnpmRoot)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(NodeRestoreProjectDirectory)', 'yarn.lock'))</_NodeRestoreYarnRoot>
-      <_NodeRestoreBunRoot Condition="'$(_NodeRestoreRushRoot)'=='' and '$(_NodeRestorePnpmRoot)'=='' and '$(_NodeRestoreYarnRoot)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(NodeRestoreProjectDirectory)', 'bun.lockb'))</_NodeRestoreBunRoot>
-      <_NodeRestoreNpmRoot Condition="'$(_NodeRestoreRushRoot)'=='' and '$(_NodeRestorePnpmRoot)'=='' and '$(_NodeRestoreYarnRoot)'=='' and '$(_NodeRestoreBunRoot)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(NodeRestoreProjectDirectory)', 'package-lock.json'))</_NodeRestoreNpmRoot>
-    </PropertyGroup>
-
-    <!-- Auto-detected tool + the root the matching marker was found in. Falls back to plain npm
-         in the project directory itself when nothing is found anywhere above it - today's
-         behavior for a bare project with no committed lockfile. -->
-    <PropertyGroup>
-      <_NodeRestoreDetectedTool Condition="'$(_NodeRestoreRushRoot)'!=''">rush</_NodeRestoreDetectedTool>
-      <_NodeRestoreDetectedTool Condition="'$(_NodeRestoreDetectedTool)'=='' and '$(_NodeRestorePnpmRoot)'!=''">pnpm</_NodeRestoreDetectedTool>
-      <_NodeRestoreDetectedTool Condition="'$(_NodeRestoreDetectedTool)'=='' and '$(_NodeRestoreYarnRoot)'!=''">yarn</_NodeRestoreDetectedTool>
-      <_NodeRestoreDetectedTool Condition="'$(_NodeRestoreDetectedTool)'=='' and '$(_NodeRestoreBunRoot)'!=''">bun</_NodeRestoreDetectedTool>
-      <_NodeRestoreDetectedTool Condition="'$(_NodeRestoreDetectedTool)'=='' and '$(_NodeRestoreNpmRoot)'!=''">npm</_NodeRestoreDetectedTool>
-      <_NodeRestoreDetectedTool Condition="'$(_NodeRestoreDetectedTool)'==''">npm</_NodeRestoreDetectedTool>
-
-      <_NodeRestoreDetectedRoot Condition="'$(_NodeRestoreDetectedTool)'=='rush'">$(_NodeRestoreRushRoot)</_NodeRestoreDetectedRoot>
-      <_NodeRestoreDetectedRoot Condition="'$(_NodeRestoreDetectedTool)'=='pnpm'">$(_NodeRestorePnpmRoot)</_NodeRestoreDetectedRoot>
-      <_NodeRestoreDetectedRoot Condition="'$(_NodeRestoreDetectedTool)'=='yarn'">$(_NodeRestoreYarnRoot)</_NodeRestoreDetectedRoot>
-      <_NodeRestoreDetectedRoot Condition="'$(_NodeRestoreDetectedTool)'=='bun'">$(_NodeRestoreBunRoot)</_NodeRestoreDetectedRoot>
-      <_NodeRestoreDetectedRoot Condition="'$(_NodeRestoreDetectedTool)'=='npm' and '$(_NodeRestoreNpmRoot)'!=''">$(_NodeRestoreNpmRoot)</_NodeRestoreDetectedRoot>
-      <_NodeRestoreDetectedRoot Condition="'$(_NodeRestoreDetectedRoot)'==''">$(NodeRestoreProjectDirectory)</_NodeRestoreDetectedRoot>
-    </PropertyGroup>
-
-    <!-- Explicit NodePackageManager overrides the tool choice only - workspace root is still
-         resolved via the same walk-up as auto-detection (so an override doesn't also have to
-         re-specify where the project root lives). -->
-    <PropertyGroup>
-      <_NodeRestoreResolvedTool Condition="'$(NodePackageManager)' != ''">$(NodePackageManager)</_NodeRestoreResolvedTool>
-      <_NodeRestoreResolvedTool Condition="'$(_NodeRestoreResolvedTool)'==''">$(_NodeRestoreDetectedTool)</_NodeRestoreResolvedTool>
-      <_NodeRestoreWorkspaceRoot>$(_NodeRestoreDetectedRoot)</_NodeRestoreWorkspaceRoot>
-
-      <!-- Yarn Berry vs Classic only changes which frozen flag applies. -->
-      <_NodeRestoreYarnBerry Condition="'$(_NodeRestoreResolvedTool)'=='yarn' and Exists('$(_NodeRestoreWorkspaceRoot)/.yarnrc.yml')">true</_NodeRestoreYarnBerry>
-    </PropertyGroup>
-
-    <!-- Proactive rush.json registration check, not reactive error-matching. Once Build
-         delegation routes through an unscoped "rush build" (see Pcf/ScriptLibrary/CodeApp
-         targets), Rush silently skips any project absent from its own rush.json "projects" array
-         instead of erroring - so a failed-command/error-text check can no longer detect "this
-         project isn't registered with Rush yet" (a legitimate incremental-adoption state: a
-         project can sit under a Rush-marked directory tree before its own package.json has been
-         added to rush.json - not a misconfiguration). Checked once, here, so both this restore
-         branch and every build-delegation branch downstream share one answer. Deliberately a
-         lightweight substring check (is "<relative-project-dir>" quoted anywhere in rush.json),
-         not a full JSON parse - false negatives only cost an extra graceful-fallback warning, not
-         a silent incorrectness, so the lower-maintenance check is the right trade-off here. -->
-    <PropertyGroup Condition="'$(_NodeRestoreResolvedTool)'=='rush'">
-      <_NodeRestoreRushRelativeDir>$([MSBuild]::MakeRelative('$(_NodeRestoreWorkspaceRoot)\', '$(NodeRestoreProjectDirectory)\'))</_NodeRestoreRushRelativeDir>
-      <_NodeRestoreRushRelativeDir>$(_NodeRestoreRushRelativeDir.Replace('\', '/').TrimEnd('/'))</_NodeRestoreRushRelativeDir>
-      <_NodeRestoreRushJsonText Condition="Exists('$(_NodeRestoreWorkspaceRoot)/rush.json')">$([System.IO.File]::ReadAllText('$(_NodeRestoreWorkspaceRoot)/rush.json'))</_NodeRestoreRushJsonText>
-      <_NodeRestoreIsRushRegistered Condition="'$(_NodeRestoreRushJsonText)' != '' and $(_NodeRestoreRushJsonText.Contains('&quot;$(_NodeRestoreRushRelativeDir)&quot;'))">true</_NodeRestoreIsRushRegistered>
-      <_NodeRestoreIsRushRegistered Condition="'$(_NodeRestoreIsRushRegistered)' == ''">false</_NodeRestoreIsRushRegistered>
-    </PropertyGroup>
-
-    <Warning Condition="'$(_NodeRestoreResolvedTool)'=='rush' and '$(_NodeRestoreIsRushRegistered)' == 'false'"
-             Text="NodeRestore: '$(NodeRestoreProjectDirectory)' sits under a Rush workspace ('$(_NodeRestoreWorkspaceRoot)/rush.json') but is not yet listed in its 'projects' array - falling back to a direct npm install/build for this project instead of Rush. Add it to rush.json to have Rush manage (and cache) it." />
-
-    <!-- Not registered yet: fall back to plain npm, scoped to this project's own directory - a
-         graceful downgrade (unlike the hard-fail used for Pcf's command-line.json check, see
-         TALXIS.DevKit.Build.Dataverse.Pcf.targets/Finding #9): an unregistered project is
-         legitimately mid-incremental-adoption, which this SDK cannot distinguish from "forgot to
-         register it," so it must not hard-fail here. -->
-    <PropertyGroup Condition="'$(_NodeRestoreResolvedTool)'=='rush' and '$(_NodeRestoreIsRushRegistered)' != 'true'">
-      <_NodeRestoreResolvedTool>npm</_NodeRestoreResolvedTool>
-      <_NodeRestoreWorkspaceRoot>$(NodeRestoreProjectDirectory)</_NodeRestoreWorkspaceRoot>
-    </PropertyGroup>
-
-    <!-- Frozen/CI-safe variant (npm ci, pnpm's frozen-lockfile flag, ...) per #88: requires CI AND an
-         actual lockfile at the resolved root - never CI alone, since that's exactly what makes
-         "npm ci" hard-fail when no lockfile exists, and never for the plain "no lockfile found
-         anywhere" npm fallback either. Rush always counts as having a lockfile equivalent: its
-         own install-run-rush.js already enforces install-vs-update semantics internally. -->
-    <PropertyGroup>
-      <_NodeRestoreHasLockfile Condition="'$(_NodeRestoreResolvedTool)'=='rush'">true</_NodeRestoreHasLockfile>
-      <_NodeRestoreHasLockfile Condition="'$(_NodeRestoreHasLockfile)'=='' and '$(_NodeRestoreResolvedTool)'=='pnpm' and Exists('$(_NodeRestoreWorkspaceRoot)/pnpm-lock.yaml')">true</_NodeRestoreHasLockfile>
-      <_NodeRestoreHasLockfile Condition="'$(_NodeRestoreHasLockfile)'=='' and '$(_NodeRestoreResolvedTool)'=='yarn' and Exists('$(_NodeRestoreWorkspaceRoot)/yarn.lock')">true</_NodeRestoreHasLockfile>
-      <_NodeRestoreHasLockfile Condition="'$(_NodeRestoreHasLockfile)'=='' and '$(_NodeRestoreResolvedTool)'=='bun' and Exists('$(_NodeRestoreWorkspaceRoot)/bun.lockb')">true</_NodeRestoreHasLockfile>
-      <_NodeRestoreHasLockfile Condition="'$(_NodeRestoreHasLockfile)'=='' and '$(_NodeRestoreResolvedTool)'=='npm' and Exists('$(_NodeRestoreWorkspaceRoot)/package-lock.json')">true</_NodeRestoreHasLockfile>
-      <_NodeRestoreHasLockfile Condition="'$(_NodeRestoreHasLockfile)'==''">false</_NodeRestoreHasLockfile>
-
-      <_NodeRestoreUseFrozen Condition="'$(_NodeRestoreIsCI)'=='true' and '$(_NodeRestoreHasLockfile)'=='true'">true</_NodeRestoreUseFrozen>
-      <_NodeRestoreUseFrozen Condition="'$(_NodeRestoreUseFrozen)'==''">false</_NodeRestoreUseFrozen>
-    </PropertyGroup>
-
-    <!-- Single, always-existing incremental-check key for the non-Rush stamp target below: the
-         actual lockfile that was matched, or package.json when no lockfile exists anywhere -
-         a single known-to-exist path avoids relying on MSBuild's handling of missing Input files. -->
-    <PropertyGroup>
-      <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreResolvedTool)'=='pnpm' and '$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestoreWorkspaceRoot)/pnpm-lock.yaml</_NodeRestoreLockfilePath>
-      <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreLockfilePath)'=='' and '$(_NodeRestoreResolvedTool)'=='yarn' and '$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestoreWorkspaceRoot)/yarn.lock</_NodeRestoreLockfilePath>
-      <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreLockfilePath)'=='' and '$(_NodeRestoreResolvedTool)'=='bun' and '$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestoreWorkspaceRoot)/bun.lockb</_NodeRestoreLockfilePath>
-      <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreLockfilePath)'=='' and '$(_NodeRestoreResolvedTool)'=='npm' and '$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestoreWorkspaceRoot)/package-lock.json</_NodeRestoreLockfilePath>
-      <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreLockfilePath)'==''">$(_NodeRestoreWorkspaceRoot)/package.json</_NodeRestoreLockfilePath>
-    </PropertyGroup>
-
-    <!-- Command table: local variant / frozen-CI variant per tool. -->
-    <PropertyGroup>
-      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='rush' and '$(_NodeRestoreUseFrozen)'!='true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" update</_NodeRestoreResolvedCommand>
-      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='rush' and '$(_NodeRestoreUseFrozen)'=='true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" install</_NodeRestoreResolvedCommand>
-
-      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='pnpm' and '$(_NodeRestoreUseFrozen)'!='true'">pnpm install</_NodeRestoreResolvedCommand>
-      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='pnpm' and '$(_NodeRestoreUseFrozen)'=='true'">pnpm install --frozen-lockfile</_NodeRestoreResolvedCommand>
-
-      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='yarn' and '$(_NodeRestoreUseFrozen)'!='true'">yarn install</_NodeRestoreResolvedCommand>
-      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='yarn' and '$(_NodeRestoreUseFrozen)'=='true' and '$(_NodeRestoreYarnBerry)'=='true'">yarn install --immutable</_NodeRestoreResolvedCommand>
-      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='yarn' and '$(_NodeRestoreUseFrozen)'=='true' and '$(_NodeRestoreYarnBerry)'!='true'">yarn install --frozen-lockfile</_NodeRestoreResolvedCommand>
-
-      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='bun' and '$(_NodeRestoreUseFrozen)'!='true'">bun install</_NodeRestoreResolvedCommand>
-      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='bun' and '$(_NodeRestoreUseFrozen)'=='true'">bun install --frozen-lockfile</_NodeRestoreResolvedCommand>
-
-      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='npm' and '$(_NodeRestoreUseFrozen)'!='true'">npm install</_NodeRestoreResolvedCommand>
-      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='npm' and '$(_NodeRestoreUseFrozen)'=='true'">npm ci</_NodeRestoreResolvedCommand>
-    </PropertyGroup>
-
-    <!-- Explicit NodeRestoreCommand wins over everything computed above. -->
-    <PropertyGroup Condition="'$(NodeRestoreCommand)' != ''">
-      <_NodeRestoreResolvedCommand>$(NodeRestoreCommand)</_NodeRestoreResolvedCommand>
-    </PropertyGroup>
-
-    <Warning Condition="'$(NodeRestoreCommand)'=='' and '$(_NodeRestoreIsCI)'=='true' and '$(_NodeRestoreResolvedTool)'=='npm' and '$(_NodeRestoreHasLockfile)'!='true'"
-             Text="NodeRestore: running in CI with no package-lock.json found at '$(_NodeRestoreWorkspaceRoot)' - falling back to 'npm install' instead of the reproducible, cache-friendly 'npm ci'. Commit a lockfile to fix this (see #88)." />
-
-    <Error Condition="'$(_NodeRestoreResolvedCommand)' == ''"
-           Text="NodeRestore: could not resolve a Node install command for '$(NodeRestoreProjectDirectory)'. Set the NodeRestoreCommand MSBuild property to the exact command to run, or NodePackageManager=None if dependencies are hydrated externally." />
-  </Target>
-
-  <!--
-    Shared retry-on-lock-contention helper, used by both the Rush install/update branch below and
-    the Rush build-delegation branches in Pcf/ScriptLibrary/CodeApp (see their PcfBuild/
-    BuildTypeScript/BuildCodeApp overrides). Rush's own whole-repo lock
-    (common/temp/rush#<pid>.lock) is fail-fast, not wait-based: a second concurrent Rush
-    invocation (install/update OR build - both acquire the exact same lock, confirmed at the
-    rushstack source level) errors immediately with "Another Rush command is already running in
-    this repository" instead of queuing. That is exactly the shape multiple MSBuild
-    projects/solution-level parallel builds create once every Rush-registered project's restore
-    and build both route through Rush. Rather than inventing our own generic cross-process lock,
-    this helper makes NodeRestore resilient to that one, already-known, already-documented Rush
-    failure mode: whichever invocation wins already does the complete job for the entire Rush
-    workspace (rush update/install/build are never project-scoped in a way that leaves other
-    projects unrestored/unbuilt), so a retry after the winner finishes is either an instant no-op
-    (Rush's own state hash / incremental-skip already satisfied) or, worst case, just waits out
-    the real work already happening on its behalf.
-
-    One unified retry budget serves every call site (install/update AND build): once build
-    delegation uses a single unscoped "rush build" per solution-scope invocation (matching how
-    install/update already works), both call sites share the identical risk profile - "first
-    invocation does the real work, every other invocation gets a fast no-op" - so there is no
-    reason to size install/update's budget any differently than build's. Exponential backoff for
-    the first few attempts (1/2/4/8/16s), then capped at 30s/attempt, ~45 attempts (~20 minute
-    ceiling) before propagating Rush's own real exit code - long enough to outlast a legitimately
-    slow cold install/build elsewhere in the repo, short enough to still fail loudly if Rush's
-    lock is genuinely stuck.
-
-    Implemented as a single inline "node -e" snippet (no new shipped .js file, no NuGet content
-    wiring - keeps this SDK from owning a JS build pipeline) rather than MSBuild-native retry
-    logic, because MSBuild has no looping construct suitable for "run a process, inspect its
-    output, conditionally retry with backoff." stdio is streamed live (not buffered) to the
-    MSBuild log exactly as today's direct Exec does - we only ever wrap retry *decision* logic
-    around Rush's own output, never swallow or summarize it. Any failure that is NOT Rush's own
-    lock-contention message propagates immediately with its real exit code - no retry, no masking
-    of a genuine install/build error.
-
-    Callers set _NodeRestoreRetryCommand/_NodeRestoreRetryWorkingDirectory and invoke this target
-    via the MSBuild task (self-invocation of $(MSBuildProjectFullPath)), NOT CallTarget. This
-    matters because a single "dotnet build" runs both the restore-hydration branch
-    (_NodeRestoreRunRush) and, for Rush-registered projects, the build-delegation branch in the
-    same project instance/same build - i.e. this target legitimately needs to run twice per
-    build, once per phase, with different command/working-directory values each time. MSBuild
-    only executes a given target name once per project build no matter how many times CallTarget
-    references it (confirmed empirically); a second CallTarget call in the same build silently
-    no-ops instead of running with the new property values. Invoking via the MSBuild task with an
-    explicit Properties list creates a distinct (project, global-properties) build request each
-    time, which MSBuild always executes fresh - the correct, documented way to invoke the same
-    target repeatedly with different arguments within one build.
-  -->
-  <PropertyGroup>
-    <_NodeRestoreRushLockMessage>Another Rush command is already running in this repository</_NodeRestoreRushLockMessage>
-  </PropertyGroup>
-  <Target Name="_NodeRestoreExecWithRetry">
-    <!-- Buffers BOTH stdout and stderr for the lock-message match, not stderr alone - confirmed
-         empirically (direct concurrent-spawn test against a real Rush workspace) that Rush prints
-         "Another Rush command is already running in this repository." to STDOUT, not stderr. A
-         stderr-only buffer would never detect this condition and would treat every lock conflict
-         as an unconditional real failure instead of retrying - exactly the false-failure scenario
-         this whole mechanism exists to prevent. -->
-    <Exec Command="node -e &quot;const{spawn}=require('child_process');const cmd=process.env.NR_CMD;const cwd=process.env.NR_CWD;const lockMsg=process.env.NR_LOCK_MSG;const delays=[1000,2000,4000,8000,16000];const maxAttempts=45;function run(){return new Promise(function(resolve){const isWin=process.platform==='win32';const shell=isWin?'cmd.exe':'/bin/sh';const args=isWin?['/d','/s','/c',cmd]:['-c',cmd];const child=spawn(shell,args,{cwd:cwd,stdio:['inherit','pipe','pipe']});let outBuf='';child.stdout.on('data',function(d){process.stdout.write(d);outBuf+=d.toString();});child.stderr.on('data',function(d){process.stderr.write(d);outBuf+=d.toString();});child.on('close',function(code){resolve({code:code,outBuf:outBuf});});});}function wait(ms){return new Promise(function(r){setTimeout(r,ms);});}(async function(){let attempt=0;while(true){attempt=attempt+1;const result=await run();if(result.code===0){process.exit(0);}const isLockConflict=result.outBuf.indexOf(lockMsg)!==-1;if(!isLockConflict){process.exit(result.code);}if(attempt&gt;=maxAttempts){console.error('NodeRestore: Rush lock held by another process for over 20 minutes, giving up after '+attempt+' attempts.');process.exit(result.code);}const idx=attempt-1;const delay=idx&lt;delays.length?delays[idx]:30000;console.log('NodeRestore: Rush is busy, retrying ('+attempt+'/'+maxAttempts+') in '+(delay/1000)+'s...');await wait(delay);}})();&quot;"
-          WorkingDirectory="$(_NodeRestoreRetryWorkingDirectory)"
-          EnvironmentVariables="NR_CMD=$(_NodeRestoreRetryCommand);NR_CWD=$(_NodeRestoreRetryWorkingDirectory);NR_LOCK_MSG=$(_NodeRestoreRushLockMessage)"
-          StandardOutputImportance="Low"
-          StandardErrorImportance="High" />
-  </Target>
-
-  <!-- Explicit raw override: run exactly the given command, every build. No incremental
-       caching here - we don't know the shape of a user-supplied command well enough to key an
-       up-to-date check on it, so this mirrors today's "runs every build" npm install behavior. -->
-  <Target Name="_NodeRestoreRunCustom"
-          DependsOnTargets="_NodeRestoreResolve"
-          Condition="'$(NodePackageManager)' != 'None' and '$(NodeRestoreCommand)' != ''">
-    <Exec Command="$(_NodeRestoreResolvedCommand)"
-          WorkingDirectory="$(NodeRestoreProjectDirectory)"
-          StandardOutputImportance="Low"
-          StandardErrorImportance="High" />
-  </Target>
-
-  <!-- Rush is already self-idempotent (state hash vs common/temp/last-install.flag) and
-       self-serializing (its own common/temp/rush#<pid>.lock) - invoke it unconditionally on
-       every build and let Rush's own fast-path absorb the cost. Adding a second, custom
-       stamp-file gate on top of Rush's own would duplicate an incrementality mechanism Rush
-       already owns, and would be a likely source of "not implemented correctly" bugs (our
-       stamp going stale relative to Rush's own state, or vice versa). -->
-  <Target Name="_NodeRestoreRunRush"
-          DependsOnTargets="_NodeRestoreResolve"
-          Condition="'$(NodePackageManager)' != 'None' and '$(NodeRestoreCommand)' == '' and '$(_NodeRestoreResolvedTool)' == 'rush'">
-    <PropertyGroup>
-      <_NodeRestoreRetryCommand>$(_NodeRestoreResolvedCommand)</_NodeRestoreRetryCommand>
-      <_NodeRestoreRetryWorkingDirectory>$(_NodeRestoreWorkspaceRoot)</_NodeRestoreRetryWorkingDirectory>
-    </PropertyGroup>
-    <!-- MSBuild self-invocation, not CallTarget - see the "why" comment on
-         _NodeRestoreExecWithRetry above: this same target also runs from the build-delegation
-         branch later in the same "dotnet build", and CallTarget would silently no-op the second
-         call. -->
-    <MSBuild Projects="$(MSBuildProjectFullPath)"
-             Targets="_NodeRestoreExecWithRetry"
-             Properties="_NodeRestoreRetryCommand=$(_NodeRestoreRetryCommand);_NodeRestoreRetryWorkingDirectory=$(_NodeRestoreRetryWorkingDirectory)" />
-  </Target>
-
-  <!-- Non-Rush tools: gated by Target Inputs/Outputs against a stamp file next to node_modules,
-       keyed on the lockfile (or package.json when no lockfile exists at all). The second,
-       third, ... project sharing the same workspace root in one build sees this target as
-       already up-to-date and skips the Exec entirely - the "once per workspace, not once per
-       project" guarantee from #93.
-       Documented limitation, not solved with a custom lock: concurrent multi-proc MSBuild
-       builds of independent projects sharing one workspace root can still race to invoke
-       install simultaneously, since none of npm/pnpm/yarn/bun ship a cross-process lock of
-       their own (unlike Rush, see above). -->
-  <Target Name="_NodeRestoreRunOther"
-          DependsOnTargets="_NodeRestoreResolve"
-          Condition="'$(NodePackageManager)' != 'None' and '$(NodeRestoreCommand)' == '' and '$(_NodeRestoreResolvedTool)' != 'rush'"
-          Inputs="$(_NodeRestoreLockfilePath)"
-          Outputs="$(_NodeRestoreWorkspaceRoot)/node_modules/.node-restore-stamp">
-    <MakeDir Directories="$(_NodeRestoreWorkspaceRoot)/node_modules" Condition="!Exists('$(_NodeRestoreWorkspaceRoot)/node_modules')" />
-    <Exec Command="$(_NodeRestoreResolvedCommand)"
-          WorkingDirectory="$(_NodeRestoreWorkspaceRoot)"
-          StandardOutputImportance="Low"
-          StandardErrorImportance="High" />
-    <Touch Files="$(_NodeRestoreWorkspaceRoot)/node_modules/.node-restore-stamp" AlwaysCreate="true" />
-  </Target>
+  <Import Project="$(MSBuildThisFileDirectory)NodeRestore\*.targets" />
 
   <!-- NodeRestore explicitly runs _NodeRestoreResolve FIRST (not merely via each branch's own
        DependsOnTargets). MSBuild evaluates a target's own Condition BEFORE running its
        DependsOnTargets, so a Condition referencing a property that only _NodeRestoreResolve sets
        would otherwise see it as still-empty at check time for whichever branch is evaluated
-       first in the list - silently mis-routing every tool (including Rush) into the wrong branch.
-       Listing _NodeRestoreResolve first here guarantees it has already run - and _NodeRestoreResolvedTool
-       etc. are already correct - by the time _NodeRestoreRunRush/_NodeRestoreRunOther's own
-       Conditions are checked. -->
-  <Target Name="NodeRestore" DependsOnTargets="_NodeRestoreResolve;_NodeRestoreRunCustom;_NodeRestoreRunRush;_NodeRestoreRunOther" />
+       first in the list. Listing _NodeRestoreResolve first here guarantees _NodeRestoreResolvedTool
+       etc. are already correct by the time the other targets' own Conditions are checked. -->
+  <Target Name="NodeRestore" DependsOnTargets="_NodeRestoreResolve;_NodeRestoreRunCustom;_NodeRestoreRunRush;_NodeRestoreRunGeneric;_NodeRestoreValidateResolvedCommand" />
 
 </Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/CustomCommand.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/CustomCommand.targets
@@ -1,0 +1,13 @@
+<Project>
+  <!-- Explicit raw override: run exactly the given command, every build. No incremental caching
+       here - an arbitrary user-supplied command isn't well-defined enough to key an up-to-date
+       check on, so this always runs, mirroring plain "npm install" behavior. -->
+  <Target Name="_NodeRestoreRunCustom"
+          DependsOnTargets="_NodeRestoreResolve"
+          Condition="'$(NodePackageManager)' != 'None' and '$(NodeRestoreCommand)' != ''">
+    <Exec Command="$(_NodeRestoreResolvedCommand)"
+          WorkingDirectory="$(NodeRestoreProjectDirectory)"
+          StandardOutputImportance="Low"
+          StandardErrorImportance="High" />
+  </Target>
+</Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Detection.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Detection.targets
@@ -1,0 +1,89 @@
+<Project>
+  <!--
+    Pure resolution - no side effects. Runs once per project build (cheap: a handful of ancestor
+    directory walks), determining which package manager or orchestrator governs this project and
+    what its workspace root is. Tool-specific install/build logic lives in the sibling files in
+    this folder; this file only answers "which tool, and where".
+
+    CI detection mirrors GenerateGitVersion.DetectIsRunningInCI (same property, same env-var
+    list) rather than defining a second notion of "what counts as CI". IsRunningInCI itself is
+    empty unless a consumer sets it explicitly or GenerateVersionNumber already ran and exported
+    it as a property, so this file re-detects independently rather than depending on
+    version-numbering having run first.
+  -->
+  <PropertyGroup>
+    <_NodeRestoreIsCI Condition="'$(IsRunningInCI)'!=''">$(IsRunningInCI)</_NodeRestoreIsCI>
+    <_NodeRestoreIsCI Condition="'$(_NodeRestoreIsCI)'=='' and (
+        '$(CI)'=='true' or
+        '$(TF_BUILD)'=='True' or '$(TF_BUILD)'=='true' or
+        '$(GITHUB_ACTIONS)'=='true' or
+        '$(GITLAB_CI)'=='true' or
+        '$(CIRCLECI)'=='true' or
+        '$(JENKINS_URL)'!='' or
+        '$(TEAMCITY_VERSION)'!='')">true</_NodeRestoreIsCI>
+    <_NodeRestoreIsCI Condition="'$(_NodeRestoreIsCI)'==''">false</_NodeRestoreIsCI>
+  </PropertyGroup>
+
+  <Target Name="_NodeRestoreResolve" Condition="'$(NodePackageManager)' != 'None'">
+
+    <!-- Marker walk-up, in precedence order. Rush is checked first because it is an orchestrator
+         that sits above a package manager, not a package manager itself - a workspace can have
+         both an rush.json and a pnpm-lock.yaml, and Rush must win in that case. Each Condition
+         short-circuits once an earlier one has already matched, so at most one
+         GetDirectoryNameOfFileAbove call actually walks the disk per project in practice. -->
+    <PropertyGroup>
+      <_NodeRestoreRushRoot>$([MSBuild]::GetDirectoryNameOfFileAbove('$(NodeRestoreProjectDirectory)', 'rush.json'))</_NodeRestoreRushRoot>
+      <_NodeRestorePnpmRoot Condition="'$(_NodeRestoreRushRoot)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(NodeRestoreProjectDirectory)', 'pnpm-lock.yaml'))</_NodeRestorePnpmRoot>
+      <_NodeRestoreYarnRoot Condition="'$(_NodeRestoreRushRoot)'=='' and '$(_NodeRestorePnpmRoot)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(NodeRestoreProjectDirectory)', 'yarn.lock'))</_NodeRestoreYarnRoot>
+      <_NodeRestoreBunRoot Condition="'$(_NodeRestoreRushRoot)'=='' and '$(_NodeRestorePnpmRoot)'=='' and '$(_NodeRestoreYarnRoot)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(NodeRestoreProjectDirectory)', 'bun.lockb'))</_NodeRestoreBunRoot>
+      <_NodeRestoreNpmRoot Condition="'$(_NodeRestoreRushRoot)'=='' and '$(_NodeRestorePnpmRoot)'=='' and '$(_NodeRestoreYarnRoot)'=='' and '$(_NodeRestoreBunRoot)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(NodeRestoreProjectDirectory)', 'package-lock.json'))</_NodeRestoreNpmRoot>
+    </PropertyGroup>
+
+    <!-- Auto-detected tool + the root the matching marker was found in. Falls back to plain npm
+         in the project directory itself when nothing is found anywhere above it - the behavior
+         for a bare project with no committed lockfile. -->
+    <PropertyGroup>
+      <_NodeRestoreDetectedTool Condition="'$(_NodeRestoreRushRoot)'!=''">rush</_NodeRestoreDetectedTool>
+      <_NodeRestoreDetectedTool Condition="'$(_NodeRestoreDetectedTool)'=='' and '$(_NodeRestorePnpmRoot)'!=''">pnpm</_NodeRestoreDetectedTool>
+      <_NodeRestoreDetectedTool Condition="'$(_NodeRestoreDetectedTool)'=='' and '$(_NodeRestoreYarnRoot)'!=''">yarn</_NodeRestoreDetectedTool>
+      <_NodeRestoreDetectedTool Condition="'$(_NodeRestoreDetectedTool)'=='' and '$(_NodeRestoreBunRoot)'!=''">bun</_NodeRestoreDetectedTool>
+      <_NodeRestoreDetectedTool Condition="'$(_NodeRestoreDetectedTool)'=='' and '$(_NodeRestoreNpmRoot)'!=''">npm</_NodeRestoreDetectedTool>
+      <_NodeRestoreDetectedTool Condition="'$(_NodeRestoreDetectedTool)'==''">npm</_NodeRestoreDetectedTool>
+
+      <_NodeRestoreDetectedRoot Condition="'$(_NodeRestoreDetectedTool)'=='rush'">$(_NodeRestoreRushRoot)</_NodeRestoreDetectedRoot>
+      <_NodeRestoreDetectedRoot Condition="'$(_NodeRestoreDetectedTool)'=='pnpm'">$(_NodeRestorePnpmRoot)</_NodeRestoreDetectedRoot>
+      <_NodeRestoreDetectedRoot Condition="'$(_NodeRestoreDetectedTool)'=='yarn'">$(_NodeRestoreYarnRoot)</_NodeRestoreDetectedRoot>
+      <_NodeRestoreDetectedRoot Condition="'$(_NodeRestoreDetectedTool)'=='bun'">$(_NodeRestoreBunRoot)</_NodeRestoreDetectedRoot>
+      <_NodeRestoreDetectedRoot Condition="'$(_NodeRestoreDetectedTool)'=='npm' and '$(_NodeRestoreNpmRoot)'!=''">$(_NodeRestoreNpmRoot)</_NodeRestoreDetectedRoot>
+      <_NodeRestoreDetectedRoot Condition="'$(_NodeRestoreDetectedRoot)'==''">$(NodeRestoreProjectDirectory)</_NodeRestoreDetectedRoot>
+    </PropertyGroup>
+
+    <!-- Explicit NodePackageManager overrides the tool choice only - workspace root is still
+         resolved via the same walk-up as auto-detection, so an override doesn't also have to
+         re-specify where the project root lives. -->
+    <PropertyGroup>
+      <_NodeRestoreResolvedTool Condition="'$(NodePackageManager)' != ''">$(NodePackageManager)</_NodeRestoreResolvedTool>
+      <_NodeRestoreResolvedTool Condition="'$(_NodeRestoreResolvedTool)'==''">$(_NodeRestoreDetectedTool)</_NodeRestoreResolvedTool>
+      <_NodeRestoreWorkspaceRoot>$(_NodeRestoreDetectedRoot)</_NodeRestoreWorkspaceRoot>
+
+      <!-- Yarn Berry vs Classic only changes which frozen-install flag applies. -->
+      <_NodeRestoreYarnBerry Condition="'$(_NodeRestoreResolvedTool)'=='yarn' and Exists('$(_NodeRestoreWorkspaceRoot)/.yarnrc.yml')">true</_NodeRestoreYarnBerry>
+    </PropertyGroup>
+
+    <!-- An explicit NodeRestoreCommand always wins over whatever the tool-specific resolution
+         targets below compute, regardless of which one runs. -->
+    <PropertyGroup Condition="'$(NodeRestoreCommand)' != ''">
+      <_NodeRestoreResolvedCommand>$(NodeRestoreCommand)</_NodeRestoreResolvedCommand>
+    </PropertyGroup>
+  </Target>
+
+  <!-- Runs after every tool-specific resolution target (Rush.targets, Generic.targets) has had
+       a chance to set _NodeRestoreResolvedCommand, so it catches any tool/configuration
+       combination none of them produced a command for. -->
+  <Target Name="_NodeRestoreValidateResolvedCommand"
+          DependsOnTargets="_NodeRestoreResolve;_NodeRestoreResolveRush;_NodeRestoreResolveGeneric"
+          Condition="'$(NodePackageManager)' != 'None'">
+    <Error Condition="'$(_NodeRestoreResolvedCommand)' == ''"
+           Text="NodeRestore: could not resolve a Node install command for '$(NodeRestoreProjectDirectory)'. Set the NodeRestoreCommand MSBuild property to the exact command to run, or NodePackageManager=None if dependencies are hydrated externally." />
+  </Target>
+</Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Generic.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Generic.targets
@@ -1,0 +1,77 @@
+<Project>
+  <!-- Resolves the install command and frozen/CI-safe variant for the plain package managers
+       (npm/pnpm/yarn/bun) - the path used whenever no orchestrator like Rush is in play, which is
+       every plain Node/TypeScript/React project without a monorepo tool on top. -->
+  <Target Name="_NodeRestoreResolveGeneric"
+          DependsOnTargets="_NodeRestoreResolve;_NodeRestoreResolveRush"
+          Condition="'$(NodePackageManager)' != 'None' and '$(_NodeRestoreResolvedTool)' != 'rush'">
+
+    <!-- Frozen/CI-safe variant (npm ci, pnpm/yarn/bun's frozen-lockfile flag) requires CI AND an
+         actual lockfile at the resolved root - never CI alone, since that is exactly what makes
+         "npm ci" hard-fail when no lockfile exists. -->
+    <PropertyGroup>
+      <_NodeRestoreHasLockfile Condition="'$(_NodeRestoreResolvedTool)'=='pnpm' and Exists('$(_NodeRestoreWorkspaceRoot)/pnpm-lock.yaml')">true</_NodeRestoreHasLockfile>
+      <_NodeRestoreHasLockfile Condition="'$(_NodeRestoreHasLockfile)'=='' and '$(_NodeRestoreResolvedTool)'=='yarn' and Exists('$(_NodeRestoreWorkspaceRoot)/yarn.lock')">true</_NodeRestoreHasLockfile>
+      <_NodeRestoreHasLockfile Condition="'$(_NodeRestoreHasLockfile)'=='' and '$(_NodeRestoreResolvedTool)'=='bun' and Exists('$(_NodeRestoreWorkspaceRoot)/bun.lockb')">true</_NodeRestoreHasLockfile>
+      <_NodeRestoreHasLockfile Condition="'$(_NodeRestoreHasLockfile)'=='' and '$(_NodeRestoreResolvedTool)'=='npm' and Exists('$(_NodeRestoreWorkspaceRoot)/package-lock.json')">true</_NodeRestoreHasLockfile>
+      <_NodeRestoreHasLockfile Condition="'$(_NodeRestoreHasLockfile)'==''">false</_NodeRestoreHasLockfile>
+
+      <_NodeRestoreUseFrozen Condition="'$(_NodeRestoreIsCI)'=='true' and '$(_NodeRestoreHasLockfile)'=='true'">true</_NodeRestoreUseFrozen>
+      <_NodeRestoreUseFrozen Condition="'$(_NodeRestoreUseFrozen)'==''">false</_NodeRestoreUseFrozen>
+    </PropertyGroup>
+
+    <!-- Single, always-existing incremental-check key for the stamp-gated install target below:
+         the actual lockfile that was matched, or package.json when no lockfile exists anywhere -
+         a single known-to-exist path avoids relying on MSBuild's handling of missing Input
+         files. -->
+    <PropertyGroup>
+      <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreResolvedTool)'=='pnpm' and '$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestoreWorkspaceRoot)/pnpm-lock.yaml</_NodeRestoreLockfilePath>
+      <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreLockfilePath)'=='' and '$(_NodeRestoreResolvedTool)'=='yarn' and '$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestoreWorkspaceRoot)/yarn.lock</_NodeRestoreLockfilePath>
+      <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreLockfilePath)'=='' and '$(_NodeRestoreResolvedTool)'=='bun' and '$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestoreWorkspaceRoot)/bun.lockb</_NodeRestoreLockfilePath>
+      <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreLockfilePath)'=='' and '$(_NodeRestoreResolvedTool)'=='npm' and '$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestoreWorkspaceRoot)/package-lock.json</_NodeRestoreLockfilePath>
+      <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreLockfilePath)'==''">$(_NodeRestoreWorkspaceRoot)/package.json</_NodeRestoreLockfilePath>
+    </PropertyGroup>
+
+    <!-- Command table: local variant / frozen-CI variant per tool. Skipped entirely when an
+         explicit NodeRestoreCommand override already set _NodeRestoreResolvedCommand. -->
+    <PropertyGroup Condition="'$(_NodeRestoreResolvedCommand)'==''">
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='pnpm' and '$(_NodeRestoreUseFrozen)'!='true'">pnpm install</_NodeRestoreResolvedCommand>
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='pnpm' and '$(_NodeRestoreUseFrozen)'=='true'">pnpm install --frozen-lockfile</_NodeRestoreResolvedCommand>
+
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='yarn' and '$(_NodeRestoreUseFrozen)'!='true'">yarn install</_NodeRestoreResolvedCommand>
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='yarn' and '$(_NodeRestoreUseFrozen)'=='true' and '$(_NodeRestoreYarnBerry)'=='true'">yarn install --immutable</_NodeRestoreResolvedCommand>
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='yarn' and '$(_NodeRestoreUseFrozen)'=='true' and '$(_NodeRestoreYarnBerry)'!='true'">yarn install --frozen-lockfile</_NodeRestoreResolvedCommand>
+
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='bun' and '$(_NodeRestoreUseFrozen)'!='true'">bun install</_NodeRestoreResolvedCommand>
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='bun' and '$(_NodeRestoreUseFrozen)'=='true'">bun install --frozen-lockfile</_NodeRestoreResolvedCommand>
+
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='npm' and '$(_NodeRestoreUseFrozen)'!='true'">npm install</_NodeRestoreResolvedCommand>
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedTool)'=='npm' and '$(_NodeRestoreUseFrozen)'=='true'">npm ci</_NodeRestoreResolvedCommand>
+    </PropertyGroup>
+
+    <Warning Condition="'$(NodeRestoreCommand)'=='' and '$(_NodeRestoreIsCI)'=='true' and '$(_NodeRestoreResolvedTool)'=='npm' and '$(_NodeRestoreHasLockfile)'!='true'"
+             Text="NodeRestore: running in CI with no package-lock.json found at '$(_NodeRestoreWorkspaceRoot)' - falling back to 'npm install' instead of the reproducible, cache-friendly 'npm ci'. Commit a lockfile to fix this." />
+  </Target>
+
+  <!-- Gated by Target Inputs/Outputs against a stamp file next to node_modules, keyed on the
+       lockfile (or package.json when no lockfile exists at all). A second project sharing the
+       same workspace root in one build sees this target as already up-to-date and skips the
+       Exec entirely, so a shared workspace's install runs once per build, not once per project.
+
+       Documented limitation, not solved with a custom lock: concurrent multi-process MSBuild
+       builds of independent projects sharing one workspace root can still race to invoke install
+       simultaneously, since none of npm/pnpm/yarn/bun ship a cross-process lock of their own
+       (unlike Rush, see Rush.targets/Retry.targets). -->
+  <Target Name="_NodeRestoreRunGeneric"
+          DependsOnTargets="_NodeRestoreResolveGeneric"
+          Condition="'$(NodePackageManager)' != 'None' and '$(NodeRestoreCommand)' == '' and '$(_NodeRestoreResolvedTool)' != 'rush'"
+          Inputs="$(_NodeRestoreLockfilePath)"
+          Outputs="$(_NodeRestoreWorkspaceRoot)/node_modules/.node-restore-stamp">
+    <MakeDir Directories="$(_NodeRestoreWorkspaceRoot)/node_modules" Condition="!Exists('$(_NodeRestoreWorkspaceRoot)/node_modules')" />
+    <Exec Command="$(_NodeRestoreResolvedCommand)"
+          WorkingDirectory="$(_NodeRestoreWorkspaceRoot)"
+          StandardOutputImportance="Low"
+          StandardErrorImportance="High" />
+    <Touch Files="$(_NodeRestoreWorkspaceRoot)/node_modules/.node-restore-stamp" AlwaysCreate="true" />
+  </Target>
+</Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Generic.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Generic.targets
@@ -20,16 +20,21 @@
       <_NodeRestoreUseFrozen Condition="'$(_NodeRestoreUseFrozen)'==''">false</_NodeRestoreUseFrozen>
     </PropertyGroup>
 
-    <!-- Single, always-existing incremental-check key for the stamp-gated install target below:
-         the actual lockfile that was matched, or package.json when no lockfile exists anywhere -
-         a single known-to-exist path avoids relying on MSBuild's handling of missing Input
-         files. -->
+    <!-- Incremental-check keys for the stamp-gated install target below:
+         - this project's own package.json, so dependency-manifest edits always re-run hydration;
+         - the matched lockfile too when one exists, so lockfile changes also invalidate the stamp.
+         The stamp itself lives at the workspace root (not under node_modules) so package managers
+         that do not create node_modules, e.g. Yarn Berry PnP, stay side-effect-free until the
+         actual install command runs. -->
     <PropertyGroup>
+      <_NodeRestorePackageJsonPath>$(NodeRestoreProjectDirectory)/package.json</_NodeRestorePackageJsonPath>
       <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreResolvedTool)'=='pnpm' and '$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestoreWorkspaceRoot)/pnpm-lock.yaml</_NodeRestoreLockfilePath>
       <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreLockfilePath)'=='' and '$(_NodeRestoreResolvedTool)'=='yarn' and '$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestoreWorkspaceRoot)/yarn.lock</_NodeRestoreLockfilePath>
       <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreLockfilePath)'=='' and '$(_NodeRestoreResolvedTool)'=='bun' and '$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestoreWorkspaceRoot)/bun.lockb</_NodeRestoreLockfilePath>
       <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreLockfilePath)'=='' and '$(_NodeRestoreResolvedTool)'=='npm' and '$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestoreWorkspaceRoot)/package-lock.json</_NodeRestoreLockfilePath>
-      <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreLockfilePath)'==''">$(_NodeRestoreWorkspaceRoot)/package.json</_NodeRestoreLockfilePath>
+      <_NodeRestoreIncrementalInputs>$(_NodeRestorePackageJsonPath)</_NodeRestoreIncrementalInputs>
+      <_NodeRestoreIncrementalInputs Condition="'$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestorePackageJsonPath);$(_NodeRestoreLockfilePath)</_NodeRestoreIncrementalInputs>
+      <_NodeRestoreStampPath>$(_NodeRestoreWorkspaceRoot)/.node-restore.stamp</_NodeRestoreStampPath>
     </PropertyGroup>
 
     <!-- Command table: local variant / frozen-CI variant per tool. Skipped entirely when an
@@ -65,13 +70,12 @@
   <Target Name="_NodeRestoreRunGeneric"
           DependsOnTargets="_NodeRestoreResolveGeneric"
           Condition="'$(NodePackageManager)' != 'None' and '$(NodeRestoreCommand)' == '' and '$(_NodeRestoreResolvedTool)' != 'rush'"
-          Inputs="$(_NodeRestoreLockfilePath)"
-          Outputs="$(_NodeRestoreWorkspaceRoot)/node_modules/.node-restore-stamp">
-    <MakeDir Directories="$(_NodeRestoreWorkspaceRoot)/node_modules" Condition="!Exists('$(_NodeRestoreWorkspaceRoot)/node_modules')" />
+          Inputs="$(_NodeRestoreIncrementalInputs)"
+          Outputs="$(_NodeRestoreStampPath)">
     <Exec Command="$(_NodeRestoreResolvedCommand)"
           WorkingDirectory="$(_NodeRestoreWorkspaceRoot)"
           StandardOutputImportance="Low"
           StandardErrorImportance="High" />
-    <Touch Files="$(_NodeRestoreWorkspaceRoot)/node_modules/.node-restore-stamp" AlwaysCreate="true" />
+    <Touch Files="$(_NodeRestoreStampPath)" AlwaysCreate="true" />
   </Target>
 </Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Retry.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Retry.targets
@@ -1,0 +1,49 @@
+<Project>
+  <!--
+    Shared retry-on-lock-contention helper, used by both the Rush install/update branch
+    (Rush.targets) and the Rush build-delegation branch used by Pcf/ScriptLibrary/CodeApp.
+
+    Rush's own whole-repo lock (common/temp/rush#<pid>.lock) is fail-fast, not queue-based: a
+    second concurrent Rush invocation - install/update or build, both acquire the same lock -
+    errors immediately with "Another Rush command is already running in this repository" instead
+    of waiting its turn. That is exactly the shape multiple MSBuild projects, or a solution-level
+    parallel build, create once every Rush-registered project's restore and build both route
+    through Rush. Rather than inventing a separate cross-process lock, this target retries with
+    backoff whenever it recognizes Rush's own lock message: whichever invocation wins already
+    does the complete job for the entire Rush workspace, so a retry after the winner finishes is
+    either an instant no-op (Rush's own incremental-skip already satisfied) or, worst case, just
+    waits out real work already happening on its behalf.
+
+    One retry budget serves both call sites (install/update and build), since a single unscoped
+    "rush build"/"rush update" per solution-scope invocation gives both the same risk profile:
+    the first invocation does the real work, every other invocation gets a fast no-op.
+  -->
+  <PropertyGroup>
+    <_NodeRestoreRushLockMessage>Another Rush command is already running in this repository</_NodeRestoreRushLockMessage>
+  </PropertyGroup>
+
+  <!--
+    Callers set _NodeRestoreRetryCommand/_NodeRestoreRetryWorkingDirectory and invoke this target
+    via the MSBuild task (self-invocation of $(MSBuildProjectFullPath)), not CallTarget. A single
+    build can legitimately need to run this target twice - once for restore-hydration
+    (_NodeRestoreRunRush) and once for build delegation - each with a different command/working
+    directory. MSBuild only executes a given target name once per project build no matter how
+    many times CallTarget references it, so a second CallTarget call would silently no-op instead
+    of running with the new property values. Invoking via the MSBuild task with an explicit
+    Properties list creates a distinct build request each time, which MSBuild always executes
+    fresh.
+
+    The actual retry/backoff loop and process spawning is implemented by the ExecWithRetry task
+    (Tasks/ExecWithRetry.cs) rather than as an inline script, matching how every other piece of
+    custom build logic in this repo is a C# MSBuild task. Output is streamed live at Low
+    importance during the run, then the full buffered stdout+stderr is re-logged at High
+    importance if the command ultimately fails, so a default-verbosity build still shows the real
+    underlying error instead of just an exit code.
+  -->
+  <Target Name="_NodeRestoreExecWithRetry">
+    <ExecWithRetry Command="$(_NodeRestoreRetryCommand)"
+                   WorkingDirectory="$(_NodeRestoreRetryWorkingDirectory)"
+                   EnvironmentVariables="$(_NodeRestoreRetryEnvironmentVariables)"
+                   LockMessage="$(_NodeRestoreRushLockMessage)" />
+  </Target>
+</Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Rush.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Rush.targets
@@ -1,0 +1,74 @@
+<Project>
+  <!-- Rush is a monorepo orchestrator, not a package manager: it delegates the actual dependency
+       install to pnpm underneath and adds its own workspace-wide state tracking, locking, and
+       build-graph on top. This file only handles the orchestrator-specific concerns - workspace
+       registration and the install/update command - kept separate from Generic.targets, which
+       handles package managers proper (npm/pnpm/yarn/bun). -->
+  <Target Name="_NodeRestoreResolveRush"
+          DependsOnTargets="_NodeRestoreResolve"
+          Condition="'$(NodePackageManager)' != 'None' and '$(_NodeRestoreResolvedTool)' == 'rush'">
+
+    <!-- A project can legitimately sit under a Rush-marked directory tree before its own
+         package.json has been added to rush.json's "projects" array - a normal state during
+         incremental adoption, not a misconfiguration. This is checked proactively here (a
+         lightweight substring check for the project's relative path inside rush.json, not a full
+         JSON parse - a false negative only costs an extra graceful-fallback warning, not a
+         silent incorrectness) rather than reactively from a failed Rush command, because once
+         build delegation routes through an unscoped "rush build", Rush silently skips any
+         unregistered project instead of erroring - a failed-command check could no longer detect
+         this case at all. Checked once, here, so both this restore branch and the build-
+         delegation branch downstream share the same answer. -->
+    <PropertyGroup>
+      <_NodeRestoreRushRelativeDir>$([MSBuild]::MakeRelative('$(_NodeRestoreWorkspaceRoot)\', '$(NodeRestoreProjectDirectory)\'))</_NodeRestoreRushRelativeDir>
+      <_NodeRestoreRushRelativeDir>$(_NodeRestoreRushRelativeDir.Replace('\', '/').TrimEnd('/'))</_NodeRestoreRushRelativeDir>
+      <_NodeRestoreRushJsonText Condition="Exists('$(_NodeRestoreWorkspaceRoot)/rush.json')">$([System.IO.File]::ReadAllText('$(_NodeRestoreWorkspaceRoot)/rush.json'))</_NodeRestoreRushJsonText>
+      <_NodeRestoreIsRushRegistered Condition="'$(_NodeRestoreRushJsonText)' != '' and $(_NodeRestoreRushJsonText.Contains('&quot;$(_NodeRestoreRushRelativeDir)&quot;'))">true</_NodeRestoreIsRushRegistered>
+      <_NodeRestoreIsRushRegistered Condition="'$(_NodeRestoreIsRushRegistered)' == ''">false</_NodeRestoreIsRushRegistered>
+    </PropertyGroup>
+
+    <Warning Condition="'$(_NodeRestoreIsRushRegistered)' == 'false'"
+             Text="NodeRestore: '$(NodeRestoreProjectDirectory)' sits under a Rush workspace ('$(_NodeRestoreWorkspaceRoot)/rush.json') but is not yet listed in its 'projects' array - falling back to a direct npm install/build for this project instead of Rush. Add it to rush.json to have Rush manage (and cache) it." />
+
+    <!-- Not registered yet: fall back to plain npm, scoped to this project's own directory. An
+         unregistered project is legitimately mid-incremental-adoption, which this SDK cannot
+         distinguish from "forgot to register it", so this is a graceful downgrade rather than a
+         hard failure (unlike PCF's command-line.json declaration check, which is a genuine
+         misconfiguration and does hard-fail). -->
+    <PropertyGroup Condition="'$(_NodeRestoreIsRushRegistered)' != 'true'">
+      <_NodeRestoreResolvedTool>npm</_NodeRestoreResolvedTool>
+      <_NodeRestoreWorkspaceRoot>$(NodeRestoreProjectDirectory)</_NodeRestoreWorkspaceRoot>
+    </PropertyGroup>
+
+    <!-- Rush always counts as having a lockfile equivalent for CI/frozen purposes - its own
+         install-run-rush.js already enforces install-vs-update semantics internally. -->
+    <PropertyGroup Condition="'$(_NodeRestoreResolvedTool)' == 'rush'">
+      <_NodeRestoreHasLockfile>true</_NodeRestoreHasLockfile>
+      <_NodeRestoreUseFrozen Condition="'$(_NodeRestoreIsCI)'=='true'">true</_NodeRestoreUseFrozen>
+      <_NodeRestoreUseFrozen Condition="'$(_NodeRestoreUseFrozen)'==''">false</_NodeRestoreUseFrozen>
+
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedCommand)'=='' and '$(_NodeRestoreUseFrozen)'!='true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" update</_NodeRestoreResolvedCommand>
+      <_NodeRestoreResolvedCommand Condition="'$(_NodeRestoreResolvedCommand)'=='' and '$(_NodeRestoreUseFrozen)'=='true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" install</_NodeRestoreResolvedCommand>
+    </PropertyGroup>
+  </Target>
+
+  <!-- Rush is already self-idempotent (state hash vs common/temp/last-install.flag) and
+       self-serializing (its own common/temp/rush#<pid>.lock) - invoke it unconditionally on
+       every build and let Rush's own fast path absorb the cost. A second, custom stamp-file gate
+       on top of Rush's own would duplicate an incrementality mechanism Rush already owns, and
+       would risk our stamp going stale relative to Rush's own state. -->
+  <Target Name="_NodeRestoreRunRush"
+          DependsOnTargets="_NodeRestoreResolveRush"
+          Condition="'$(NodePackageManager)' != 'None' and '$(NodeRestoreCommand)' == '' and '$(_NodeRestoreResolvedTool)' == 'rush'">
+    <PropertyGroup>
+      <_NodeRestoreRetryCommand>$(_NodeRestoreResolvedCommand)</_NodeRestoreRetryCommand>
+      <_NodeRestoreRetryWorkingDirectory>$(_NodeRestoreWorkspaceRoot)</_NodeRestoreRetryWorkingDirectory>
+    </PropertyGroup>
+    <!-- MSBuild self-invocation, not CallTarget - see the "why" comment on
+         _NodeRestoreExecWithRetry in Retry.targets: this same target also runs from the build-
+         delegation branch later in the same build, and CallTarget would silently no-op the
+         second call. -->
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="_NodeRestoreExecWithRetry"
+             Properties="_NodeRestoreRetryCommand=$(_NodeRestoreRetryCommand);_NodeRestoreRetryWorkingDirectory=$(_NodeRestoreRetryWorkingDirectory)" />
+  </Target>
+</Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Rush.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Rush.targets
@@ -19,8 +19,10 @@
          this case at all. Checked once, here, so both this restore branch and the build-
          delegation branch downstream share the same answer. -->
     <PropertyGroup>
-      <_NodeRestoreRushRelativeDir>$([MSBuild]::MakeRelative('$(_NodeRestoreWorkspaceRoot)\', '$(NodeRestoreProjectDirectory)\'))</_NodeRestoreRushRelativeDir>
-      <_NodeRestoreRushRelativeDir>$(_NodeRestoreRushRelativeDir.Replace('\', '/').TrimEnd('/'))</_NodeRestoreRushRelativeDir>
+      <_NodeRestoreRushWorkspaceRootNormalized>$([System.String]::Copy('$(_NodeRestoreWorkspaceRoot)').Replace('\', '/').TrimEnd('/'))</_NodeRestoreRushWorkspaceRootNormalized>
+      <_NodeRestoreRushProjectDirectoryNormalized>$([System.String]::Copy('$(NodeRestoreProjectDirectory)').Replace('\', '/').TrimEnd('/'))</_NodeRestoreRushProjectDirectoryNormalized>
+      <_NodeRestoreRushRelativeDir>$([MSBuild]::MakeRelative('$(_NodeRestoreRushWorkspaceRootNormalized)/', '$(_NodeRestoreRushProjectDirectoryNormalized)'))</_NodeRestoreRushRelativeDir>
+      <_NodeRestoreRushRelativeDir>$([System.String]::Copy('$(_NodeRestoreRushRelativeDir)').Replace('\', '/').TrimEnd('/'))</_NodeRestoreRushRelativeDir>
       <_NodeRestoreRushJsonText Condition="Exists('$(_NodeRestoreWorkspaceRoot)/rush.json')">$([System.IO.File]::ReadAllText('$(_NodeRestoreWorkspaceRoot)/rush.json'))</_NodeRestoreRushJsonText>
       <_NodeRestoreIsRushRegistered Condition="'$(_NodeRestoreRushJsonText)' != '' and $(_NodeRestoreRushJsonText.Contains('&quot;$(_NodeRestoreRushRelativeDir)&quot;'))">true</_NodeRestoreIsRushRegistered>
       <_NodeRestoreIsRushRegistered Condition="'$(_NodeRestoreIsRushRegistered)' == ''">false</_NodeRestoreIsRushRegistered>


### PR DESCRIPTION
## Summary

Adds shared Node dependency restore and build orchestration for `Pcf`, `ScriptLibrary`, and `CodeApp` projects in the SDK, so plain `dotnet restore`, `dotnet build`, and `dotnet clean` handle their Node side too.

A single `NodeBuildConfiguration` signal drives build mode consistently across all three project types: Debug maps to `development`, Release maps to `production`, and developers do not pass Node-specific flags manually.

## What changed

- adds shared `NodeRestore` and `NodeBuild` MSBuild targets plus a reusable `ExecWithRetry` task
- auto-detects the governing workspace/tool from the project path and hydrates dependencies at project, solution, and repo-root restore scope
- delegates restore and build through Rush for `rush.json`-registered projects, using Rush's own incrementality/cache and forwarding the build mode via the required kebab-case `--build-mode` custom parameter in `common/config/rush/command-line.json`
- gracefully falls back to direct `npm install` / `npm run build` when a project lives under a Rush repo but is not yet registered in `rush.json`, supporting incremental adoption
- keeps non-Rush installs CI-safe with frozen lockfile behavior where available, adds clean parity for ScriptLibrary/CodeApp build outputs, and documents the consumer setup in `docs/NodeDependencies.md` / `docs/BuildProcess.md`

## Validation

Validated against the downstream `INT0015` FileExplorer migration and dedicated fixtures, including clean-clone restore, Debug/Release output, Rush and non-Rush builds, parallel builds, and project-reference scenarios.

Closes #88
Closes #90
Closes #93
