### PR TITLE
Validate AppName format and guard against duplicate AppName across CodeApp references

### DIFF
--- a/src/Dataverse/CodeApp/README.md
+++ b/src/Dataverse/CodeApp/README.md
@@ -32,7 +32,7 @@ Or use the SDK approach:
 
 1. **CheckCodeAppPrereqs** -- validates that `package.json` exists and that `node` is available in PATH (package manager presence is checked by `NodeRestore` itself, since it depends on what's detected). Runs only when `RunNodeBuild` is `true` (auto-detected from the presence of `package.json`).
 2. **BuildCodeApp** (runs before `Build`, depends on `CheckCodeAppPrereqs`) -- calls the shared `NodeRestore` target (auto-detected package manager) followed by `npm run build` in the project root directory.
-3. **CopyCodeAppDist** (runs after `Build`) -- copies the `dist/` folder to `$(OutputPath)$(AppName)\`. Fails the build if `dist/` is missing or if `AppName` is not set.
+3. **CopyCodeAppDist** (runs after `Build`, depends on `ValidateCodeAppAppName`) -- copies the `dist/` folder to `$(OutputPath)$(AppName)\`. Fails the build if `dist/` is missing, `AppName` is not set, or `AppName` doesn't match the required format.
 4. **CopyCodeAppDistPublish** (runs after `Publish`) -- same as above, but copies to `$(PublishDir)` instead.
 
 ### Integration targets
@@ -40,7 +40,7 @@ Or use the SDK approach:
 These targets are called by `TALXIS.DevKit.Build.Dataverse.Solution` when it discovers this project via `ProjectReference`:
 
 - **GetProjectType** -- returns `CodeApp` so the Solution build knows how to handle this reference.
-- **GetCodeAppOutputs** (depends on `Build`) -- returns the path to the compiled `dist/` folder along with `AppName` and `ConfigPath` (location of `power.config.json`) metadata. The Solution project uses this to call `GenerateCodeAppMetaXml` and produce the `.meta.xml` file for PAC packaging.
+- **GetCodeAppOutputs** (depends on `Build` and `ValidateCodeAppAppName`) -- returns the path to the compiled `dist/` folder along with `AppName` and `ConfigPath` (location of `power.config.json`) metadata. The Solution project uses this to call `GenerateCodeAppMetaXml` and produce the `.meta.xml` file for PAC packaging.
 
 ### What happens in the Solution project
 
@@ -48,8 +48,9 @@ When a Solution project has a `ProjectReference` to a CodeApp project, the follo
 
 1. **ProbeCodeApps** discovers the CodeApp reference by calling `GetProjectType`.
 2. **BuildCodeApps** calls `GetCodeAppOutputs`, which triggers the full CodeApp build (Node dependency restore + build).
-3. **PrepareCodeAppsSources** generates `.meta.xml` via `GenerateCodeAppMetaXml`, adds a `RootComponent` entry (Type 300) to `Solution.xml`, and ensures the `CanvasApps` node exists in `Customizations.xml`.
-4. **CopyCodeAppsToMetadata** copies the CodeApp dist output into the solution metadata `CanvasApps/` folder before PAC packages the solution.
+3. **ValidateCodeAppNamesUnique** errors out if two or more referenced CodeApp projects resolve to the same `AppName` (it's used verbatim for the schema name, `.meta.xml` file name, and package folder, so a collision would otherwise silently overwrite one Code App's output with another's).
+4. **PrepareCodeAppsSources** generates `.meta.xml` via `GenerateCodeAppMetaXml`, adds a `RootComponent` entry (Type 300) to `Solution.xml`, and ensures the `CanvasApps` node exists in `Customizations.xml`.
+5. **CopyCodeAppsToMetadata** copies the CodeApp dist output into the solution metadata `CanvasApps/` folder before PAC packages the solution.
 
 The CodeApp reference is automatically filtered out of the standard `ResolveProjectReferences` pipeline to avoid unnecessary assembly resolution.
 
@@ -58,7 +59,7 @@ The CodeApp reference is automatically filtered out of the standard `ResolveProj
 | Property | Default | Description |
 |----------|---------|-------------|
 | `ProjectType` | `CodeApp` | Marks the project as a code app for reference discovery. |
-| `AppName` | _(required)_ | Application name; used as the output folder name and in `.meta.xml` generation. |
+| `AppName` | _(required)_ | Logical app name, without the publisher prefix. Must start with a lowercase letter and contain only lowercase letters and digits (`^[a-z][a-z0-9]*$`). Used verbatim for the output folder name, the CanvasApp schema name (`<PublisherPrefix>_<AppName>`), the generated `.meta.xml` file name, and the package folder — must be unique among all Code Apps referenced by the same Solution project. |
 | `RunNodeBuild` | Auto-detected | Set to `true` if `package.json` exists in project root; set explicitly to override. |
 
 ## power.config.json

--- a/src/Dataverse/CodeApp/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.CodeApp.targets
+++ b/src/Dataverse/CodeApp/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.CodeApp.targets
@@ -17,6 +17,17 @@
     <Error Condition="'$(MSBuildLastTaskResult)'!='True'" Text="Node.js not found in PATH. Install Node.js to build CodeApp." />
   </Target>
 
+  <!-- Single source of truth for AppName validation, shared by every target that consumes it
+       (CopyCodeAppDist, CopyCodeAppDistPublish, GetCodeAppOutputs) instead of each duplicating
+       its own empty-check. AppName is used verbatim, unsanitized, downstream by the Solution
+       project to build the CanvasApp schema name, so a format check here catches a bad value
+       before it produces an invalid schema name or a broken file/folder path later. -->
+  <Target Name="ValidateCodeAppAppName">
+    <Error Condition="'$(AppName)'==''" Text="AppName property is not set. Set it in the project file." />
+    <Error Condition="'$(AppName)'!='' and !$([System.Text.RegularExpressions.Regex]::IsMatch($(AppName), '^[a-z][a-z0-9]*$'))"
+           Text="AppName '$(AppName)' is invalid. It must start with a lowercase letter and contain only lowercase letters and digits (a-z, 0-9)." />
+  </Target>
+
   <!-- Node dependency hydration, anchored to AfterTargets="CollectPackageReferences" (not
        BeforeTargets="Build"/inlined into BuildCodeApp below) so it also fires during a bare
        "dotnet restore" at the repo/solution root, not just when this project's own Build target
@@ -59,9 +70,8 @@
 
   <Target Name="CopyCodeAppDist"
     AfterTargets="Build"
+    DependsOnTargets="ValidateCodeAppAppName"
     Condition="'$(RunNodeBuild)'=='true'">
-    <Error Condition="'$(AppName)'==''" Text="AppName property is not set. Set it in the project file." />
-
     <ItemGroup>
       <CodeAppDistFiles Include="$(MSBuildProjectDirectory)/dist/**/*.*" />
     </ItemGroup>
@@ -94,7 +104,7 @@
   </Target>
 
   <Target Name="GetCodeAppOutputs"
-    DependsOnTargets="Build"
+    DependsOnTargets="Build;ValidateCodeAppAppName"
     Returns="@(_CodeAppOutputs)">
     <ItemGroup>
       <_CodeAppOutputs Include="$(MSBuildProjectDirectory)/dist">
@@ -106,9 +116,8 @@
 
   <Target Name="CopyCodeAppDistPublish"
     AfterTargets="Publish"
+    DependsOnTargets="ValidateCodeAppAppName"
     Condition="'$(RunNodeBuild)'=='true'">
-    <Error Condition="'$(AppName)'==''" Text="AppName property is not set. Set it in the project file." />
-
     <ItemGroup>
       <CodeAppDistPublishFiles Include="$(MSBuildProjectDirectory)/dist/**/*.*" />
     </ItemGroup>

--- a/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.CodeApps.targets
+++ b/src/Dataverse/Solution/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Solution.CodeApps.targets
@@ -51,9 +51,26 @@
              Condition="'@(_CodeAppOutputs)'!=''" />
   </Target>
 
+  <!-- Guards against AppName being reused across multiple CodeApp ProjectReferences in the same
+       solution - since AppName is used verbatim, unsanitized, for the CanvasApp schema name, the
+       generated .meta.xml file name, and the package folder below, a collision would otherwise
+       silently overwrite one Code App's output with another's during the build. -->
+  <Target Name="ValidateCodeAppNamesUnique"
+          DependsOnTargets="BuildCodeApps"
+          Condition="'@(_CodeAppOutputs)'!=''">
+
+    <ItemGroup>
+      <_CodeAppOutputAppNames Include="%(_CodeAppOutputs.AppName)" />
+      <_DistinctCodeAppOutputAppNames Include="@(_CodeAppOutputAppNames->Distinct())" />
+    </ItemGroup>
+
+    <Error Condition="'@(_CodeAppOutputAppNames->Count())' != '@(_DistinctCodeAppOutputAppNames->Count())'"
+           Text="Duplicate AppName detected among CodeApp project references in this solution: @(_CodeAppOutputAppNames). Each Code App must have a unique AppName - it is used verbatim for the CanvasApp schema name, the generated .meta.xml file name, and the package folder." />
+  </Target>
+
   <Target Name="PrepareCodeAppsSources"
           BeforeTargets="CopyCdsSolutionContent"
-          DependsOnTargets="BuildCodeApps">
+          DependsOnTargets="BuildCodeApps;ValidateCodeAppNamesUnique">
 
     <PropertyGroup>
       <_HasCodeAppOutputs Condition="'@(_CodeAppOutputs)'!=''">true</_HasCodeAppOutputs>
@@ -89,7 +106,7 @@
   <Target Name="CopyCodeAppsToMetadata"
           AfterTargets="CopyCdsSolutionContent"
           BeforeTargets="ProcessCdsProjectReferencesOutputs"
-          DependsOnTargets="BuildCodeApps">
+          DependsOnTargets="BuildCodeApps;ValidateCodeAppNamesUnique">
 
     <PropertyGroup>
       <_HasCodeAppOutputs Condition="'@(_CodeAppOutputs)'!=''">true</_HasCodeAppOutputs>


### PR DESCRIPTION
## Summary

Companion hardening for [TALXIS/tools-devkit-templates#pp-app-code AppName fix] — `pp-app-code`'s template now exposes `AppName` as a required, user-chosen parameter instead of silently deriving it from the output folder name. `AppName` flows unsanitized into the CanvasApp schema name (`<PublisherPrefix>_<AppName>`), the generated `.meta.xml` filename, and the package folder in `Solution.CodeApps.targets`, so a bad or colliding value is now a realistic input worth guarding against here.

- `CodeApp.targets`: consolidate the duplicated empty-`AppName` checks in `CopyCodeAppDist`/`CopyCodeAppDistPublish`/`GetCodeAppOutputs` into a single `ValidateCodeAppAppName` target, and add a format check requiring `AppName` to start with a lowercase letter and contain only lowercase letters and digits (`^[a-z][a-z0-9]*$`).
- `Solution.CodeApps.targets`: add `ValidateCodeAppNamesUnique`, erroring out if two `CodeApp` `ProjectReference`s in the same solution resolve to the same `AppName` — previously this would silently overwrite one Code App's schema entry/`.meta.xml`/package folder with another's.
- `CodeApp/README.md`: document the new validation target and the updated target ordering.

## Test plan
- [ ] Build a CodeApp project with an empty `AppName` — confirm the existing "AppName property is not set" error still fires.
- [ ] Build a CodeApp project with an invalid `AppName` (e.g. containing a dot or an uppercase letter) — confirm the new format-validation error fires with a clear message.
- [ ] Build a Solution project referencing two CodeApp projects that share the same `AppName` — confirm `ValidateCodeAppNamesUnique` errors out before schema/`.meta.xml`/package generation.
- [ ] Build a Solution project referencing two CodeApp projects with distinct, valid `AppName` values — confirm the build still succeeds and produces two independent schema entries/`.meta.xml` files/package folders.

I don't have a `dotnet` toolchain in this environment to run these builds myself — please verify before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hws34JR5R9vXtHTBzkmAU3)_