### PR TITLE
Bump Microsoft.PowerApps.MSBuild tooling 1.x -> 2.10.1

### DIFF
--- a/docs/Tasks-Package.md
+++ b/docs/Tasks-Package.md
@@ -77,7 +77,7 @@ Now you can extend the build process explicitly calling additional tasks during 
         <AssemblyName>Some.Solution</AssemblyName>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.PowerApps.MSBuild.Solution" Version="1.48.2" />
+        <PackageReference Include="Microsoft.PowerApps.MSBuild.Solution" Version="2.10.1" />
         <PackageReference Include="TALXIS.DevKit.Build.Dataverse.Tasks" Version="1.0.*" />
         <!-- Add other project references like plugins, PCFs and scripts here...
         <ProjectReference Include="..\something_else\dependency.csproj" />

--- a/src/Dataverse/Directory.Build.props
+++ b/src/Dataverse/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
    <PropertyGroup>
-      <MicrosoftPowerAppsTargetsVersion>1.48.2</MicrosoftPowerAppsTargetsVersion>
+      <MicrosoftPowerAppsTargetsVersion>2.10.1</MicrosoftPowerAppsTargetsVersion>
    </PropertyGroup>
 </Project>

--- a/src/Dataverse/PDPackage/msbuild/build/TALXIS.DevKit.Build.Dataverse.PdPackage.props
+++ b/src/Dataverse/PDPackage/msbuild/build/TALXIS.DevKit.Build.Dataverse.PdPackage.props
@@ -2,7 +2,7 @@
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PdPackageMsBuildVersion Condition="'$(PdPackageMsBuildVersion)'==''">1.50.1</PdPackageMsBuildVersion>
+    <PdPackageMsBuildVersion Condition="'$(PdPackageMsBuildVersion)'==''">2.10.1</PdPackageMsBuildVersion>
     <!-- Disable Microsoft's GeneratePdPackageOnPublish; TALXIS _GeneratePdPackageAfterPublish handles this instead -->
     <GeneratePdPackageOnPublish>false</GeneratePdPackageOnPublish>
     <_PdPackageMsBuildProps Condition="'$(_PdPackageMsBuildProps)'==''">

--- a/src/Dataverse/PDPackage/msbuild/build/TALXIS.DevKit.Build.Dataverse.PdPackage.targets
+++ b/src/Dataverse/PDPackage/msbuild/build/TALXIS.DevKit.Build.Dataverse.PdPackage.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PdPackageMsBuildVersion Condition="'$(PdPackageMsBuildVersion)'==''">1.50.1</PdPackageMsBuildVersion>
+    <PdPackageMsBuildVersion Condition="'$(PdPackageMsBuildVersion)'==''">2.10.1</PdPackageMsBuildVersion>
     <_PdPackageMsBuildTargets Condition="'$(_PdPackageMsBuildTargets)'==''">
       $(NuGetPackageRoot)microsoft.powerapps.msbuild.pdpackage\$(PdPackageMsBuildVersion)\build\Microsoft.PowerApps.MSBuild.PDPackage.targets
     </_PdPackageMsBuildTargets>

--- a/src/Dataverse/Plugin/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Plugin.props
+++ b/src/Dataverse/Plugin/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Plugin.props
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CrmSdk.CoreAssemblies" Version="9.0.2.*" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.PowerApps.MSBuild.Plugin" Version="1.*" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.PowerApps.MSBuild.Plugin" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.*" PrivateAssets="All" />
     <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="[2.0.44.2]" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
## What
A live nuget.org registry audit tonight found this repo's pinned `Microsoft.PowerApps.MSBuild.*` dependency versions had drifted stale against a major version bump: `1.48.2`/`1.50.1` vs the current `2.10.1`, and the Plugin package used a `1.*` floating floor that can never resolve to the current 2.x major.

Changes:
- `src/Dataverse/Directory.Build.props`: `MicrosoftPowerAppsTargetsVersion` `1.48.2` -> `2.10.1`
- `src/Dataverse/PDPackage/msbuild/build/TALXIS.DevKit.Build.Dataverse.PdPackage.{props,targets}`: default `PdPackageMsBuildVersion` `1.50.1` -> `2.10.1` (this had drifted apart from `MicrosoftPowerAppsTargetsVersion` above; both are now back in line)
- `src/Dataverse/Plugin/msbuild/tasks/TALXIS.DevKit.Build.Dataverse.Plugin.props`: `Microsoft.PowerApps.MSBuild.Plugin` `1.*` -> `2.*`
- `docs/Tasks-Package.md`: updated stale hardcoded example version

This is a **major** version bump of Microsoft's own MSBuild tooling (1.x -> 2.x), so there is real risk of breaking changes on Microsoft's side.

## What I verified
- `dotnet pack` of the modified `TALXIS.DevKit.Build.Dataverse.{Plugin,PdPackage,Solution,Tasks}` projects to a local NuGet feed (using the modified `Directory.Build.props`/`.props`/`.targets` in this branch).
- `dotnet restore` of minimal throwaway consumer projects referencing each of `TALXIS.DevKit.Build.Dataverse.Plugin`, `.PdPackage`, and `.Solution` against that local feed + nuget.org. All three restored cleanly and `project.assets.json` confirms `Microsoft.PowerApps.MSBuild.Plugin`, `Microsoft.PowerApps.MSBuild.PDPackage`, and `Microsoft.PowerApps.MSBuild.Solution` all resolved to `2.10.1` — i.e. the version property/nuspec-substitution plumbing correctly wires through to the new major version, and 2.10.1 genuinely exists and resolves on nuget.org.
- `dotnet build` of the PdPackage-referencing throwaway project successfully imported the modified `TALXIS.DevKit.Build.Dataverse.PdPackage.props`/`.targets`, which in turn imported `Microsoft.PowerApps.MSBuild.PDPackage.props`/`.targets` 2.10.1 from the NuGet package cache without error (the only build error encountered was an unrelated `TargetFramework` mismatch in the throwaway project — `net472` is required by the PDPackage tooling — not a tooling/versioning issue).
- Confirmed via `grep` across the repo that no other file still references the old `1.48.2` / `1.50.1` / `1.*` values.
- All touched `.props`/`.targets` files were confirmed to be well-formed XML.

**Not completed**: a full end-to-end scaffold-and-build using the `TALXIS.DevKit.Templates.Dataverse` templates (`pp-plugin`, `pp-package`, `pp-solution`) against these locally-packed tooling packages. The template scaffold's PowerShell post-action hung indefinitely in the sandbox used for this verification, and the sandbox subsequently ran into disk exhaustion; given the package-resolution verification above already demonstrates the core risk (does 2.10.1 exist and resolve, does the version wiring work end-to-end), a full CRM-SDK plugin compile was not pursued further. Recommend a maintainer with a stable local dev environment do one real scaffold-and-build pass before merging, given this is a major-version bump of Microsoft's own tooling.

Draft PR — not to be merged without that additional confirmation.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V7jqpJTaXnk9YbPkxEXe9F)_