### PR TITLE
Fix Node restore/build regressions from the Rush-aware targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Pcf/ScriptLibrary/CodeApp projects auto-detect and run the right Node package ma
 | [TALXIS.DevKit.Build.Dataverse.Plugin](src/Dataverse/Plugin/README.md) | MSBuild integration for Dataverse plugin assemblies with auto-versioning and metadata exposure for Solution projects. |
 | [TALXIS.DevKit.Build.Dataverse.Pcf](src/Dataverse/Pcf/README.md) | MSBuild integration for PCF controls. Wraps `Microsoft.PowerApps.MSBuild.Pcf` with Git-based versioning. |
 | [TALXIS.DevKit.Build.Dataverse.WorkflowActivity](src/Dataverse/WorkflowActivity/README.md) | MSBuild integration for custom workflow activity assemblies with auto-versioning and Solution project integration. |
-| [TALXIS.DevKit.Build.Dataverse.ScriptLibrary](src/Dataverse/ScriptLibrary/README.md) | Builds TypeScript/JS web resource projects (auto-detected Node package manager restore + `npm run build`) and integrates them into Solution builds. |
+| [TALXIS.DevKit.Build.Dataverse.ScriptLibrary](src/Dataverse/ScriptLibrary/README.md) | Builds TypeScript/JS web resource projects (auto-detected Node package manager restore + SDK-managed build command for npm/pnpm/Yarn/Bun or Rush) and integrates them into Solution builds. |
 | [TALXIS.DevKit.Build.Dataverse.PdPackage](src/Dataverse/PDPackage/README.md) | Package Deployer integration with CMT metadata merge/zip support. |
 
 See [docs/BuildProcess.md](docs/BuildProcess.md) for how these packages are layered and what each one wires into the build, [docs/Versioning.md](docs/Versioning.md) for the version-numbering strategy, and [docs/NodeDependencies.md](docs/NodeDependencies.md) for how Node dependency restore is auto-detected.

--- a/docs/BuildProcess.md
+++ b/docs/BuildProcess.md
@@ -210,7 +210,7 @@ Like the Plugin package, it replaces ILRepack's default auto-hook with a no-op t
 Main hooks:
 
 - imports `Microsoft.PowerApps.VisualStudio.Pcf.props` / `.targets`
-- `_PcfNodeRestore` runs `AfterTargets="CollectPackageReferences"` (not `BeforeTargets="BeforeBuild"` - this is what makes a bare `dotnet restore` at the repo/solution root hydrate Node deps too, see [NodeDependencies.md](NodeDependencies.md#verb-parity)) and calls the shared `NodeRestore` target - replaces the previous hardcoded `NpmInstall`/`npm install` target
+- `_PcfNodeRestore` runs `AfterTargets="CollectPackageReferences"` (not `BeforeTargets="BeforeBuild"` - this is what makes a bare `dotnet restore` at the repo/solution root hydrate Node deps too, see [NodeDependencies.md](NodeDependencies.md#verb-parity)) and calls the shared `NodeRestore` target
 - `PcfBuild` is overridden (Rush-resolved projects only) to delegate the actual build to Rush's own `build` command instead of Microsoft's own `npm run build` `<Exec>`, forwarding the build mode as a `--build-mode` Rush custom command-line parameter (reusing Microsoft's own `$(PcfBuildMode)` Debug/Release mapping) - see [NodeDependencies.md](NodeDependencies.md#pcf-specific-forwarding-the-build-mode-as---build-mode)
 - `_ApplyPcfVersionAfterBuild` runs `AfterTargets="PcfBuild"` (after `ControlManifest.xml` actually exists) and applies Git-based versioning
 - `_EnsurePcfStubAssembly` runs before `Publish` / `GetCopyToPublishDirectoryItems` and creates a stub DLL if needed
@@ -234,7 +234,7 @@ Main hooks:
 - `GetScriptLibraryOutputs`
 - `GetSuppressedScriptLibraryReferences`
 
-The package expects TypeScript sources under `$(TypeScriptDir)` (default `$(MSBuildProjectDirectory)` itself, with legacy nested-layout projects setting `<TypeScriptDir>TS</TypeScriptDir>` explicitly), hydrates dependencies via the shared `NodeRestore` target (see [NodeDependencies.md](NodeDependencies.md) - replaces the previous hardcoded `npm install`), builds via Rush delegation or `npm run build` (see [NodeDependencies.md](NodeDependencies.md#build-delegation-to-rush)), copies the selected main JS file to `$(TargetDir)`, and lets Solution builds query which referenced script libraries are `CompileOnly` and therefore should not be deployed as separate web resources. Standalone `npm` packaging of a ScriptLibrary is planned but not yet implemented, so it does not currently set `IsPackable=false`.
+The package expects TypeScript sources under `$(TypeScriptDir)` (default `$(MSBuildProjectDirectory)` itself), hydrates dependencies via the shared `NodeRestore` target (see [NodeDependencies.md](NodeDependencies.md)), builds via Rush delegation or `npm run build` (see [NodeDependencies.md](NodeDependencies.md#build-delegation-to-rush)), copies the selected main JS file to `$(TargetDir)`, and lets Solution builds query which referenced script libraries are `CompileOnly` and therefore should not be deployed as separate web resources. Standalone `npm` packaging of a ScriptLibrary is planned but not yet implemented, so it does not currently set `IsPackable=false`.
 
 ### CodeApp
 
@@ -250,7 +250,7 @@ Main hooks:
 - `GetCodeAppOutputs`
 - `CopyCodeAppDistPublish` (`AfterTargets="Publish"`)
 
-The package hydrates dependencies via the shared `NodeRestore` target (see [NodeDependencies.md](NodeDependencies.md) - replaces the previous hardcoded `npm install`), builds via Rush delegation or `npm run build` (see [NodeDependencies.md](NodeDependencies.md#build-delegation-to-rush)), expects output under `dist/`, copies it into `$(OutputPath)$(AppName)/` and `$(PublishDir)$(AppName)/`, and exposes the `dist` folder plus `power.config.json` to Solution packaging. CodeApp projects are not standalone components, so the package sets `IsPackable=false` and hooks `$(BeforePack)` with `_ErrorOnCodeAppPack`, which raises a hard error before any nuspec/nupkg work starts.
+The package hydrates dependencies via the shared `NodeRestore` target (see [NodeDependencies.md](NodeDependencies.md)), builds via Rush delegation or `npm run build` (see [NodeDependencies.md](NodeDependencies.md#build-delegation-to-rush)), expects output under `dist/`, copies it into `$(OutputPath)$(AppName)/` and `$(PublishDir)$(AppName)/`, and exposes the `dist` folder plus `power.config.json` to Solution packaging. CodeApp projects are not standalone components, so the package sets `IsPackable=false` and hooks `$(BeforePack)` with `_ErrorOnCodeAppPack`, which raises a hard error before any nuspec/nupkg work starts.
 
 ### GenPage
 

--- a/docs/BuildProcess.md
+++ b/docs/BuildProcess.md
@@ -234,7 +234,7 @@ Main hooks:
 - `GetScriptLibraryOutputs`
 - `GetSuppressedScriptLibraryReferences`
 
-The package expects TypeScript sources under `$(TypeScriptDir)` (default `TS`), hydrates dependencies via the shared `NodeRestore` target (see [NodeDependencies.md](NodeDependencies.md) - replaces the previous hardcoded `npm install`), builds via Rush delegation or `npm run build` (see [NodeDependencies.md](NodeDependencies.md#build-delegation-to-rush)), copies the selected main JS file to `$(TargetDir)`, and lets Solution builds query which referenced script libraries are `CompileOnly` and therefore should not be deployed as separate web resources. Standalone `npm` packaging of a ScriptLibrary is planned but not yet implemented, so it does not currently set `IsPackable=false`.
+The package expects TypeScript sources under `$(TypeScriptDir)` (default `$(MSBuildProjectDirectory)` itself, with legacy nested-layout projects setting `<TypeScriptDir>TS</TypeScriptDir>` explicitly), hydrates dependencies via the shared `NodeRestore` target (see [NodeDependencies.md](NodeDependencies.md) - replaces the previous hardcoded `npm install`), builds via Rush delegation or `npm run build` (see [NodeDependencies.md](NodeDependencies.md#build-delegation-to-rush)), copies the selected main JS file to `$(TargetDir)`, and lets Solution builds query which referenced script libraries are `CompileOnly` and therefore should not be deployed as separate web resources. Standalone `npm` packaging of a ScriptLibrary is planned but not yet implemented, so it does not currently set `IsPackable=false`.
 
 ### CodeApp
 

--- a/docs/NodeDependencies.md
+++ b/docs/NodeDependencies.md
@@ -98,10 +98,20 @@ second, parallel mapping.
 
 Rush's generic `build` command has no built-in mechanism to forward arbitrary CLI arguments through to each
 project's own script, so this package's Rush-branch override of `PcfBuild` forwards the mode via Rush's own
-documented **custom commands and parameters** feature (`common/config/rush/command-line.json`) - the same
-mechanism used for every project type's mode flag (see "Build delegation to Rush" above), just with the
-flag spelled `--build-mode` (matching `pcf-scripts`' own `--buildMode`, camel-case-expanded by `yargs`) instead
-of the generic `--mode`.
+documented **custom commands and parameters** feature (`common/config/rush/command-line.json`), with the flag
+spelled `--build-mode` (matching `pcf-scripts`' own `--buildMode`, camel-case-expanded by `yargs`).
+
+The mode CLI flag is **opt-in per project type**, because an npm `build` script forwards extra arguments
+verbatim to whatever tool it runs, and tools like `tsc` or `rollup` hard-fail on flags they don't recognize:
+
+| Project type | Mode CLI flag | Why |
+|---|---|---|
+| `Pcf` | `--build-mode` | `pcf-scripts` parses it (`yargs`) |
+| `CodeApp` | `--mode` | vite's own CLI flag |
+| `ScriptLibrary` | _(none)_ | build script is commonly plain `tsc`/`rollup`; `NODE_ENV` is the only channel |
+
+`NODE_ENV=development|production` is always set on the build invocation for every project type regardless of
+the flag, so any build script (including ScriptLibrary's) can branch on it.
 
 **This requires a one-time addition to your repo's `common/config/rush/command-line.json`** - add the following
 to its `parameters` array (`associatedCommands` must include both `"build"` and `"rebuild"`):
@@ -218,7 +228,9 @@ Rush already owns and would be a likely source of subtly-wrong "already restored
 ## Once-per-workspace execution (non-Rush tools)
 
 For npm/pnpm/Yarn/Bun, `NodeRestore` runs at the detected workspace root and is gated by an MSBuild
-Inputs/Outputs check (lockfile → a `.node-restore-stamp` file under that root's `node_modules`), so the second,
+Inputs/Outputs check (package.json + lockfile → a `.node-restore.stamp` file inside that root's
+`node_modules`, so deleting `node_modules` re-triggers the install and the stamp can never be
+committed; Yarn Berry PnP, which materializes no `node_modules`, keeps the stamp at the root), so the second,
 third, ... project in the same build that shares a workspace root sees the install as already up-to-date and
 skips it - the same "once per workspace, not once per project" guarantee `dotnet restore` gives per solution.
 

--- a/src/Dataverse/CodeApp/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.CodeApp.targets
+++ b/src/Dataverse/CodeApp/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.CodeApp.targets
@@ -34,6 +34,7 @@
   <Target Name="_CodeAppSetNodeBuildArgs">
     <PropertyGroup>
       <_NodeBuildProjectDirectory>$(MSBuildProjectDirectory)</_NodeBuildProjectDirectory>
+      <_NodeBuildModeArgName Condition="'$(_NodeBuildModeArgName)'==''">mode</_NodeBuildModeArgName>
       <_NodeBuildExtraArgs></_NodeBuildExtraArgs>
       <_NodeBuildRequiredRushParams></_NodeBuildRequiredRushParams>
     </PropertyGroup>

--- a/src/Dataverse/Plugin/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Plugin.targets
+++ b/src/Dataverse/Plugin/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Plugin.targets
@@ -24,6 +24,8 @@
        BeforePack (rather than BeforeTargets="Pack") fails before any nuspec/nupkg work starts. -->
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <BeforePack>$(BeforePack);_ErrorOnPluginPack</BeforePack>
   </PropertyGroup>
   <Target Name="_ErrorOnPluginPack">

--- a/src/Dataverse/ScriptLibrary/README.md
+++ b/src/Dataverse/ScriptLibrary/README.md
@@ -23,9 +23,8 @@ Or use the SDK approach:
 When `RunNodeBuild` is `true` (auto-detected from the presence of `package.json` in `TypeScriptDir`):
 
 - **Node.js** must be available on `PATH`
-- **npm** must be available on `PATH`
 
-The build will fail with a descriptive error if either is missing.
+The build will fail with a descriptive error if Node.js is missing; package manager resolution/validation is handled by `NodeRestore` based on what it detects.
 
 ## How It Works
 
@@ -83,5 +82,4 @@ CompileOnly removes the referenced project from the Solution's standalone-deploy
 
 - **Depends on**: `TALXIS.DevKit.Build.Dataverse.Tasks`
 - **Consumed by**: `TALXIS.DevKit.Build.Dataverse.Solution` projects via `ProjectReference`
-
 

--- a/src/Dataverse/ScriptLibrary/README.md
+++ b/src/Dataverse/ScriptLibrary/README.md
@@ -73,7 +73,7 @@ CompileOnly removes the referenced project from the Solution's standalone-deploy
 |----------|---------|-------------|
 | `ProjectType` | `ScriptLibrary` | Marks the project for reference discovery by Solution projects. |
 | `RunNodeBuild` | Auto-detected | Set to `true` to restore Node dependencies (via `NodeRestore`) and run `npm run build`. Defaults to `true` if `package.json` exists in `TypeScriptDir`. |
-| `TypeScriptDir` | `$(MSBuildProjectDirectory)\TS` | Folder containing the TypeScript project (`package.json`, sources). |
+| `TypeScriptDir` | Auto-detected | Folder containing the TypeScript project (`package.json`, sources). Detection order: explicit value in the project file → legacy `TS\` subfolder (when `TS\package.json` exists) → the project directory itself (when `package.json` exists there). New projects should keep `package.json` directly in the project directory; the `TS\` subfolder remains supported for existing projects. |
 | `ScriptLibraryMainFile` | _(none)_ | Main script file path used by consuming targets. |
 | `<ProjectReference>` metadata `ScriptLibraryMode` | `Separate` | Controls the relationship to another referenced ScriptLibrary project: `Separate` or `CompileOnly`. See [Cross-ScriptLibrary references](#cross-scriptlibrary-references). |
 | `LangVersion` | `latest` | C# language version for the project. |

--- a/src/Dataverse/ScriptLibrary/README.md
+++ b/src/Dataverse/ScriptLibrary/README.md
@@ -73,7 +73,7 @@ CompileOnly removes the referenced project from the Solution's standalone-deploy
 |----------|---------|-------------|
 | `ProjectType` | `ScriptLibrary` | Marks the project for reference discovery by Solution projects. |
 | `RunNodeBuild` | Auto-detected | Set to `true` to restore Node dependencies (via `NodeRestore`) and run `npm run build`. Defaults to `true` if `package.json` exists in `TypeScriptDir`. |
-| `TypeScriptDir` | Auto-detected | Folder containing the TypeScript project (`package.json`, sources). Detection order: explicit value in the project file → legacy `TS\` subfolder (when `TS\package.json` exists) → the project directory itself (when `package.json` exists there). New projects should keep `package.json` directly in the project directory; the `TS\` subfolder remains supported for existing projects. |
+| `TypeScriptDir` | `$(MSBuildProjectDirectory)` | Folder containing the Node/TypeScript project (`package.json`, sources). Relative values resolve against the project directory, so projects with the nested legacy layout set `<TypeScriptDir>TS</TypeScriptDir>` - same pattern as `SolutionRootPath` on Solution projects. |
 | `ScriptLibraryMainFile` | _(none)_ | Main script file path used by consuming targets. |
 | `<ProjectReference>` metadata `ScriptLibraryMode` | `Separate` | Controls the relationship to another referenced ScriptLibrary project: `Separate` or `CompileOnly`. See [Cross-ScriptLibrary references](#cross-scriptlibrary-references). |
 | `LangVersion` | `latest` | C# language version for the project. |

--- a/src/Dataverse/ScriptLibrary/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.targets
+++ b/src/Dataverse/ScriptLibrary/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.targets
@@ -2,9 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <TypeScriptDir Condition="'$(TypeScriptDir)'=='' and Exists('$(MSBuildProjectDirectory)/TS/package.json')">$(MSBuildProjectDirectory)/TS</TypeScriptDir>
-    <TypeScriptDir Condition="'$(TypeScriptDir)'=='' and Exists('$(MSBuildProjectDirectory)/package.json')">$(MSBuildProjectDirectory)</TypeScriptDir>
-    <TypeScriptDir Condition="'$(TypeScriptDir)'==''">$(MSBuildProjectDirectory)/TS</TypeScriptDir>
+    <TypeScriptDir Condition="'$(TypeScriptDir)'==''">$(MSBuildProjectDirectory)</TypeScriptDir>
+    <TypeScriptDir>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(TypeScriptDir)'))</TypeScriptDir>
 
     <RunNodeBuild Condition="'$(RunNodeBuild)'=='' and Exists('$(TypeScriptDir)/package.json')">true</RunNodeBuild>
     <RunNodeBuild Condition="'$(RunNodeBuild)'==''">false</RunNodeBuild>

--- a/src/Dataverse/ScriptLibrary/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.targets
+++ b/src/Dataverse/ScriptLibrary/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.ScriptLibrary.targets
@@ -2,6 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
+    <TypeScriptDir Condition="'$(TypeScriptDir)'=='' and Exists('$(MSBuildProjectDirectory)/TS/package.json')">$(MSBuildProjectDirectory)/TS</TypeScriptDir>
+    <TypeScriptDir Condition="'$(TypeScriptDir)'=='' and Exists('$(MSBuildProjectDirectory)/package.json')">$(MSBuildProjectDirectory)</TypeScriptDir>
     <TypeScriptDir Condition="'$(TypeScriptDir)'==''">$(MSBuildProjectDirectory)/TS</TypeScriptDir>
 
     <RunNodeBuild Condition="'$(RunNodeBuild)'=='' and Exists('$(TypeScriptDir)/package.json')">true</RunNodeBuild>
@@ -64,7 +66,7 @@
     <Error Condition="'$(MSBuildLastTaskResult)'!='True'" Text="Node.js not found in PATH. Install Node.js to build ScriptLibrary." />
   </Target>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TypeScriptDir)' != '$(MSBuildProjectDirectory)'">
     <None Include="$(TypeScriptDir)/build/**/*.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -89,7 +91,8 @@
   <Target Name="CopyScriptLibraryMainToOutput"
     AfterTargets="Build">
     <ItemGroup>
-      <_ScriptLibraryMainFile Include="$(TypeScriptDir)/**/$(ScriptLibraryName).js" />
+      <_ScriptLibraryMainFile Include="$(TypeScriptDir)/**/$(ScriptLibraryName).js"
+                              Exclude="$(TypeScriptDir)/node_modules/**;$(TypeScriptDir)/bin/**;$(TypeScriptDir)/obj/**" />
     </ItemGroup>
     <Message Text="Copying script library main file to $(TargetDir): @(_ScriptLibraryMainFile)" Importance="High" Condition="'@(_ScriptLibraryMainFile)'!=''" />
     <Copy SourceFiles="@(_ScriptLibraryMainFile)" DestinationFiles="@(_ScriptLibraryMainFile->'$(TargetDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" Condition="'@(_ScriptLibraryMainFile)'!=''" />

--- a/src/Dataverse/Tasks/Tasks/ExecWithRetry.cs
+++ b/src/Dataverse/Tasks/Tasks/ExecWithRetry.cs
@@ -263,7 +263,7 @@ public class ExecWithRetry : Task, ICancelableTask
             ? new ProcessStartInfo
             {
                 FileName = "cmd.exe",
-                ArgumentList = { "/d", "/s", "/c", command }
+                Arguments = "/d /s /c \"" + command + "\""
             }
             : new ProcessStartInfo
             {

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild.targets
@@ -16,16 +16,21 @@
                               $(PcfBuildMode) - a developer runs "dotnet build" for an unminified,
                               source-mapped build or "dotnet build -c Release" for a
                               minified production build, the same way, for every project type.
-                              Reaches the underlying build tool two ways, both always applied:
-                                - NODE_ENV=<value> environment variable on the build invocation.
+                              Reaches the underlying build tool two ways:
+                                - NODE_ENV=<value> environment variable on the build invocation,
+                                  always applied for every project type.
                                 - a mode CLI argument appended with the same value (or a Rush custom
-                                  command-line parameter when Rush build-delegation is in play).
+                                  command-line parameter when Rush build-delegation is in play),
+                                  only when the project type declares a flag name (see below).
       _NodeBuildModeArgName   The long-form flag name (without a leading dash pair) the mode value is
-                              passed as, e.g. "mode" -> a "mode" flag of "production". Defaults to "mode";
-                              a project type whose own build tool expects a different spelling
-                              (e.g. PCF's pcf-scripts, which reads a "build-mode" flag) overrides this
-                              rather than forwarding a second, tool-specific flag alongside the
-                              generic one.
+                              passed as, e.g. "build-mode" -> a "build-mode" flag of "production".
+                              Defaults to EMPTY, meaning no CLI flag is appended at all and NODE_ENV
+                              is the only channel. A CLI flag is opt-in per project type because an
+                              npm "build" script forwards unknown extra args verbatim to whatever
+                              tool it runs, and tools like tsc or rollup hard-fail on flags they do
+                              not recognize - only a project type that KNOWS its build tool accepts
+                              a mode flag may declare one (PCF's pcf-scripts reads "build-mode",
+                              CodeApp's vite reads "mode").
 
     Implementation is split across NodeBuild\*.targets by concern:
       Direct.targets          The "no orchestrator" build branch: runs the project's own build
@@ -46,7 +51,6 @@
   <PropertyGroup>
     <NodeBuildConfiguration Condition="'$(NodeBuildConfiguration)'=='' and '$(Configuration)'=='Release'">production</NodeBuildConfiguration>
     <NodeBuildConfiguration Condition="'$(NodeBuildConfiguration)'==''">development</NodeBuildConfiguration>
-    <_NodeBuildModeArgName Condition="'$(_NodeBuildModeArgName)'==''">mode</_NodeBuildModeArgName>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)NodeBuild\*.targets" />

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild/Direct.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild/Direct.targets
@@ -9,9 +9,10 @@
       <_NodeBuildDirectCommand Condition="'$(_NodeRestoreResolvedTool)'=='yarn'">yarn run build</_NodeBuildDirectCommand>
       <_NodeBuildDirectCommand Condition="'$(_NodeRestoreResolvedTool)'=='bun'">bun run build</_NodeBuildDirectCommand>
       <_NodeBuildDirectCommand Condition="'$(_NodeBuildDirectCommand)'==''">npm run build --</_NodeBuildDirectCommand>
+      <_NodeBuildModeArgs Condition="'$(_NodeBuildModeArgName)'!=''">--$(_NodeBuildModeArgName) $(NodeBuildConfiguration)</_NodeBuildModeArgs>
     </PropertyGroup>
     <Exec WorkingDirectory="$(_NodeBuildProjectDirectory)"
-          Command="$(_NodeBuildDirectCommand) --$(_NodeBuildModeArgName) $(NodeBuildConfiguration) $(_NodeBuildExtraArgs)"
+          Command="$(_NodeBuildDirectCommand) $(_NodeBuildModeArgs) $(_NodeBuildExtraArgs)"
           EnvironmentVariables="NODE_ENV=$(NodeBuildConfiguration)" />
   </Target>
 </Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild/RushDelegation.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild/RushDelegation.targets
@@ -13,14 +13,16 @@
                                          own build script beyond the mode flag. Empty string if
                                          none.
          _NodeBuildRequiredRushParams   Semicolon-separated Rush custom-parameter longNames
-                                         (beyond the mode flag, which is always required) that must be
-                                         declared in command-line.json for _NodeBuildExtraArgs to
-                                         actually reach the build script. Empty string if none.
+                                         (beyond the mode flag, which is required whenever the
+                                         project type declares one) that must be declared in
+                                         command-line.json for _NodeBuildExtraArgs to actually
+                                         reach the build script. Empty string if none.
 
-       NodeBuildConfiguration (see NodeBuild.targets) always reaches the build both as
-       NODE_ENV=<value> and as a $(_NodeBuildModeArgName) flag on the Rush custom
-       command-line parameter list, so a Rush-registered project must declare that flag in
-       command-line.json the same way it declares any other custom parameter. -->
+       NodeBuildConfiguration (see NodeBuild.targets) always reaches the build as NODE_ENV=<value>;
+       it additionally travels as a $(_NodeBuildModeArgName) flag on the Rush custom command-line
+       parameter list when the project type declares a flag name, in which case a Rush-registered
+       project must declare that flag in command-line.json the same way it declares any other
+       custom parameter. -->
   <Target Name="_NodeRestoreDelegateBuildToRush"
           Condition="'$(_NodeRestoreResolvedTool)' == 'rush'">
 
@@ -33,8 +35,9 @@
     <PropertyGroup>
       <_NodeBuildCommandLineJsonPath>$(_NodeRestoreWorkspaceRoot)/common/config/rush/command-line.json</_NodeBuildCommandLineJsonPath>
       <_NodeBuildCommandLineJsonText Condition="Exists('$(_NodeBuildCommandLineJsonPath)')">$([System.IO.File]::ReadAllText('$(_NodeBuildCommandLineJsonPath)'))</_NodeBuildCommandLineJsonText>
-      <_NodeBuildAllRequiredRushParams Condition="'$(_NodeBuildRequiredRushParams)' == ''">--$(_NodeBuildModeArgName)</_NodeBuildAllRequiredRushParams>
-      <_NodeBuildAllRequiredRushParams Condition="'$(_NodeBuildAllRequiredRushParams)' == ''">--$(_NodeBuildModeArgName);$(_NodeBuildRequiredRushParams)</_NodeBuildAllRequiredRushParams>
+      <_NodeBuildAllRequiredRushParams Condition="'$(_NodeBuildModeArgName)' != ''">--$(_NodeBuildModeArgName)</_NodeBuildAllRequiredRushParams>
+      <_NodeBuildAllRequiredRushParams Condition="'$(_NodeBuildRequiredRushParams)' != '' and '$(_NodeBuildAllRequiredRushParams)' != ''">$(_NodeBuildAllRequiredRushParams);$(_NodeBuildRequiredRushParams)</_NodeBuildAllRequiredRushParams>
+      <_NodeBuildAllRequiredRushParams Condition="'$(_NodeBuildAllRequiredRushParams)' == ''">$(_NodeBuildRequiredRushParams)</_NodeBuildAllRequiredRushParams>
     </PropertyGroup>
 
     <ItemGroup>
@@ -68,11 +71,13 @@
       <_NodeBuildRushCommand Condition="'$(_NodeBuildIsSolutionScope)' != 'true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" build --to .</_NodeBuildRushCommand>
       <_NodeBuildRushCommand Condition="'$(_NodeBuildIsSolutionScope)' == 'true'">node "$(_NodeRestoreWorkspaceRoot)/common/scripts/install-run-rush.js" build</_NodeBuildRushCommand>
 
-      <!-- The mode flag is forwarded as a Rush custom command-line parameter, the same mechanism used
-           for every other project-type-specific flag - Rush's own build cache already
-           incorporates command-line parameters into its cache key, so Debug/Release get
-           distinct, correct cache entries with no extra work here. -->
-      <_NodeBuildRushCommand>$(_NodeBuildRushCommand) --$(_NodeBuildModeArgName) $(NodeBuildConfiguration) $(_NodeBuildExtraArgs)</_NodeBuildRushCommand>
+      <!-- The mode flag (when the project type declares one) is forwarded as a Rush custom
+           command-line parameter, the same mechanism used for every other project-type-specific
+           flag - Rush's own build cache already incorporates command-line parameters into its
+           cache key, so Debug/Release get distinct, correct cache entries with no extra work
+           here. NODE_ENV still carries the configuration for project types with no flag. -->
+      <_NodeBuildRushCommand Condition="'$(_NodeBuildModeArgName)' != ''">$(_NodeBuildRushCommand) --$(_NodeBuildModeArgName) $(NodeBuildConfiguration)</_NodeBuildRushCommand>
+      <_NodeBuildRushCommand Condition="'$(_NodeBuildExtraArgs)' != ''">$(_NodeBuildRushCommand) $(_NodeBuildExtraArgs)</_NodeBuildRushCommand>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild/RushDelegation.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeBuild/RushDelegation.targets
@@ -8,7 +8,9 @@
          _NodeBuildProjectDirectory     This project's own directory (used for the scoped rush build,
                                          Rush invocation and as the working directory).
          _NodeBuildModeArgName          (see NodeBuild.targets) the mode flag's long-form name,
-                                         without a leading dash pair. Defaults to "mode".
+                                         without a leading dash pair. Defaults to empty (no
+                                         flag); project types that opt in set it explicitly
+                                         (PCF uses "build-mode", CodeApp uses "mode").
          _NodeBuildExtraArgs            Extra CLI args this project type needs forwarded to its
                                          own build script beyond the mode flag. Empty string if
                                          none.

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore.targets
@@ -33,7 +33,6 @@
   -->
 
   <PropertyGroup>
-    <NodeRestoreProjectDirectory Condition="'$(NodeRestoreProjectDirectory)'==''">$(MSBuildProjectDirectory)</NodeRestoreProjectDirectory>
     <NodePackageManager Condition="'$(NodePackageManager)'==''"></NodePackageManager>
     <NodeRestoreCommand Condition="'$(NodeRestoreCommand)'==''"></NodeRestoreCommand>
   </PropertyGroup>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Detection.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Detection.targets
@@ -26,6 +26,10 @@
 
   <Target Name="_NodeRestoreResolve" Condition="'$(NodePackageManager)' != 'None'">
 
+    <PropertyGroup>
+      <NodeRestoreProjectDirectory Condition="'$(NodeRestoreProjectDirectory)'==''">$(MSBuildProjectDirectory)</NodeRestoreProjectDirectory>
+    </PropertyGroup>
+
     <!-- Marker walk-up, in precedence order. Rush is checked first because it is an orchestrator
          that sits above a package manager, not a package manager itself - a workspace can have
          both an rush.json and a pnpm-lock.yaml, and Rush must win in that case. Each Condition

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Generic.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Generic.targets
@@ -23,9 +23,13 @@
     <!-- Incremental-check keys for the stamp-gated install target below:
          - this project's own package.json, so dependency-manifest edits always re-run hydration;
          - the matched lockfile too when one exists, so lockfile changes also invalidate the stamp.
-         The stamp itself lives at the workspace root (not under node_modules) so package managers
-         that do not create node_modules, e.g. Yarn Berry PnP, stay side-effect-free until the
-         actual install command runs. -->
+         The stamp lives INSIDE node_modules, not at the workspace root: deleting node_modules (the
+         universal npm-land "reset" move, and what a fresh clone looks like) must take the stamp
+         with it, or the up-to-date check would keep skipping the install against a node_modules
+         that no longer exists. Inside node_modules it is also automatically git-ignored everywhere,
+         so it can never be accidentally committed (a committed stamp would suppress the very first
+         install on every fresh clone). Yarn Berry PnP is the one exception - it materializes no
+         node_modules at all - so only there the stamp stays at the workspace root. -->
     <PropertyGroup>
       <_NodeRestorePackageJsonPath>$(NodeRestoreProjectDirectory)/package.json</_NodeRestorePackageJsonPath>
       <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreResolvedTool)'=='pnpm' and '$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestoreWorkspaceRoot)/pnpm-lock.yaml</_NodeRestoreLockfilePath>
@@ -34,7 +38,8 @@
       <_NodeRestoreLockfilePath Condition="'$(_NodeRestoreLockfilePath)'=='' and '$(_NodeRestoreResolvedTool)'=='npm' and '$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestoreWorkspaceRoot)/package-lock.json</_NodeRestoreLockfilePath>
       <_NodeRestoreIncrementalInputs>$(_NodeRestorePackageJsonPath)</_NodeRestoreIncrementalInputs>
       <_NodeRestoreIncrementalInputs Condition="'$(_NodeRestoreHasLockfile)'=='true'">$(_NodeRestorePackageJsonPath);$(_NodeRestoreLockfilePath)</_NodeRestoreIncrementalInputs>
-      <_NodeRestoreStampPath>$(_NodeRestoreWorkspaceRoot)/.node-restore.stamp</_NodeRestoreStampPath>
+      <_NodeRestoreStampPath>$(_NodeRestoreWorkspaceRoot)/node_modules/.node-restore.stamp</_NodeRestoreStampPath>
+      <_NodeRestoreStampPath Condition="'$(_NodeRestoreYarnBerry)'=='true'">$(_NodeRestoreWorkspaceRoot)/.node-restore.stamp</_NodeRestoreStampPath>
     </PropertyGroup>
 
     <!-- Command table: local variant / frozen-CI variant per tool. Skipped entirely when an
@@ -76,6 +81,8 @@
           WorkingDirectory="$(_NodeRestoreWorkspaceRoot)"
           StandardOutputImportance="Low"
           StandardErrorImportance="High" />
+    <MakeDir Directories="$(_NodeRestoreWorkspaceRoot)/node_modules" Condition="'$(_NodeRestoreYarnBerry)'!='true'" />
+    <Delete Files="$(_NodeRestoreWorkspaceRoot)/.node-restore.stamp" Condition="'$(_NodeRestoreYarnBerry)'!='true' and Exists('$(_NodeRestoreWorkspaceRoot)/.node-restore.stamp')" />
     <Touch Files="$(_NodeRestoreStampPath)" AlwaysCreate="true" />
   </Target>
 </Project>

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Generic.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Generic.targets
@@ -63,10 +63,11 @@
              Text="NodeRestore: running in CI with no package-lock.json found at '$(_NodeRestoreWorkspaceRoot)' - falling back to 'npm install' instead of the reproducible, cache-friendly 'npm ci'. Commit a lockfile to fix this." />
   </Target>
 
-  <!-- Gated by Target Inputs/Outputs against a stamp file next to node_modules, keyed on the
-       lockfile (or package.json when no lockfile exists at all). A second project sharing the
-       same workspace root in one build sees this target as already up-to-date and skips the
-       Exec entirely, so a shared workspace's install runs once per build, not once per project.
+  <!-- Gated by Target Inputs/Outputs against a stamp file inside node_modules (or at the
+       workspace root for Yarn Berry PnP), keyed on the lockfile (or package.json when no
+       lockfile exists at all). A second project sharing the same workspace root in one build
+       sees this target as already up-to-date and skips the Exec entirely, so a shared
+       workspace's install runs once per build, not once per project.
 
        Documented limitation, not solved with a custom lock: concurrent multi-process MSBuild
        builds of independent projects sharing one workspace root can still race to invoke install

--- a/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Rush.targets
+++ b/src/Dataverse/Tasks/msbuild/tasks/Targets/NodeRestore/Rush.targets
@@ -61,6 +61,18 @@
   <Target Name="_NodeRestoreRunRush"
           DependsOnTargets="_NodeRestoreResolveRush"
           Condition="'$(NodePackageManager)' != 'None' and '$(NodeRestoreCommand)' == '' and '$(_NodeRestoreResolvedTool)' == 'rush'">
+
+    <ItemGroup>
+      <_NodeRestoreRushBootstrapFlag Remove="@(_NodeRestoreRushBootstrapFlag)" />
+      <_NodeRestoreRushBootstrapFlag Include="$(_NodeRestoreWorkspaceRoot)/common/temp/install-run/*/installed.flag" />
+      <_NodeRestoreRushBrokenBootstrap Remove="@(_NodeRestoreRushBrokenBootstrap)" />
+      <_NodeRestoreRushBrokenBootstrap Include="@(_NodeRestoreRushBootstrapFlag->'%(RootDir)%(Directory)')"
+                                       Condition="!Exists('%(RootDir)%(Directory)node_modules')" />
+    </ItemGroup>
+    <Warning Condition="'@(_NodeRestoreRushBrokenBootstrap)' != ''"
+             Text="NodeRestore: Rush bootstrap at '@(_NodeRestoreRushBrokenBootstrap)' has an installed.flag but no node_modules (a recursive node_modules cleanup likely removed it) - deleting the folder so install-run-rush reinstalls the engine cleanly." />
+    <RemoveDir Directories="@(_NodeRestoreRushBrokenBootstrap)" Condition="'@(_NodeRestoreRushBrokenBootstrap)' != ''" />
+
     <PropertyGroup>
       <_NodeRestoreRetryCommand>$(_NodeRestoreResolvedCommand)</_NodeRestoreRetryCommand>
       <_NodeRestoreRetryWorkingDirectory>$(_NodeRestoreWorkspaceRoot)</_NodeRestoreRetryWorkingDirectory>

--- a/src/Dataverse/WorkflowActivity/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.WorkflowActivity.targets
+++ b/src/Dataverse/WorkflowActivity/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.WorkflowActivity.targets
@@ -24,6 +24,8 @@
        work starts. -->
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <BeforePack>$(BeforePack);_ErrorOnWorkflowActivityPack</BeforePack>
   </PropertyGroup>
   <Target Name="_ErrorOnWorkflowActivityPack">


### PR DESCRIPTION
The Node targets from #99  broke real builds in both TALXIS and INT0015, this fixes all the failure modes we found there plus one plugin packaging problem.

npm install ran in the ScriptLibrary project root instead of TS\. The Tasks package defaults NodeRestoreProjectDirectory at evaluation time and imports before the ScriptLibrary targets, so their override never won. The default moved to execution time.

npm run build -- --mode development fails on plain tsc and rollup build scripts (TS5023). The mode flag is per project type now: pcf-scripts gets --build-mode, vite gets --mode, ScriptLibrary gets no flag and relies on NODE_ENV, which is set for everyone anyway.

deleting node_modules didn't retrigger the install: .node-restore.stamp sat next to it and survived, so the incremental gate skipped the restore. The stamp lives inside node_modules now (Yarn Berry PnP keeps the root path since it has no node_modules), stale root stamps get cleaned on the next restore.

every Rush invocation on Windows died with MODULE_NOT_FOUND. ExecWithRetry passed the command to cmd.exe through ArgumentList, which escapes quotes as \", and cmd doesn't parse that, so node received paths with literal quotes. cmd gets a raw /d /s /c "..." string now, same as MSBuild's own Exec.

wiping node_modules recursively also removes Rush's engine under common/temp/install-run but leaves its installed.flag, and install-run-rush then trusts the flag and launches a binary that isn't there. NodeRestore detects that half-deleted bootstrap and removes it so the engine reinstalls itself.

Also turned off GeneratePackageOnBuild for Plugin and WorkflowActivity projects, PAC's targets auto-pack them on build and that broke build and publish for both.