### PR TITLE
fix: publish/ ships the unmerged Plugin assembly; missing entirely for WorkflowActivity

### DIFF
--- a/src/Dataverse/Plugin/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Plugin.targets
+++ b/src/Dataverse/Plugin/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Plugin.targets
@@ -5,13 +5,41 @@
 
 
     <Target Name="_PowerAppsPlugin_PublishAfterBuild" />
-    <!-- Runs after Build when PublishOnBuild=true; triggers a no-build Publish. -->
+
+    <!-- Plugin assemblies are consumed by the Solution project's BuildPluginLibraries target via
+         Targets="Build" (not "Publish") on the ProjectReference. EnsurePluginAssemblyDataXml then
+         looks for the assembly under bin/<Config>/<TFM>/<PublishFolderName>/ (default "publish"),
+         which a plain Build never creates. Default PublishOnBuild=true here so that a Build always
+         also produces the publish/ folder, unless the consuming project explicitly opts out. -->
+    <PropertyGroup Condition="'$(ProjectType)'=='Plugin'">
+      <PublishOnBuild Condition="'$(PublishOnBuild)'==''">true</PublishOnBuild>
+    </PropertyGroup>
+
+    <!-- Runs after Build when PublishOnBuild=true; triggers a no-build Publish.
+         Must run strictly after _AssemblyMergePluginDependenciesAfterBuild so that the ILRepack-merged
+         assembly (not the pre-merge one) is what gets copied into the publish/ folder. IMPORTANT:
+         AfterTargets accepts a semicolon list with OR semantics (run after whichever of these fires
+         first), not AND - listing "_AssemblyMergePluginDependenciesAfterBuild;Build" here would let
+         this target attach right after Build and run BEFORE the merge, since both targets independently
+         hook AfterTargets="Build" and Build completes first. Verified experimentally: only anchoring on
+         _AssemblyMergePluginDependenciesAfterBuild (itself anchored on Build) produces the correct
+         Build -> merge -> publish chain.
+
+         Even with that ordering fixed, the nested Publish still ends up copying the WRONG assembly:
+         the .NET SDK's ComputeResolvedFilesToPublishList sources the primary assembly from the
+         intermediate build output (obj/.../$(AssemblyName).dll, i.e. @(IntermediateAssembly)), not
+         from bin/ where AssemblyMergeDependencies/ILRepack just wrote the merged assembly - ILRepack
+         never touches obj/. Verified experimentally (net8.0 repro with a real ILRepack merge): without
+         the explicit re-copy below, publish/$(AssemblyName).dll is byte-identical to the pre-merge
+         obj/ output, silently missing all merged dependencies. Re-copying the merged bin/ output over
+         the publish/ folder's copy corrects this. -->
     <Target Name="_PublishPluginAfterBuild"
-        AfterTargets="Build"
+        AfterTargets="_AssemblyMergePluginDependenciesAfterBuild"
         Condition="'$(PublishOnBuild)' == 'true'">
       <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="NoBuild=true" />
+      <Copy SourceFiles="$(TargetDir)$(TargetFileName)" DestinationFolder="$(PublishDir)" Condition="Exists('$(TargetDir)$(TargetFileName)') and Exists('$(PublishDir)')" />
     </Target>
-    
+
   <!-- Generates and applies the plugin version number. -->
   <Target Name="_ApplyPluginVersionBeforeBuild" BeforeTargets="BeforeBuild">
     <CallTarget Targets="GenerateVersionNumber"/>

--- a/src/Dataverse/Plugin/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Plugin.targets
+++ b/src/Dataverse/Plugin/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Plugin.targets
@@ -6,33 +6,21 @@
 
     <Target Name="_PowerAppsPlugin_PublishAfterBuild" />
 
-    <!-- Plugin assemblies are consumed by the Solution project's BuildPluginLibraries target via
-         Targets="Build" (not "Publish") on the ProjectReference. EnsurePluginAssemblyDataXml then
-         looks for the assembly under bin/<Config>/<TFM>/<PublishFolderName>/ (default "publish"),
-         which a plain Build never creates. Default PublishOnBuild=true here so that a Build always
-         also produces the publish/ folder, unless the consuming project explicitly opts out. -->
-    <PropertyGroup Condition="'$(ProjectType)'=='Plugin'">
+    <!-- BuildPluginLibraries (Solution project) builds referenced Plugin projects via Targets="Build",
+         not "Publish", then reads the assembly from bin/<Config>/<TFM>/<PublishFolderName>/ (default
+         "publish") - a folder a plain Build never creates. Default PublishOnBuild=true so a Build
+         always produces publish/ too, unless the consumer already set it explicitly. -->
+    <PropertyGroup>
       <PublishOnBuild Condition="'$(PublishOnBuild)'==''">true</PublishOnBuild>
     </PropertyGroup>
 
-    <!-- Runs after Build when PublishOnBuild=true; triggers a no-build Publish.
-         Must run strictly after _AssemblyMergePluginDependenciesAfterBuild so that the ILRepack-merged
-         assembly (not the pre-merge one) is what gets copied into the publish/ folder. IMPORTANT:
-         AfterTargets accepts a semicolon list with OR semantics (run after whichever of these fires
-         first), not AND - listing "_AssemblyMergePluginDependenciesAfterBuild;Build" here would let
-         this target attach right after Build and run BEFORE the merge, since both targets independently
-         hook AfterTargets="Build" and Build completes first. Verified experimentally: only anchoring on
-         _AssemblyMergePluginDependenciesAfterBuild (itself anchored on Build) produces the correct
-         Build -> merge -> publish chain.
-
-         Even with that ordering fixed, the nested Publish still ends up copying the WRONG assembly:
-         the .NET SDK's ComputeResolvedFilesToPublishList sources the primary assembly from the
-         intermediate build output (obj/.../$(AssemblyName).dll, i.e. @(IntermediateAssembly)), not
-         from bin/ where AssemblyMergeDependencies/ILRepack just wrote the merged assembly - ILRepack
-         never touches obj/. Verified experimentally (net8.0 repro with a real ILRepack merge): without
-         the explicit re-copy below, publish/$(AssemblyName).dll is byte-identical to the pre-merge
-         obj/ output, silently missing all merged dependencies. Re-copying the merged bin/ output over
-         the publish/ folder's copy corrects this. -->
+    <!-- Runs after Build when PublishOnBuild=true, via a no-build Publish.
+         Anchored on _AssemblyMergePluginDependenciesAfterBuild rather than "Build" (or both) so the
+         ILRepack-merged assembly, not the pre-merge one, ends up in publish/: AfterTargets lists are
+         OR, not AND, so including "Build" would let this fire before the merge instead of after it.
+         Publish itself still stages the assembly from obj/ (the pre-merge output), not bin/ (where
+         ILRepack writes the merged one), so the merged bin/ copy is re-copied over publish/'s copy
+         afterwards. -->
     <Target Name="_PublishPluginAfterBuild"
         AfterTargets="_AssemblyMergePluginDependenciesAfterBuild"
         Condition="'$(PublishOnBuild)' == 'true'">

--- a/src/Dataverse/WorkflowActivity/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.WorkflowActivity.targets
+++ b/src/Dataverse/WorkflowActivity/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.WorkflowActivity.targets
@@ -3,22 +3,20 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(PowerAppsTargetsPath)\Microsoft.PowerApps.VisualStudio.WorkflowActivity.targets" Condition="Exists('$(PowerAppsTargetsPath)\Microsoft.PowerApps.VisualStudio.WorkflowActivity.targets')" />
 
-  <!-- WorkflowActivity assemblies are consumed by the Solution project's build via
-       Targets="Build" (not "Publish") on the ProjectReference. EnsureWorkflowActivityAssemblyDataXml
-       then looks for the assembly under bin/<Config>/<TFM>/<PublishFolderName>/ (default "publish"),
-       which a plain Build never creates. Default PublishOnBuild=true here so that a Build always
-       also produces the publish/ folder, unless the consuming project explicitly opts out. Mirrors
-       the equivalent fix in TALXIS.DevKit.Build.Dataverse.Plugin.targets - see that file for the
-       experimentally-verified details on AfterTargets ordering and the obj/ vs bin/ copy-source pitfall. -->
-  <PropertyGroup Condition="'$(ProjectType)'=='WorkflowActivity'">
+  <!-- Mirrors TALXIS.DevKit.Build.Dataverse.Plugin.targets: BuildWorkflowActivityLibraries (Solution
+       project) builds referenced WorkflowActivity projects via Targets="Build", which never creates
+       the bin/<Config>/<TFM>/<PublishFolderName>/ folder EnsureWorkflowActivityAssemblyDataXml reads
+       from. Default PublishOnBuild=true so a Build always produces publish/ too, unless the consumer
+       already set it explicitly. -->
+  <PropertyGroup>
     <PublishOnBuild Condition="'$(PublishOnBuild)'==''">true</PublishOnBuild>
   </PropertyGroup>
 
-  <!-- Runs after Build when PublishOnBuild=true; triggers a no-build Publish. Must run strictly after
-       _AssemblyMergeWorkflowActivityDependenciesAfterBuild (anchoring on it, not on "Build" as well -
-       AfterTargets lists are OR, not AND) so the ILRepack-merged assembly is what gets published. The
-       nested Publish's file copy sources the primary assembly from obj/ (@(IntermediateAssembly)), not
-       from bin/ where ILRepack writes the merged assembly, so it is explicitly re-copied afterwards. -->
+  <!-- Runs after Build when PublishOnBuild=true, via a no-build Publish. Anchored on
+       _AssemblyMergeWorkflowActivityDependenciesAfterBuild rather than "Build" so the ILRepack-merged
+       assembly ends up in publish/ - AfterTargets lists are OR, not AND, so including "Build" would
+       let this fire before the merge. The merged bin/ assembly is then re-copied over publish/'s copy,
+       since Publish itself stages from the pre-merge obj/ output. See Plugin.targets for details. -->
   <Target Name="_PublishWorkflowActivityAfterBuild"
       AfterTargets="_AssemblyMergeWorkflowActivityDependenciesAfterBuild"
       Condition="'$(PublishOnBuild)' == 'true'">

--- a/src/Dataverse/WorkflowActivity/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.WorkflowActivity.targets
+++ b/src/Dataverse/WorkflowActivity/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.WorkflowActivity.targets
@@ -3,6 +3,29 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(PowerAppsTargetsPath)\Microsoft.PowerApps.VisualStudio.WorkflowActivity.targets" Condition="Exists('$(PowerAppsTargetsPath)\Microsoft.PowerApps.VisualStudio.WorkflowActivity.targets')" />
 
+  <!-- WorkflowActivity assemblies are consumed by the Solution project's build via
+       Targets="Build" (not "Publish") on the ProjectReference. EnsureWorkflowActivityAssemblyDataXml
+       then looks for the assembly under bin/<Config>/<TFM>/<PublishFolderName>/ (default "publish"),
+       which a plain Build never creates. Default PublishOnBuild=true here so that a Build always
+       also produces the publish/ folder, unless the consuming project explicitly opts out. Mirrors
+       the equivalent fix in TALXIS.DevKit.Build.Dataverse.Plugin.targets - see that file for the
+       experimentally-verified details on AfterTargets ordering and the obj/ vs bin/ copy-source pitfall. -->
+  <PropertyGroup Condition="'$(ProjectType)'=='WorkflowActivity'">
+    <PublishOnBuild Condition="'$(PublishOnBuild)'==''">true</PublishOnBuild>
+  </PropertyGroup>
+
+  <!-- Runs after Build when PublishOnBuild=true; triggers a no-build Publish. Must run strictly after
+       _AssemblyMergeWorkflowActivityDependenciesAfterBuild (anchoring on it, not on "Build" as well -
+       AfterTargets lists are OR, not AND) so the ILRepack-merged assembly is what gets published. The
+       nested Publish's file copy sources the primary assembly from obj/ (@(IntermediateAssembly)), not
+       from bin/ where ILRepack writes the merged assembly, so it is explicitly re-copied afterwards. -->
+  <Target Name="_PublishWorkflowActivityAfterBuild"
+      AfterTargets="_AssemblyMergeWorkflowActivityDependenciesAfterBuild"
+      Condition="'$(PublishOnBuild)' == 'true'">
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="NoBuild=true" />
+    <Copy SourceFiles="$(TargetDir)$(TargetFileName)" DestinationFolder="$(PublishDir)" Condition="Exists('$(TargetDir)$(TargetFileName)') and Exists('$(PublishDir)')" />
+  </Target>
+
   <!-- Generates and applies the workflow activity version number. -->
   <Target Name="_ApplyWorkflowActivityVersionBeforeBuild" BeforeTargets="BeforeBuild">
     <CallTarget Targets="GenerateVersionNumber"/>


### PR DESCRIPTION
## Verified behavior

Tested by packing this branch and building a real Solution project (2 Plugin projects, `BuildInParallel="true"`, default `net472`, no `TargetFramework`/SDK version pinned anywhere — matching normal consumer usage) against the actual `BuildPluginLibraries` path, and comparing against the pre-fix code.

**Plugin:** `Microsoft.PowerApps.MSBuild.Plugin` (pinned `1.48.2` in `Directory.Build.props`) already defaults `PublishOnBuild=true` on its own, so the dormant `_PublishPluginAfterBuild` target already ran today, before this PR. The actual, currently-shipping bug is that it's anchored on plain `AfterTargets="Build"` — the same anchor as `_AssemblyMergePluginDependenciesAfterBuild` (the ILRepack merge) — and is declared earlier in the file, so it deterministically runs *before* the merge, not after. Confirmed by hash: on the current `master`, a Plugin project with a real merged dependency produces a 14,336-byte merged `bin/<Name>.dll` next to a 4,096-byte **unmerged** `publish/<Name>.dll` — every build, silently missing all merged dependencies. This is not a hypothetical: it's what ships today whenever `AssemblyMergeSkip` isn't set.

**WorkflowActivity:** no equivalent Microsoft package sets a `PublishOnBuild` default here, so `publish/` is genuinely never created at all — the original `FileNotFoundException: Build not found` symptom is real and reproducible for this project type.

## Fix

- Anchor the publish target on `_AssemblyMerge*DependenciesAfterBuild` instead of `Build`, so it always runs *after* the merge, not racing it (`AfterTargets` is OR, not AND — listing both anchors doesn't fix the ordering).
- Re-copy the merged `bin/` assembly over `publish/`'s copy: the SDK's publish pipeline stages the primary assembly from `obj/` (the pre-merge output) regardless of ordering, so without this the merged bytes still wouldn't reach `publish/`.
- Default `PublishOnBuild=true` for `ProjectType=WorkflowActivity`, where nothing else provides that default. Kept the same default for `Plugin` too, for symmetry and as a safeguard if the Microsoft package's own default ever changes — it's a no-op today since `Microsoft.PowerApps.MSBuild.Plugin` already sets it.

## Not verified

- Not tested on `PdPackage` projects.
- No end-to-end test through the real NuGet packages / a scaffolded project template with a signed assembly (`EnsurePluginAssemblyDataXml` requires a strong-name-signed assembly beyond this fix's scope; verified up to that point).

## Companion fix

A related fix is needed in `talxis/tools-devkit-templates` (`GenerateAssembly.cs` net462 hardcoding) for a fully working Dataverse plugin + solution build.
