### PR TITLE
Bump and centralize Microsoft.Build/Microsoft.Build.Tasks.Core pin to 18.8.2

### DIFF
--- a/src/Dataverse/CodeApp/TALXIS.DevKit.Build.Dataverse.CodeApp.csproj
+++ b/src/Dataverse/CodeApp/TALXIS.DevKit.Build.Dataverse.CodeApp.csproj
@@ -15,8 +15,8 @@
         <NuspecProperties>Version=$(Version);MicrosoftPowerAppsTargetsVersion=$(MicrosoftPowerAppsTargetsVersion)</NuspecProperties>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build" Version="18.0.2" />
-        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
+        <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
         <!-- Do not add any of the dependencies above to nuspec -->
         <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
     </ItemGroup>

--- a/src/Dataverse/Directory.Build.props
+++ b/src/Dataverse/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
    <PropertyGroup>
       <MicrosoftPowerAppsTargetsVersion>1.48.2</MicrosoftPowerAppsTargetsVersion>
+      <MicrosoftBuildVersion>18.8.2</MicrosoftBuildVersion>
    </PropertyGroup>
 </Project>

--- a/src/Dataverse/Pcf/TALXIS.DevKit.Build.Dataverse.Pcf.csproj
+++ b/src/Dataverse/Pcf/TALXIS.DevKit.Build.Dataverse.Pcf.csproj
@@ -15,8 +15,8 @@
         <NuspecProperties>Version=$(Version);MicrosoftPowerAppsTargetsVersion=$(MicrosoftPowerAppsTargetsVersion)</NuspecProperties>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build" Version="18.0.2" />
-        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
+        <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
         <!-- Do not add any of the dependencies above to nuspec -->
         <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
     </ItemGroup>

--- a/src/Dataverse/Plugin/TALXIS.DevKit.Build.Dataverse.Plugin.csproj
+++ b/src/Dataverse/Plugin/TALXIS.DevKit.Build.Dataverse.Plugin.csproj
@@ -15,8 +15,8 @@
         <NuspecProperties>Version=$(Version);MicrosoftPowerAppsTargetsVersion=$(MicrosoftPowerAppsTargetsVersion)</NuspecProperties>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build" Version="18.0.2" />
-        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
+        <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
         <!-- Do not add any of the dependencies above to nuspec -->
         <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
     </ItemGroup>

--- a/src/Dataverse/Solution/TALXIS.DevKit.Build.Dataverse.Solution.csproj
+++ b/src/Dataverse/Solution/TALXIS.DevKit.Build.Dataverse.Solution.csproj
@@ -15,8 +15,8 @@
         <NuspecProperties>Version=$(Version);MicrosoftPowerAppsTargetsVersion=$(MicrosoftPowerAppsTargetsVersion)</NuspecProperties>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build" Version="18.0.2" />
-        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
+        <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
         <!-- Do not add any of the dependencies above to nuspec -->
         <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
     </ItemGroup>

--- a/src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj
+++ b/src/Dataverse/Tasks/TALXIS.DevKit.Build.Dataverse.Tasks.csproj
@@ -21,8 +21,8 @@
     </PropertyGroup>
     <ItemGroup>
         <!--<PackageReference Include="LibGit2Sharp" Version="0.26.2" />-->
-        <PackageReference Include="Microsoft.Build" Version="18.0.2" />
-        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
+        <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
         <PackageReference Include="TALXIS.Platform.Metadata" Version="0.9.0" />
         <PackageReference Include="TALXIS.Platform.Metadata.Validation" Version="0.9.0" />
         <PackageReference Include="TALXIS.Platform.Metadata.Serialization.Xml" Version="0.9.0" />

--- a/src/Dataverse/WorkflowActivity/TALXIS.DevKit.Build.Dataverse.WorkflowActivity.csproj
+++ b/src/Dataverse/WorkflowActivity/TALXIS.DevKit.Build.Dataverse.WorkflowActivity.csproj
@@ -15,8 +15,8 @@
         <NuspecProperties>Version=$(Version);MicrosoftPowerAppsTargetsVersion=$(MicrosoftPowerAppsTargetsVersion)</NuspecProperties>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build" Version="18.0.2" />
-        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
+        <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
         <!-- Do not add any of the dependencies above to nuspec -->
         <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
     </ItemGroup>


### PR DESCRIPTION
## What
A live nuget.org registry audit tonight found the `Microsoft.Build` / `Microsoft.Build.Tasks.Core` pin (`18.0.2`) duplicated identically across 6 `.csproj` files under `src/Dataverse/{WorkflowActivity,Pcf,Plugin,Tasks,Solution,CodeApp}`, stale against the current `18.8.2`.

Changes:
- Bumped all 6 `PackageReference`s from `18.0.2` to the new shared version.
- Centralized the version into a single `MicrosoftBuildVersion` property in `src/Dataverse/Directory.Build.props`, following the same pattern as the existing `MicrosoftPowerAppsTargetsVersion` property already there. Each `.csproj` now references `$(MicrosoftBuildVersion)` instead of a hardcoded literal, so future bumps only touch one place.

This is lower risk than a Power Apps tooling bump — these are plain MSBuild SDK assemblies (`Microsoft.Build`, `Microsoft.Build.Tasks.Core`), not Power Apps runtime/build behavior, and the version bump is a minor/patch-level bump (18.0 -> 18.8), not a major.

## What I verified
- Confirmed via `grep` that the `18.0.2` pin appeared in exactly these 6 `.csproj` files before the change, and no `18.0.2` references remain afterward.
- Ran `dotnet build -c Release` on all 6 affected projects directly (via the `ghcr.io/talxis/tools-agentbox/image` devcontainer recipe) against the modified `Directory.Build.props` — all 6 built with **0 errors** (only pre-existing, unrelated `NU1903` advisory warnings for a transitive `System.Security.Cryptography.Xml` package).
- Inspected `obj/project.assets.json` for the `Tasks` project and confirmed `Microsoft.Build`/`Microsoft.Build.Tasks.Core` resolved to `18.8.2`, proving the new shared property correctly wires through to the intended version.
- Confirmed `Directory.Build.props` remains well-formed XML after the change.

Draft PR — not to be merged without further review.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V7jqpJTaXnk9YbPkxEXe9F)_