### PR TITLE
fix: run schema validation on solution builds and disable plugin auto-pack

### DIFF
--- a/src/Dataverse/Plugin/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Plugin.targets
+++ b/src/Dataverse/Plugin/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Plugin.targets
@@ -24,6 +24,8 @@
        BeforePack (rather than BeforeTargets="Pack") fails before any nuspec/nupkg work starts. -->
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <BeforePack>$(BeforePack);_ErrorOnPluginPack</BeforePack>
   </PropertyGroup>
   <Target Name="_ErrorOnPluginPack">

--- a/src/Dataverse/Plugin/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Plugin.targets
+++ b/src/Dataverse/Plugin/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Plugin.targets
@@ -24,6 +24,7 @@
        BeforePack (rather than BeforeTargets="Pack") fails before any nuspec/nupkg work starts. -->
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+
     <BeforePack>$(BeforePack);_ErrorOnPluginPack</BeforePack>
   </PropertyGroup>
   <Target Name="_ErrorOnPluginPack">

--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.targets
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.targets
@@ -48,9 +48,14 @@
         MetadataWorkingDirectory="$(SolutionPackagerMetadataWorkingDirectory)" />
   </Target>
   
-<!-- XSD schema validation of solution components. Not wired automatically.
-       Invoke explicitly: dotnet msbuild -t:InitializeSolutionPackagerWorkingDirectory;ValidateSolutionComponentSchema
-       The actual validation logic is defined in the Tasks package (ValidateSolutionComponentSchema.targets). -->
+  <!-- Runs after ProcessCds / before PowerAppsPackage; validates solution component files against
+       the embedded XSD/JSON schemas (ValidateSolutionComponentSchema from the Tasks package).
+       Opt out: set SkipSchemaValidation=true. -->
+  <Target Name="_ValidateSolutionComponentSchemaBeforePackage"
+          AfterTargets="ProcessCdsProjectReferencesOutputs"
+          BeforeTargets="PowerAppsPackage"
+          DependsOnTargets="ValidateSolutionComponentSchema"
+          Condition="'$(SkipSchemaValidation)' != 'true' and Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\Solution.xml')" />
 
   <!-- Runs after ProcessCds / before PowerAppsPackage; validates no duplicate GUIDs.
        Opt out: set SkipDuplicateGuidValidation=true. -->

--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.targets
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.targets
@@ -48,9 +48,14 @@
         MetadataWorkingDirectory="$(SolutionPackagerMetadataWorkingDirectory)" />
   </Target>
   
-<!-- XSD schema validation of solution components. Not wired automatically.
-       Invoke explicitly: dotnet msbuild -t:InitializeSolutionPackagerWorkingDirectory;ValidateSolutionComponentSchema
-       The actual validation logic is defined in the Tasks package (ValidateSolutionComponentSchema.targets). -->
+  <!-- Runs after ProcessCds / before PowerAppsPackage; validates solution component files against
+       the embedded XSD/JSON schemas (ValidateSolutionComponentSchema from the Tasks package).
+       Opt out: set SkipSchemaValidation=true. -->
+  <Target Name="_ValidateSolutionComponentSchemaBeforePackage"
+          AfterTargets="ProcessCdsProjectReferencesOutputs"
+          BeforeTargets="PowerAppsPackage"
+          DependsOnTargets="ValidateSolutionComponentSchema"
+          Condition="'$(SkipSchemaValidation)' != 'true' and Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\Solution.xml')" />
 
   <!-- Runs after ProcessCds / before PowerAppsPackage; validates no duplicate GUIDs.
        Opt out: set SkipDuplicateGuidValidation=true. -->
@@ -67,6 +72,15 @@
           BeforeTargets="PowerAppsPackage"
           DependsOnTargets="ValidateQuickFindViews"
           Condition="'$(SkipQuickFindValidation)' != 'true' and Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\Solution.xml')" />
+
+  <!-- Runs after ProcessCds / before PowerAppsPackage; validates the manifest against the component
+       files on disk. Solution-scoped only, so it stays quiet on a normal build.
+       Opt out: set SkipSolutionManifestValidation=true. -->
+  <Target Name="_ValidateSolutionManifestBeforePackage"
+          AfterTargets="ProcessCdsProjectReferencesOutputs"
+          BeforeTargets="PowerAppsPackage"
+          DependsOnTargets="ValidateSolutionManifest"
+          Condition="'$(SkipSolutionManifestValidation)' != 'true' and Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\Solution.xml')" />
 
     <!--  Data update in solution.xml logic  -->
     <Import Project="$(MSBuildThisFileDirectory)TALXIS.DevKit.Build.Dataverse.Solution.Data.targets"

--- a/src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj
+++ b/src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj
@@ -23,7 +23,7 @@
         <!--<PackageReference Include="LibGit2Sharp" Version="0.26.2" />-->
         <PackageReference Include="Microsoft.Build" Version="18.0.2" />
         <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
-        <PackageReference Include="TALXIS.Platform.Metadata" Version="0.8.0" />
+               <PackageReference Include="TALXIS.Platform.Metadata" Version="0.8.0" />
         <PackageReference Include="TALXIS.Platform.Metadata.Validation" Version="0.8.0" />
         <PackageReference Include="TALXIS.Platform.Metadata.Serialization.Xml" Version="0.8.0" />
         <PackageReference Include="TALXIS.Platform.Metadata.Packaging" Version="0.8.0" />

--- a/src/Dataverse/Tasks/Tasks/ValidateSolutionManifest.cs
+++ b/src/Dataverse/Tasks/Tasks/ValidateSolutionManifest.cs
@@ -1,0 +1,67 @@
+using System;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using TALXIS.Platform.Metadata.Serialization.Xml;
+using TALXIS.Platform.Metadata.Validation;
+
+public class ValidateSolutionManifest : Task
+{
+    [Required]
+    public string SolutionRoot { get; set; }
+
+    public override bool Execute()
+    {
+        try
+        {
+            if (!Directory.Exists(SolutionRoot))
+            {
+                Log.LogError($"ValidateSolutionManifest: directory not found: {SolutionRoot}");
+                return false;
+            }
+
+            var workspace = new XmlWorkspaceReader().Load(SolutionRoot);
+            var results = new SolutionManifestValidator().Validate(workspace);
+
+            foreach (var result in results)
+            {
+                var line = result.Line ?? 0;
+                var col = result.Column ?? 0;
+
+                if (result.Severity == ValidationSeverity.Error)
+                {
+                    Log.LogError(
+                        subcategory: "manifest",
+                        errorCode: result.Code,
+                        helpKeyword: null,
+                        file: result.FilePath ?? SolutionRoot,
+                        lineNumber: line,
+                        columnNumber: col,
+                        endLineNumber: 0,
+                        endColumnNumber: 0,
+                        message: result.Message);
+                }
+                else
+                {
+                    Log.LogWarning(
+                        subcategory: "manifest",
+                        warningCode: result.Code,
+                        helpKeyword: null,
+                        file: result.FilePath ?? SolutionRoot,
+                        lineNumber: line,
+                        columnNumber: col,
+                        endLineNumber: 0,
+                        endColumnNumber: 0,
+                        message: result.Message);
+                }
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+        catch (Exception ex)
+        {
+            Log.LogErrorFromException(ex);
+            return false;
+        }
+    }
+}

--- a/src/Dataverse/Tasks/msbuild/tasks/Props/SolutionFileItems.props
+++ b/src/Dataverse/Tasks/msbuild/tasks/Props/SolutionFileItems.props
@@ -1,27 +1,9 @@
 <Project>
+    <!-- Solution component file globs moved into ValidateSolutionComponentSchema.targets so they
+         expand at execution time, after the working directory is populated. -->
     <ItemGroup>
         <SolutionXml Include="$(SolutionPackagerMetadataWorkingDirectory)\Other\Solution.xml"/>
-        <EntityMaps Include="$(SolutionPackagerMetadataWorkingDirectory)\Other\EntityMaps.xml" Condition="Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\EntityMaps.xml')"/>
-        <AppModules Include="$(SolutionPackagerMetadataWorkingDirectory)\AppModules\*\*.xml"/>
-        <Sitemaps Include="$(SolutionPackagerMetadataWorkingDirectory)\AppModuleSiteMaps\*\*.xml"/>
-        <FormXmlDefinitions Include="$(SolutionPackagerMetadataWorkingDirectory)\Entities\*\FormXml\*\*.xml"/>
-        <DialogDefinitions Include="$(SolutionPackagerMetadataWorkingDirectory)\Dialogs\*.xml"/>
-        <EntityRibbons Include="$(SolutionPackagerMetadataWorkingDirectory)\Entities\*\RibbonDiff.xml"/>
-        <GlobalRibbons Include="$(SolutionPackagerMetadataWorkingDirectory)\Other\RibbonCustomization.xml" Condition="Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\RibbonCustomization.xml')"/>
-        <EntityXmlDefinitions Include="$(SolutionPackagerMetadataWorkingDirectory)\Entities\*\Entity.xml"/>
-        <EntityRelationships Include="$(SolutionPackagerMetadataWorkingDirectory)\Other\Relationships\*.xml"/>
-        <OptionSets Include="$(SolutionPackagerMetadataWorkingDirectory)\OptionSets\**\*.xml"/>
-        <SavedQueries Include="$(SolutionPackagerMetadataWorkingDirectory)\Entities\*\SavedQueries\*.xml" />
         <WorkflowMetadata Include="$(SolutionPackagerMetadataWorkingDirectory)\Workflows\*.xaml"/>
-        <SdkMessageProcessingSteps Include="$(SolutionPackagerMetadataWorkingDirectory)\SdkMessageProcessingSteps\*.xml"/>
-        <WorkflowMetadataFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\Workflows\*.data.xml"/>
-        <PluginAssemblyMetadataFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\PluginAssemblies\*\*.dll.data.xml"/>
-        <WebResourceMetadataFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\WebResources\**\*.data.xml"/>
-        <ConnectionRoles Include="$(SolutionPackagerMetadataWorkingDirectory)\Other\ConnectionRoles.xml" Condition="Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\ConnectionRoles.xml')"/>
-        <SecurityRoles Include="$(SolutionPackagerMetadataWorkingDirectory)\Roles\*.xml"/>
-        <FieldSecurityProfiles Include="$(SolutionPackagerMetadataWorkingDirectory)\Other\FieldSecurityProfiles.xml" Condition="Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\FieldSecurityProfiles.xml')"/>
-        <Flows Include="$(SolutionPackagerMetadataWorkingDirectory)\Workflows\*.json"/>
-        <EnvironmentVariables Include="$(SolutionPackagerMetadataWorkingDirectory)\environmentvariabledefinitions\**\environmentvariabledefinition.xml"/>
         <ResxFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\Resources\**\*.resx"/>
 
         <ControlsMetadataFolder Include="$(SolutionPackagerMetadataWorkingDirectory)\Controls\"/>

--- a/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Tasks.targets
@@ -13,6 +13,13 @@
         <TasksAssembly>$(ThisPackageBuildExtensionsDirectory)$(MSBuildThisFileName).dll</TasksAssembly>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(SkipValidation)' == 'true'">
+        <SkipSchemaValidation Condition="'$(SkipSchemaValidation)' == ''">true</SkipSchemaValidation>
+        <SkipDuplicateGuidValidation Condition="'$(SkipDuplicateGuidValidation)' == ''">true</SkipDuplicateGuidValidation>
+        <SkipQuickFindValidation Condition="'$(SkipQuickFindValidation)' == ''">true</SkipQuickFindValidation>
+        <SkipPcfDependencyValidation Condition="'$(SkipPcfDependencyValidation)' == ''">true</SkipPcfDependencyValidation>
+    </PropertyGroup>
+
 
     <UsingTask TaskName="GenerateGitVersion" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
     <UsingTask TaskName="ApplyVersionNumber" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
@@ -39,6 +46,7 @@
     <UsingTask TaskName="EnsureAllCustomizationsNodes" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
     <UsingTask TaskName="ValidatePcfDependencies" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
     <UsingTask TaskName="ValidateWorkspace" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
+    <UsingTask TaskName="ValidateSolutionManifest" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
     <UsingTask TaskName="PatchGenPageCompiledCode" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
     <UsingTask TaskName="GenerateGenPageConfigJson" AssemblyFile="$(TasksAssembly)" Runtime="NET" />
     <UsingTask TaskName="GenerateGenPageProjectXml" AssemblyFile="$(TasksAssembly)" Runtime="NET" />

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/ValidateSolutionComponentSchema.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/ValidateSolutionComponentSchema.targets
@@ -1,5 +1,29 @@
 <Project>
     <Target Name="ValidateSolutionComponentSchema">
+        <!-- Globs must expand at execution time: the working directory is populated during the
+             build, after static item evaluation. -->
+        <ItemGroup>
+            <EntityMaps Include="$(SolutionPackagerMetadataWorkingDirectory)\Other\EntityMaps.xml" Condition="Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\EntityMaps.xml')"/>
+            <AppModules Include="$(SolutionPackagerMetadataWorkingDirectory)\AppModules\*\*.xml"/>
+            <Sitemaps Include="$(SolutionPackagerMetadataWorkingDirectory)\AppModuleSiteMaps\*\*.xml"/>
+            <FormXmlDefinitions Include="$(SolutionPackagerMetadataWorkingDirectory)\Entities\*\FormXml\*\*.xml"/>
+            <DialogDefinitions Include="$(SolutionPackagerMetadataWorkingDirectory)\Dialogs\*.xml"/>
+            <EntityRibbons Include="$(SolutionPackagerMetadataWorkingDirectory)\Entities\*\RibbonDiff.xml"/>
+            <GlobalRibbons Include="$(SolutionPackagerMetadataWorkingDirectory)\Other\RibbonCustomization.xml" Condition="Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\RibbonCustomization.xml')"/>
+            <EntityXmlDefinitions Include="$(SolutionPackagerMetadataWorkingDirectory)\Entities\*\Entity.xml"/>
+            <EntityRelationships Include="$(SolutionPackagerMetadataWorkingDirectory)\Other\Relationships\*.xml"/>
+            <OptionSets Include="$(SolutionPackagerMetadataWorkingDirectory)\OptionSets\**\*.xml"/>
+            <SavedQueries Include="$(SolutionPackagerMetadataWorkingDirectory)\Entities\*\SavedQueries\*.xml" />
+            <SdkMessageProcessingSteps Include="$(SolutionPackagerMetadataWorkingDirectory)\SdkMessageProcessingSteps\*.xml"/>
+            <WorkflowMetadataFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\Workflows\*.data.xml"/>
+            <PluginAssemblyMetadataFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\PluginAssemblies\*\*.dll.data.xml"/>
+            <WebResourceMetadataFiles Include="$(SolutionPackagerMetadataWorkingDirectory)\WebResources\**\*.data.xml"/>
+            <ConnectionRoles Include="$(SolutionPackagerMetadataWorkingDirectory)\Other\ConnectionRoles.xml" Condition="Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\ConnectionRoles.xml')"/>
+            <SecurityRoles Include="$(SolutionPackagerMetadataWorkingDirectory)\Roles\*.xml"/>
+            <FieldSecurityProfiles Include="$(SolutionPackagerMetadataWorkingDirectory)\Other\FieldSecurityProfiles.xml" Condition="Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\FieldSecurityProfiles.xml')"/>
+            <Flows Include="$(SolutionPackagerMetadataWorkingDirectory)\Workflows\*.json"/>
+            <EnvironmentVariables Include="$(SolutionPackagerMetadataWorkingDirectory)\environmentvariabledefinitions\**\environmentvariabledefinition.xml"/>
+        </ItemGroup>
         <ItemGroup>
             <XmlFilesToBeValidated Include="@(SolutionXml);@(AppModules);@(Sitemaps);@(EntityXmlDefinitions);@(EntityRelationships);@(OptionSets);@(EntityRibbons);@(GlobalRibbons);@(FormXmlDefinitions);@(DialogDefinitions);@(SavedQueries);@(WorkflowMetadataFiles);@(PluginAssemblyMetadataFiles);@(SdkMessageProcessingSteps);@(WebResourceMetadataFiles);@(EnvironmentVariables);@(EntityMaps);@(SecurityRoles);@(FieldSecurityProfiles);@(ConnectionRoles)" />
         </ItemGroup>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/ValidateSolutionManifest.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/ValidateSolutionManifest.targets
@@ -1,0 +1,13 @@
+<Project>
+    <Target Name="ValidateSolutionManifest">
+        <!--
+          Runs against the populated metadata working directory, so the manifest is compared
+          against the component files that will actually be packed, including anything added
+          by build-time transforms.
+        -->
+        <Message Text="Validating solution manifest against component files..." Importance="high" />
+        <ValidateSolutionManifest SolutionRoot="$(SolutionPackagerMetadataWorkingDirectory)"
+                                  Condition="Exists('$(SolutionPackagerMetadataWorkingDirectory)\Other\Solution.xml')" />
+        <Message Text="Solution manifest validation finished." Importance="high" />
+    </Target>
+</Project>

--- a/src/Dataverse/WorkflowActivity/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.WorkflowActivity.targets
+++ b/src/Dataverse/WorkflowActivity/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.WorkflowActivity.targets
@@ -24,6 +24,8 @@
        work starts. -->
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <BeforePack>$(BeforePack);_ErrorOnWorkflowActivityPack</BeforePack>
   </PropertyGroup>
   <Target Name="_ErrorOnWorkflowActivityPack">

--- a/src/Dataverse/WorkflowActivity/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.WorkflowActivity.targets
+++ b/src/Dataverse/WorkflowActivity/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.WorkflowActivity.targets
@@ -24,6 +24,7 @@
        work starts. -->
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+
     <BeforePack>$(BeforePack);_ErrorOnWorkflowActivityPack</BeforePack>
   </PropertyGroup>
   <Target Name="_ErrorOnWorkflowActivityPack">


### PR DESCRIPTION
Wires the existing ValidateSolutionComponentSchema target into the solution build (after ProcessCds, before packaging), so component XML/JSON gets schema-checked on every build instead of only when invoked by hand. Opt out with SkipSchemaValidation=true.

Also fixes a regression from #96: Microsoft.PowerApps.MSBuild.Plugin.props defaults GeneratePackageOnBuild to true, so Pack ran after every plugin/workflow activity build and hit the new "cannot be packed" guard. Those project types now set GeneratePackageOnBuild=false; explicit dotnet pack still errors as intended.

Since then the branch picked up a few more things:

- a ValidateSolutionManifest task that checks each solution manifest against the component files on disk (declared root components that have no file, missing MissingDependencies element). The heavy lifting lives in TALXIS.Platform.Metadata.Validation, this side just wires it into the solution build.
- a SkipValidation master switch that flips all the individual flags at once (SkipSchemaValidation, SkipDuplicateGuidValidation, SkipQuickFindValidation, SkipPcfDependencyValidation). A flag set explicitly by the project still wins.


Note: the manifest validation needs the platform-metadata release that carries the source-format tolerances (TALXIS/platform-metadata#74), otherwise it reports false positives on app solutions.
