### PR TITLE
Bump remaining .NET 10 stragglers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,8 +52,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            9.0.x
+            10.0.x
       - name: Assemble cumulative release notes
         if: github.event_name == 'release'
         env:

--- a/src/Dataverse/GenPage/TALXIS.DevKit.Build.Dataverse.GenPage.csproj
+++ b/src/Dataverse/GenPage/TALXIS.DevKit.Build.Dataverse.GenPage.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version Condition="'$(Version)'==''">0.0.1</Version>
     <NuspecFile>TALXIS.DevKit.Build.Dataverse.GenPage.nuspec</NuspecFile>


### PR DESCRIPTION
## Summary

Audited the repo for .NET version consistency after the net10.0 migration. Found and fixed two stragglers:

- `src/Dataverse/GenPage/TALXIS.DevKit.Build.Dataverse.GenPage.csproj` still targeted `net8.0` while every other package (Sdk, Plugin, Tasks, Pcf, PDPackage, Solution, WorkflowActivity, ScriptLibrary) targets `net10.0`. Bumped to match.
- `.github/workflows/publish.yml`'s `create_nuget` job pinned `actions/setup-dotnet` to install SDKs `6.0.x` and `9.0.x`, neither of which understands the `net10.0` TFM used by the packages this job builds via `dotnet pack`. Updated to `10.0.x`.

`net472`/`net462` targets elsewhere in the repo (Sdk.props, Plugin.targets, WorkflowActivity.targets) were left untouched — those are intentional, since Dataverse plugins/workflow activities run in the .NET Framework sandbox, not .NET Core/5+.

## Test plan

- [ ] CI (`publish` workflow) runs `dotnet pack` successfully with the `10.0.x` SDK against all `net10.0` projects including the updated GenPage project.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fc2M8jZqCHkJtY4udpbn2z)_