### PR TITLE
fix(tasks): stop loading plugin assemblies with Assembly.LoadFrom

### DIFF
--- a/src/Dataverse/Tasks/Tasks/ApplyPluginVersionNumberInSolution.cs
+++ b/src/Dataverse/Tasks/Tasks/ApplyPluginVersionNumberInSolution.cs
@@ -25,7 +25,10 @@ public class ApplyPluginVersionNumberInSolution : Task
             var sourceFilePath = item.ItemSpec;
             if(componentType == "Plugin")
             {
-                var version = Assembly.LoadFrom(sourceFilePath).GetName().Version.ToString();
+                // Read the assembly's version from its PE headers instead of loading it (Assembly.LoadFrom):
+                // this task runs in-process in a persistent, node-reused MSBuild worker, and loading the
+                // same-named assembly twice across separate builds throws FileLoadException.
+                var version = AssemblyName.GetAssemblyName(sourceFilePath).Version.ToString();
                 Log.LogMessage(MessageImportance.High, $"Processing {sourceFilePath}, version: {version}");
                 var pluginAssemblies = Directory.EnumerateFiles(WorkingDirectoryPath, "*.dll.data.xml", SearchOption.AllDirectories);
                 foreach (var pluginAssemblyXmlPath in pluginAssemblies)

--- a/src/Dataverse/Tasks/Tasks/ApplyVersionNumber.cs
+++ b/src/Dataverse/Tasks/Tasks/ApplyVersionNumber.cs
@@ -25,7 +25,7 @@ public class ApplyVersionNumber : Task
     public ITaskItem WorkflowsFolder { get; set; }
     public ITaskItem ControlsFolder { get; set; }
 
-    private readonly IList<Assembly> _assemblies = new List<Assembly>();
+    private readonly IList<AssemblyName> _assemblies = new List<AssemblyName>();
 
     public override bool Execute()
     {
@@ -52,7 +52,10 @@ public class ApplyVersionNumber : Task
                     continue;
                 }
 
-                var assembly = Assembly.LoadFrom(assemblyPath);
+                // Read the assembly's identity from its PE headers instead of loading it (Assembly.LoadFrom):
+                // this task runs in-process in a persistent, node-reused MSBuild worker, and loading the
+                // same-named assembly twice across separate builds throws FileLoadException.
+                var assembly = AssemblyName.GetAssemblyName(assemblyPath);
                 _assemblies.Add(assembly);
 
                 Log.LogMessage(MessageImportance.High, $" > Discovered {assembly.FullName} at {pluginAssemblyXmlPath}");
@@ -124,11 +127,11 @@ public class ApplyVersionNumber : Task
             {
                 var currentVersion = ExtractVersionFromFQDN(attr.Value);
                 var assemblyName = attr.Value.Split(',')[1]?.Trim();
-                var assembly = _assemblies.Where(x => x.GetName().Name == assemblyName).FirstOrDefault();
+                var assembly = _assemblies.Where(x => x.Name == assemblyName).FirstOrDefault();
                 Log.LogMessage(MessageImportance.High, $" > Updating Workflow Activity Reference to {assemblyName} from version {currentVersion}, assembly in project {assembly != null}");
                 if (assembly != null)
                 {
-                    var newVersion = assembly.GetName().Version.ToString();
+                    var newVersion = assembly.Version.ToString();
                     if (currentVersion == newVersion)
                     {
                         continue;
@@ -154,10 +157,10 @@ public class ApplyVersionNumber : Task
 
         if (pluginTypeNameElement?.Value != null)
         {
-            var assembly = _assemblies.Where(x => x.GetName().Name == assemblyName).FirstOrDefault();
+            var assembly = _assemblies.Where(x => x.Name == assemblyName).FirstOrDefault();
             if (assembly != null)
             {
-                var newVersion = assembly.GetName().Version.ToString();
+                var newVersion = assembly.Version.ToString();
                 Log.LogMessage(MessageImportance.High, $"Version found: {currentVersion}, updating to {newVersion}");
                 if (currentVersion == newVersion)
                 {


### PR DESCRIPTION
## Summary
- `ApplyVersionNumber` and its sibling `ApplyPluginVersionNumberInSolution` intermittently fail with `MSB4018` / `System.IO.FileLoadException: ... Assembly with same name is already loaded`, surfacing as a flaky failure building a Dataverse solution project that references a plugin assembly.
- Root cause: both tasks run in-process inside the MSBuild worker node. MSBuild defaults to `/nodeReuse:true`, so a worker node persists across separate `dotnet build`/`dotnet publish` CLI invocations (~15 min idle timeout). `Assembly.LoadFrom` routes through `AssemblyLoadContext.Default`, so if a same-identity plugin assembly gets loaded a second time in a reused node, the CLR throws `FileLoadException`. Confirmed byte-identical in 1.8.2 and 1.8.3 — not something the 1.8.3 bump addressed. The sibling task has the identical pattern.
- Fix: neither task ever needs to *execute* the assembly — only its name/version/public key token. Replaced `Assembly.LoadFrom(path)` with `AssemblyName.GetAssemblyName(path)`, which reads that identity straight from the PE headers without loading anything into any `AssemblyLoadContext`, eliminating the collision mechanism entirely (rather than working around a specific trigger condition).

## Testing
- `dotnet build` on `TALXIS.DevKit.Build.Dataverse.Tasks.csproj`: 0 errors.
- Direct repro of the failure mechanism: calling `Assembly.LoadFrom` twice in one process on the same assembly identity can throw `FileLoadException`/`FileNotFoundException` depending on file state; calling `AssemblyName.GetAssemblyName` twice on the same path never touches any `AssemblyLoadContext` and cannot hit this failure mode by construction.
- End-to-end: built the fix, patched it into a local NuGet cache copy of `talxis.devkit.build.dataverse.tasks` 1.8.3, and ran `TALXIS/alm-lab`'s full `LOCAL-DRY-RUN.md` flow (CP01→CP08, the exact sequence that originally reproduced the crash), plus 5 additional immediate `dotnet build` rebuilds of the whole solution in the same shell session to maximize MSBuild node-reuse pressure. All builds succeeded with 0 errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_014i8SSGCDJR1wvfi555UdNz)_